### PR TITLE
Add initial Client Application type tests

### DIFF
--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Actions/Marketing/ActionCollection.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Actions/Marketing/ActionCollection.cs
@@ -2,6 +2,7 @@
 {
     internal sealed class ActionCollection
     {
+        internal ClientApplicationTypeActions ClientApplicationTypeActions { get; set; }
         internal ContactDetailsActions ContactDetailsActions { get; set; }
         internal FeaturesActions FeaturesActions { get; set; }
         internal CommonActions CommonActions { get; set; }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Actions/Marketing/ClientApplicationTypeActions.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Actions/Marketing/ClientApplicationTypeActions.cs
@@ -1,0 +1,73 @@
+﻿using NHSD.GPIT.BuyingCatalogue.E2ETests.Common.Actions;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.Marketing;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.RandomData;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+using System;
+using System.Linq;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Actions.Marketing
+{
+    internal class ClientApplicationTypeActions : ActionBase
+    {
+        public ClientApplicationTypeActions(IWebDriver driver) : base(driver)
+        {
+        }
+
+        internal void SelectClientApplicationCheckbox(string clientApplicationType)
+        {
+            switch (clientApplicationType)
+            {
+                case "Browser-based":
+                    Driver.FindElement(ClientApplicationObjects.BrowserBasedCheckbox).Click();
+                    break;
+                case "Native mobile or tablet":
+                    Driver.FindElement(ClientApplicationObjects.NativeMobileCheckbox).Click();
+                    break;
+                case "Native desktop":
+                    Driver.FindElement(ClientApplicationObjects.NativeDesktopCheckbox).Click();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(clientApplicationType));
+            }
+        }
+
+        internal string ClickBrowserCheckbox(int index = 0)
+        {
+            var checkboxItems = Driver.FindElements(ClientApplicationObjects.BrowserCheckboxItem);
+
+            var selected = checkboxItems[index];
+
+            selected.FindElement(By.TagName("input")).Click();
+            return selected.FindElement(By.TagName("label")).Text;
+        }
+
+        internal void ClickRadioButtonWithText(string label)
+        {
+            var radioButtonItems = Driver.FindElements(ClientApplicationObjects.RadioButtonItems);
+
+            radioButtonItems.Single(r => r.FindElement(By.TagName("label")).Text == label).FindElement(By.TagName("input")).Click();
+        }
+
+        internal string EnterAdditionalInformation(int numChars)
+        {
+            var generatedString = Strings.RandomString(numChars);
+
+            Driver.FindElement(ClientApplicationObjects.AdditionalInfoTextArea).SendKeys(generatedString);
+
+            return generatedString;
+        }
+
+        internal void SelectConnectionSpeedDropdown(int index = 0)
+        {
+            var select = Driver.FindElement(ClientApplicationObjects.ConnectionSpeedSelect);
+            new SelectElement(select).SelectByIndex(index);
+        }
+
+        internal void SelectResolutionDropdown(int index = 0)
+        {
+            var select = Driver.FindElement(ClientApplicationObjects.ResolutionSelect);
+            new SelectElement(select).SelectByIndex(index);
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Actions/Marketing/MarketingPageActions.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Actions/Marketing/MarketingPageActions.cs
@@ -13,6 +13,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Actions.Marketing
                 ContactDetailsActions = new(driver),
                 DashboardActions = new(driver),
                 FeaturesActions = new(driver),
+                ClientApplicationTypeActions = new(driver),
                 SolutionDescriptionActions = new(driver)
             };
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/ClientApplication/BrowserBased/BrowserBasedDashboard.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/ClientApplication/BrowserBased/BrowserBasedDashboard.cs
@@ -1,0 +1,62 @@
+﻿using FluentAssertions;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Marketing.ClientApplication.BrowserBased
+{
+    public sealed class BrowserBasedDashboard : TestBase, IClassFixture<LocalWebApplicationFactory>
+    {
+        public BrowserBasedDashboard(LocalWebApplicationFactory factory) : base(factory, "marketing/supplier/solution/99999-99/section/browser-based")
+        {
+            using var context = GetBCContext();
+            var solution = context.Solutions.Single(s => s.Id == "99999-99");
+            solution.ClientApplication = @"{
+                        ""ClientApplicationTypes"": [
+                            ""browser-based""
+                        ],
+                        ""BrowsersSupported"": [],
+                        ""MobileResponsive"": null,
+                        ""Plugins"": null,
+                        ""HardwareRequirements"": null,
+                        ""NativeMobileHardwareRequirements"": null,
+                        ""NativeDesktopHardwareRequirements"": null,
+                        ""AdditionalInformation"": null,
+                        ""MinimumConnectionSpeed"": null,
+                        ""MinimumDesktopResolution"": null,
+                        ""MobileFirstDesign"": null,
+                        ""NativeMobileFirstDesign"": null,
+                        ""MobileOperatingSystems"": null,
+                        ""MobileConnectionDetails"": null,
+                        ""MobileMemoryAndStorage"": null,
+                        ""MobileThirdParty"": {
+                            ""ThirdPartyComponents"": null,
+                            ""DeviceCapabilities"": null
+                        },
+                        ""NativeMobileAdditionalInformation"": null,
+                        ""NativeDesktopOperatingSystemsDescription"": null,
+                        ""NativeDesktopMinimumConnectionSpeed"": null,
+                        ""NativeDesktopThirdParty"": null,
+                        ""NativeDesktopMemoryAndStorage"": null,
+                        ""NativeDesktopAdditionalInformation"": null
+                    }";
+            context.SaveChanges();
+        }
+
+        [Theory]
+        [InlineData("Supported browsers")]
+        [InlineData("Mobile first approach")]
+        [InlineData("Plug-ins or extensions required")]
+        [InlineData("Connectivity and resolution")]
+        [InlineData("Hardware requirements")]
+        [InlineData("Additional information")]
+        public void BrowserBasedDashboard_SectionsDisplayed(string section)
+        {
+            MarketingPages.DashboardActions.SectionDisplayed(section).Should().BeTrue();
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/ClientApplication/BrowserBased/ConnectivityAndResolution.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/ClientApplication/BrowserBased/ConnectivityAndResolution.cs
@@ -1,0 +1,83 @@
+﻿using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Marketing.ClientApplication.BrowserBased
+{
+    public sealed class ConnectivityAndResolution : TestBase, IClassFixture<LocalWebApplicationFactory>
+    {
+        public ConnectivityAndResolution(LocalWebApplicationFactory factory) : base(factory, "marketing/supplier/solution/99999-99/section/browser-based/connectivity-and-resolution")
+        {
+            using var context = GetBCContext();
+            var solution = context.Solutions.Single(s => s.Id == "99999-99");
+            solution.ClientApplication = @"{
+                        ""ClientApplicationTypes"": [
+                            ""browser-based""
+                        ],
+                        ""BrowsersSupported"": [],
+                        ""MobileResponsive"": null,
+                        ""Plugins"": null,
+                        ""HardwareRequirements"": null,
+                        ""NativeMobileHardwareRequirements"": null,
+                        ""NativeDesktopHardwareRequirements"": null,
+                        ""AdditionalInformation"": null,
+                        ""MinimumConnectionSpeed"": null,
+                        ""MinimumDesktopResolution"": null,
+                        ""MobileFirstDesign"": null,
+                        ""NativeMobileFirstDesign"": null,
+                        ""MobileOperatingSystems"": null,
+                        ""MobileConnectionDetails"": null,
+                        ""MobileMemoryAndStorage"": null,
+                        ""MobileThirdParty"": {
+                            ""ThirdPartyComponents"": null,
+                            ""DeviceCapabilities"": null
+                        },
+                        ""NativeMobileAdditionalInformation"": null,
+                        ""NativeDesktopOperatingSystemsDescription"": null,
+                        ""NativeDesktopMinimumConnectionSpeed"": null,
+                        ""NativeDesktopThirdParty"": null,
+                        ""NativeDesktopMemoryAndStorage"": null,
+                        ""NativeDesktopAdditionalInformation"": null
+                    }";
+            context.SaveChanges();
+
+            driver.Navigate().Refresh();
+        }
+
+        [Fact]
+        public async Task ConnectivityAndResolution_SelectBothFields()
+        {
+            MarketingPages.ClientApplicationTypeActions.SelectConnectionSpeedDropdown(1);
+            MarketingPages.ClientApplicationTypeActions.SelectResolutionDropdown(1);
+
+            MarketingPages.CommonActions.ClickSave();
+
+            using var context = GetBCContext();
+            var clientApplication = (await context.Solutions.SingleAsync(s => s.Id == "99999-99")).ClientApplication;
+            clientApplication.Should().ContainEquivalentOf(@$"""MinimumConnectionSpeed"":""0.5Mbps""");
+            clientApplication.Should().ContainEquivalentOf(@$"""MinimumDesktopResolution"":""16:9 - 640 x 360""");
+        }
+
+        [Fact]
+        public void ConnectivityAndResolution_SectionComplete()
+        {
+            MarketingPages.ClientApplicationTypeActions.SelectConnectionSpeedDropdown(1);
+            MarketingPages.ClientApplicationTypeActions.SelectResolutionDropdown(1);
+
+            MarketingPages.CommonActions.ClickSave();
+
+            MarketingPages.DashboardActions.SectionMarkedComplete("Connectivity and resolution").Should().BeTrue();
+        }
+
+        [Fact]
+        public void ConnectivityAndResolution_SectionIncomplete()
+        {
+            MarketingPages.CommonActions.ClickGoBackLink();
+
+            MarketingPages.DashboardActions.SectionMarkedComplete("Connectivity and resolution").Should().BeFalse();
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/ClientApplication/BrowserBased/MobileFirstApproach.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/ClientApplication/BrowserBased/MobileFirstApproach.cs
@@ -1,0 +1,84 @@
+﻿using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Marketing.ClientApplication.BrowserBased
+{
+    public sealed class MobileFirstApproach : TestBase, IClassFixture<LocalWebApplicationFactory>
+    {
+        public MobileFirstApproach(LocalWebApplicationFactory factory) : base(factory, "marketing/supplier/solution/99999-99/section/browser-based/mobile-first-approach")
+        {
+            using var context = GetBCContext();
+            var solution = context.Solutions.Single(s => s.Id == "99999-99");
+            solution.ClientApplication = @"{
+                        ""ClientApplicationTypes"": [
+                            ""browser-based""
+                        ],
+                        ""BrowsersSupported"": [],
+                        ""MobileResponsive"": null,
+                        ""Plugins"": null,
+                        ""HardwareRequirements"": null,
+                        ""NativeMobileHardwareRequirements"": null,
+                        ""NativeDesktopHardwareRequirements"": null,
+                        ""AdditionalInformation"": null,
+                        ""MinimumConnectionSpeed"": null,
+                        ""MinimumDesktopResolution"": null,
+                        ""MobileFirstDesign"": null,
+                        ""NativeMobileFirstDesign"": null,
+                        ""MobileOperatingSystems"": null,
+                        ""MobileConnectionDetails"": null,
+                        ""MobileMemoryAndStorage"": null,
+                        ""MobileThirdParty"": {
+                            ""ThirdPartyComponents"": null,
+                            ""DeviceCapabilities"": null
+                        },
+                        ""NativeMobileAdditionalInformation"": null,
+                        ""NativeDesktopOperatingSystemsDescription"": null,
+                        ""NativeDesktopMinimumConnectionSpeed"": null,
+                        ""NativeDesktopThirdParty"": null,
+                        ""NativeDesktopMemoryAndStorage"": null,
+                        ""NativeDesktopAdditionalInformation"": null
+                    }";
+            context.SaveChanges();
+
+            driver.Navigate().Refresh();
+        }
+
+        [Theory]
+        [InlineData("Yes")]
+        [InlineData("No")]
+        public async Task MobileFirstApproach_SelectRadioButton(string label)
+        {
+            MarketingPages.ClientApplicationTypeActions.ClickRadioButtonWithText(label);
+
+            MarketingPages.CommonActions.ClickSave();
+
+            string labelConvert = label == "Yes" ? "true" : "false";
+
+            using var context = GetBCContext();
+            var clientApplication = (await context.Solutions.SingleAsync(s => s.Id == "99999-99")).ClientApplication;
+            clientApplication.Should().ContainEquivalentOf(@$"MobileFirstDesign"":{ labelConvert }");
+        }
+
+        [Fact]
+        public void MobileFirstApproach_SectionComplete()
+        {
+            MarketingPages.ClientApplicationTypeActions.ClickRadioButtonWithText("Yes");
+
+            MarketingPages.CommonActions.ClickSave();
+
+            MarketingPages.DashboardActions.SectionMarkedComplete("Mobile first approach").Should().BeTrue();
+        }
+
+        [Fact]
+        public void MobileFirstApproach_SectionIncomplete()
+        {
+            MarketingPages.CommonActions.ClickGoBackLink();
+
+            MarketingPages.DashboardActions.SectionMarkedComplete("Mobile first approach").Should().BeFalse();
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/ClientApplication/BrowserBased/PlugInsOrExtensions.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/ClientApplication/BrowserBased/PlugInsOrExtensions.cs
@@ -1,0 +1,89 @@
+﻿using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Marketing.ClientApplication.BrowserBased
+{
+    public sealed class PlugInsOrExtensions : TestBase, IClassFixture<LocalWebApplicationFactory>
+    {
+        public PlugInsOrExtensions(LocalWebApplicationFactory factory) : base(factory, "marketing/supplier/solution/99999-99/section/browser-based/plug-ins-or-extensions")
+        {
+            using var context = GetBCContext();
+            var solution = context.Solutions.Single(s => s.Id == "99999-99");
+            solution.ClientApplication = @"{
+                        ""ClientApplicationTypes"": [
+                            ""browser-based""
+                        ],
+                        ""BrowsersSupported"": [],
+                        ""MobileResponsive"": null,
+                        ""Plugins"": null,
+                        ""HardwareRequirements"": null,
+                        ""NativeMobileHardwareRequirements"": null,
+                        ""NativeDesktopHardwareRequirements"": null,
+                        ""AdditionalInformation"": null,
+                        ""MinimumConnectionSpeed"": null,
+                        ""MinimumDesktopResolution"": null,
+                        ""MobileFirstDesign"": null,
+                        ""NativeMobileFirstDesign"": null,
+                        ""MobileOperatingSystems"": null,
+                        ""MobileConnectionDetails"": null,
+                        ""MobileMemoryAndStorage"": null,
+                        ""MobileThirdParty"": {
+                            ""ThirdPartyComponents"": null,
+                            ""DeviceCapabilities"": null
+                        },
+                        ""NativeMobileAdditionalInformation"": null,
+                        ""NativeDesktopOperatingSystemsDescription"": null,
+                        ""NativeDesktopMinimumConnectionSpeed"": null,
+                        ""NativeDesktopThirdParty"": null,
+                        ""NativeDesktopMemoryAndStorage"": null,
+                        ""NativeDesktopAdditionalInformation"": null
+                    }";
+            context.SaveChanges();
+
+            driver.Navigate().Refresh();
+        }
+
+        [Theory]
+        [InlineData("Yes")]
+        [InlineData("No")]
+        public async Task PlugInsOrExtensions_SelectRadioButton(string label)
+        {
+            MarketingPages.ClientApplicationTypeActions.ClickRadioButtonWithText(label);
+            var additional = MarketingPages.ClientApplicationTypeActions.EnterAdditionalInformation(1000);
+
+            MarketingPages.CommonActions.ClickSave();
+
+            string labelConvert = label == "Yes" ? "true" : "false";
+
+            using var context = GetBCContext();
+            var clientApplication = (await context.Solutions.SingleAsync(s => s.Id == "99999-99")).ClientApplication;
+            clientApplication.Should().ContainEquivalentOf(@$"Plugins"":{{""Required"":{labelConvert},""AdditionalInformation"":""{additional}""}}");
+        }
+
+        [Fact]
+        public void PlugInsOrExtensions_SectionComplete()
+        {
+            MarketingPages.ClientApplicationTypeActions.ClickRadioButtonWithText("Yes");
+            MarketingPages.ClientApplicationTypeActions.EnterAdditionalInformation(1000);
+
+            MarketingPages.CommonActions.ClickSave();
+
+            MarketingPages.DashboardActions.SectionMarkedComplete("Plug-ins or extensions required").Should().BeTrue();
+        }
+
+        [Fact]
+        public void PlugInsOrExtensions_SectionIncomplete()
+        {
+            MarketingPages.CommonActions.ClickGoBackLink();
+
+            MarketingPages.DashboardActions.SectionMarkedComplete("Plug-ins or extensions required").Should().BeFalse();
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/ClientApplication/BrowserBased/SupportedBrowsers.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/ClientApplication/BrowserBased/SupportedBrowsers.cs
@@ -1,0 +1,77 @@
+﻿using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Marketing.ClientApplication.BrowserBased
+{
+    public sealed class SupportedBrowsers : TestBase, IClassFixture<LocalWebApplicationFactory>
+    {
+        public SupportedBrowsers(LocalWebApplicationFactory factory) : base(factory, "marketing/supplier/solution/99999-99/section/browser-based/supported-browsers")
+        {
+            using var context = GetBCContext();
+            var solution = context.Solutions.Single(s => s.Id == "99999-99");
+            solution.ClientApplication = @"{
+                        ""ClientApplicationTypes"": [
+                            ""browser-based""
+                        ],
+                        ""BrowsersSupported"": [],
+                        ""MobileResponsive"": null,
+                        ""Plugins"": null,
+                        ""HardwareRequirements"": null,
+                        ""NativeMobileHardwareRequirements"": null,
+                        ""NativeDesktopHardwareRequirements"": null,
+                        ""AdditionalInformation"": null,
+                        ""MinimumConnectionSpeed"": null,
+                        ""MinimumDesktopResolution"": null,
+                        ""MobileFirstDesign"": null,
+                        ""NativeMobileFirstDesign"": null,
+                        ""MobileOperatingSystems"": null,
+                        ""MobileConnectionDetails"": null,
+                        ""MobileMemoryAndStorage"": null,
+                        ""MobileThirdParty"": {
+                            ""ThirdPartyComponents"": null,
+                            ""DeviceCapabilities"": null
+                        },
+                        ""NativeMobileAdditionalInformation"": null,
+                        ""NativeDesktopOperatingSystemsDescription"": null,
+                        ""NativeDesktopMinimumConnectionSpeed"": null,
+                        ""NativeDesktopThirdParty"": null,
+                        ""NativeDesktopMemoryAndStorage"": null,
+                        ""NativeDesktopAdditionalInformation"": null
+                    }";
+            context.SaveChanges();
+        }
+
+        [Fact]
+        public async Task SupportedBrowser_SelectBrowser()
+        {
+            var browser = MarketingPages.ClientApplicationTypeActions.ClickBrowserCheckbox();
+            MarketingPages.ClientApplicationTypeActions.ClickRadioButtonWithText("Yes");
+
+            MarketingPages.CommonActions.ClickSave();
+
+            using var context = GetBCContext();
+            (await context.Solutions.SingleAsync(s => s.Id == "99999-99")).ClientApplication.Should().ContainEquivalentOf(browser);
+        }
+
+        [Theory]
+        [InlineData("Yes")]
+        [InlineData("No")]
+        public async Task SupportedBrowser_SelectMobileResponsive(string label)
+        {
+            MarketingPages.ClientApplicationTypeActions.ClickBrowserCheckbox();
+            MarketingPages.ClientApplicationTypeActions.ClickRadioButtonWithText(label);
+
+            MarketingPages.CommonActions.ClickSave();
+
+            string labelConvert = label == "Yes" ? "true" : "false";
+
+            using var context = GetBCContext();
+            var clientApplication = (await context.Solutions.SingleAsync(s => s.Id == "99999-99")).ClientApplication;
+            clientApplication.Should().ContainEquivalentOf(@$"MobileResponsive"":{ labelConvert }");
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/ClientApplication/NativeDesktop/NativeDesktopDashboard.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/ClientApplication/NativeDesktop/NativeDesktopDashboard.cs
@@ -1,0 +1,62 @@
+﻿using FluentAssertions;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Marketing.ClientApplication.NativeDesktop
+{
+    public sealed class NativeDesktopDashboard : TestBase, IClassFixture<LocalWebApplicationFactory>
+    {
+        public NativeDesktopDashboard(LocalWebApplicationFactory factory) : base(factory, "marketing/supplier/solution/99999-99/section/native-desktop")
+        {
+            using var context = GetBCContext();
+            var solution = context.Solutions.Single(s => s.Id == "99999-99");
+            solution.ClientApplication = @"{
+                        ""ClientApplicationTypes"": [
+                            ""native-desktop""
+                        ],
+                        ""BrowsersSupported"": [],
+                        ""MobileResponsive"": null,
+                        ""Plugins"": null,
+                        ""HardwareRequirements"": null,
+                        ""NativeMobileHardwareRequirements"": null,
+                        ""NativeDesktopHardwareRequirements"": null,
+                        ""AdditionalInformation"": null,
+                        ""MinimumConnectionSpeed"": null,
+                        ""MinimumDesktopResolution"": null,
+                        ""MobileFirstDesign"": null,
+                        ""NativeMobileFirstDesign"": null,
+                        ""MobileOperatingSystems"": null,
+                        ""MobileConnectionDetails"": null,
+                        ""MobileMemoryAndStorage"": null,
+                        ""MobileThirdParty"": {
+                            ""ThirdPartyComponents"": null,
+                            ""DeviceCapabilities"": null
+                        },
+                        ""NativeMobileAdditionalInformation"": null,
+                        ""NativeDesktopOperatingSystemsDescription"": null,
+                        ""NativeDesktopMinimumConnectionSpeed"": null,
+                        ""NativeDesktopThirdParty"": null,
+                        ""NativeDesktopMemoryAndStorage"": null,
+                        ""NativeDesktopAdditionalInformation"": null
+                    }";
+            context.SaveChanges();
+        }
+
+        [Theory]
+        [InlineData("Supported operating systems")]
+        [InlineData("Connectivity")]
+        [InlineData("Memory, storage, processing and resolution")]
+        [InlineData("Third-party components and device capabilities")]
+        [InlineData("Hardware requirements")]
+        [InlineData("Additional information")]
+        public void NativeDesktopDashboard_SectionsDisplayed(string section)
+        {
+            MarketingPages.DashboardActions.SectionDisplayed(section).Should().BeTrue();
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/ClientApplication/NativeMobile/NativeMobileDashboard.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/ClientApplication/NativeMobile/NativeMobileDashboard.cs
@@ -1,0 +1,63 @@
+﻿using FluentAssertions;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Marketing.ClientApplication.NativeMobile
+{
+    public sealed class NativeMobileDashboard : TestBase, IClassFixture<LocalWebApplicationFactory>
+    {
+        public NativeMobileDashboard(LocalWebApplicationFactory factory) : base(factory, "marketing/supplier/solution/99999-99/section/native-mobile")
+        {
+            using var context = GetBCContext();
+            var solution = context.Solutions.Single(s => s.Id == "99999-99");
+            solution.ClientApplication = @"{
+                        ""ClientApplicationTypes"": [
+                            ""native-mobile""
+                        ],
+                        ""BrowsersSupported"": [],
+                        ""MobileResponsive"": null,
+                        ""Plugins"": null,
+                        ""HardwareRequirements"": null,
+                        ""NativeMobileHardwareRequirements"": null,
+                        ""NativeDesktopHardwareRequirements"": null,
+                        ""AdditionalInformation"": null,
+                        ""MinimumConnectionSpeed"": null,
+                        ""MinimumDesktopResolution"": null,
+                        ""MobileFirstDesign"": null,
+                        ""NativeMobileFirstDesign"": null,
+                        ""MobileOperatingSystems"": null,
+                        ""MobileConnectionDetails"": null,
+                        ""MobileMemoryAndStorage"": null,
+                        ""MobileThirdParty"": {
+                            ""ThirdPartyComponents"": null,
+                            ""DeviceCapabilities"": null
+                        },
+                        ""NativeMobileAdditionalInformation"": null,
+                        ""NativeDesktopOperatingSystemsDescription"": null,
+                        ""NativeDesktopMinimumConnectionSpeed"": null,
+                        ""NativeDesktopThirdParty"": null,
+                        ""NativeDesktopMemoryAndStorage"": null,
+                        ""NativeDesktopAdditionalInformation"": null
+                    }";
+            context.SaveChanges();
+        }
+
+        [Theory]
+        [InlineData("Supported operating systems")]
+        [InlineData("Mobile first approach")]
+        [InlineData("Connectivity")]
+        [InlineData("Memory and storage")]
+        [InlineData("Third-party components and device capabilities")]
+        [InlineData("Hardware requirements")]
+        [InlineData("Additional information")]
+        public void NativeMobileDashboard_SectionsDisplayed(string section)
+        {
+            MarketingPages.DashboardActions.SectionDisplayed(section).Should().BeTrue();
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/ClientApplication/SelectClientApplication.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/ClientApplication/SelectClientApplication.cs
@@ -1,0 +1,47 @@
+﻿using FluentAssertions;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using System.Linq;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Marketing.ClientApplication
+{
+    public sealed class SelectClientApplication : TestBase, IClassFixture<LocalWebApplicationFactory>
+    {
+        public SelectClientApplication(LocalWebApplicationFactory factory) : base(factory, "marketing/supplier/solution/99999-99/section/client-application-types")
+        {
+            using var context = GetBCContext();
+            var solution = context.Solutions.Single(s => s.Id == "99999-99");
+            solution.ClientApplication = string.Empty;
+            context.SaveChanges();
+        }
+
+        [Theory]
+        [InlineData("Browser-based")]
+        [InlineData("Native mobile or tablet")]
+        [InlineData("Native desktop")]
+        public void SelectClientApplication_DashboardSectionEnabled(string clientApplicationType)
+        {
+            MarketingPages.ClientApplicationTypeActions.SelectClientApplicationCheckbox(clientApplicationType);
+            MarketingPages.CommonActions.ClickSave();
+
+            MarketingPages.DashboardActions.SectionDisplayed(clientApplicationType).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SelectClientApplication_SectionMarkedAsComplete()
+        {
+            MarketingPages.ClientApplicationTypeActions.SelectClientApplicationCheckbox("Browser-based");
+            MarketingPages.CommonActions.ClickSave();
+
+            MarketingPages.DashboardActions.SectionMarkedComplete("Client application type").Should().BeTrue();
+        }
+
+        [Fact]
+        public void SelectClientApplication_SectionMarkedAsIncomplete()
+        {
+            MarketingPages.CommonActions.ClickGoBackLink();
+
+            MarketingPages.DashboardActions.SectionMarkedComplete("Client application type").Should().BeFalse();
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/NHSD.GPIT.BuyingCatalogue.E2ETests.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/NHSD.GPIT.BuyingCatalogue.E2ETests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="90.0.4430.2400" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Objects/Marketing/ClientApplicationObjects.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Objects/Marketing/ClientApplicationObjects.cs
@@ -1,0 +1,23 @@
+﻿using OpenQA.Selenium;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.Marketing
+{
+    internal static class ClientApplicationObjects
+    {
+        internal static By AdditionalInfoTextArea => By.Id("AdditionalInformation");
+
+        internal static By RadioButtonItems => By.CssSelector(".nhsuk-radios__item");
+
+        internal static By BrowserCheckboxItem => By.CssSelector(".nhsuk-checkboxes__item");
+
+        internal static By BrowserBasedCheckbox => By.Id("BrowserBased");
+
+        internal static By NativeMobileCheckbox => By.Id("NativeMobile");
+
+        internal static By NativeDesktopCheckbox => By.Id("NativeDesktop");
+
+        internal static By ConnectionSpeedSelect => By.Id("SelectedConnectionSpeed");
+
+        internal static By ResolutionSelect => By.Id("SelectedScreenResolution");
+    }
+}


### PR DESCRIPTION
I will be updating these so that the initial cleardown of the client application column is put somewhere central