### PR TITLE
Fix Solution with Duplicate Name Saving

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Solutions/ISolutionsService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Solutions/ISolutionsService.cs
@@ -17,6 +17,8 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions
 
         Task<CatalogueItem> GetSolution(CatalogueItemId solutionId);
 
+        Task<CatalogueItem> GetSolutionByName(string solutionName);
+
         Task<CatalogueItem> GetSolutionCapability(CatalogueItemId catalogueItemId, Guid capabilityId);
 
         Task<CatalogueItem> GetSolutionWithAllAssociatedServices(CatalogueItemId solutionId);

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Solutions/SolutionsService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Solutions/SolutionsService.cs
@@ -90,6 +90,17 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Solutions
                 .FirstOrDefaultAsync();
         }
 
+        public Task<CatalogueItem> GetSolutionByName(string solutionName)
+        {
+            return dbContext.CatalogueItems
+                .Include(i => i.Solution).ThenInclude(s => s.SolutionCapabilities).ThenInclude(sc => sc.Capability)
+                .Include(i => i.Supplier)
+                .Include(i => i.Solution).ThenInclude(s => s.FrameworkSolutions).ThenInclude(fs => fs.Framework)
+                .Include(i => i.Solution).ThenInclude(s => s.MarketingContacts)
+                .Where(i => i.Name == solutionName)
+                .FirstOrDefaultAsync();
+        }
+
         public async Task<CatalogueItem> GetSolutionCapability(CatalogueItemId catalogueItemId, Guid capabilityId)
         {
             catalogueItemId.ValidateNotNull(nameof(catalogueItemId));

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AddCatalogueSolutionController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AddCatalogueSolutionController.cs
@@ -38,6 +38,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
         [HttpPost]
         public async Task<IActionResult> Index(AddSolutionModel model)
         {
+            if (await solutionsService.GetSolutionByName(model.SolutionName) is not null)
+                ModelState.AddModelError(nameof(AddSolutionModel.SolutionName), "A solution with this name already exists");
+
             if (!ModelState.IsValid)
             {
                 var suppliers = await solutionsService.GetAllSuppliers();

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AddSolution.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AddSolution.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers;
 using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution
@@ -59,6 +60,30 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution
 
             dbSolution.Supplier.Id.Should().Be("99999");
             dbSolution.PublishedStatus.Should().Be(PublicationStatus.Draft);
+        }
+
+        [Fact]
+        public async Task AddSolution_SolutionWithDuplicateName_ThrowsError()
+        {
+            await using var context = GetEndToEndDbContext();
+            var existingSolution = await context.CatalogueItems.FirstOrDefaultAsync();
+
+            CommonActions.ElementAddValue(Objects.Admin.AddSolutionObjects.SolutionName, existingSolution.Name);
+
+            CommonActions.SelectDropdownItem(Objects.Admin.AddSolutionObjects.SupplierName, 0);
+
+            CommonActions.ClickFirstCheckbox();
+
+            CommonActions.ClickSave();
+
+            CommonActions.PageLoadedCorrectGetIndex(
+                typeof(AddCatalogueSolutionController),
+                nameof(AddCatalogueSolutionController.Index)).Should().BeTrue();
+
+            CommonActions.ErrorSummaryDisplayed().Should().BeTrue();
+
+            CommonActions.ElementShowingCorrectErrorMessage("SolutionName", "A solution with this name already exists")
+                .Should().BeTrue();
         }
     }
 }


### PR DESCRIPTION
Fix trying to add a solution with a duplicate name saving. it will now throw an error.
Add a net GetSolutionByName to SolutionsServices to help facilitate this check.