### PR TITLE
Update Components For Compatibility.

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsDeleteButton/NhsDeleteButton.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsDeleteButton/NhsDeleteButton.cshtml
@@ -1,5 +1,5 @@
 ﻿@model NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsDeleteButton.NhsDeleteButtonModel
 
-<a href="@Model.Url" style="color: red;" draggable="false">
+<a href="@Model.Url" style="color: #CC0000;" draggable="false">
     @Model.Text
 </a>

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/FieldSet/FieldSetFormContainerTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/FieldSet/FieldSetFormContainerTagHelper.cs
@@ -33,7 +33,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.FieldS
             string formName = TagHelperFunctions.GetModelKebabNameFromFor(For);
 
             var formGroup = TagHelperBuilders.GetFormGroupBuilder();
-            var fieldset = GetFieldsetBuilder(formName);
+            var fieldset = GetFieldsetBuilder(formName, LabelHint);
             var fieldsetheading = GetFieldSetLegendHeadingBuilder(SelectedSize, LabelText);
             var hint = TagHelperBuilders.GetLabelHintBuilder(For, LabelHint, formName);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/FieldSet/FieldSetFormLabelTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/FieldSet/FieldSetFormLabelTagHelper.cs
@@ -56,7 +56,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
 
             var formGroup = TagHelperBuilders.GetFormGroupBuilder();
 
-            var fieldset = GetFieldsetBuilder(formName);
+            var fieldset = GetFieldsetBuilder(formName, LabelHint);
 
             var fieldsetheading = GetFieldSetLegendHeadingBuilder(SelectedSize, LabelText);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/FieldSet/FieldSetTagHelperBuilders.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/FieldSet/FieldSetTagHelperBuilders.cs
@@ -23,12 +23,14 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.FieldS
             Small = 3,
         }
 
-        public static TagBuilder GetFieldsetBuilder(string formName)
+        public static TagBuilder GetFieldsetBuilder(string formName, string labelHint)
         {
             var builder = new TagBuilder(TagHelperConstants.FieldSet);
 
             builder.AddCssClass(NhsFieldset);
-            builder.MergeAttribute(TagHelperConstants.AriaDescribedBy, $"{formName}-hint");
+
+            if (!string.IsNullOrWhiteSpace(labelHint))
+                builder.MergeAttribute(TagHelperConstants.AriaDescribedBy, TagBuilder.CreateSanitizedId($"{formName}-hint", "_"));
 
             return builder;
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Helpers/TagHelperBuilders.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Helpers/TagHelperBuilders.cs
@@ -66,9 +66,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
         {
             if ((string.IsNullOrEmpty(aspFor?.Name) && string.IsNullOrEmpty(formName))
                 || string.IsNullOrEmpty(hintText))
-            {
                 return null;
-            }
 
             var name = !string.IsNullOrEmpty(aspFor?.Name) ? aspFor.Name : formName;
 
@@ -91,9 +89,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
         {
             if ((string.IsNullOrEmpty(aspFor.Name) && string.IsNullOrEmpty(formName))
                 || string.IsNullOrEmpty(htmlAttributeLabelText))
-            {
                 return null;
-            }
 
             return htmlGenerator.GenerateLabel(
                 viewContext,

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Helpers/TagHelperConstants.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Helpers/TagHelperConstants.cs
@@ -35,6 +35,7 @@
         internal const string DataModule = "data-module";
         internal const string DataMaxLength = "data-maxlength";
         internal const string AriaDescribedBy = "aria-describedby";
+        internal const string AriaDescription = "aria-description";
         internal const string AriaControls = "aria-controls";
         internal const string AriaExpanded = "aria-expanded";
         internal const string AriaLive = "aria-live";

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/InputBoxes/BookendedTextInputTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/InputBoxes/BookendedTextInputTagHelper.cs
@@ -150,7 +150,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.InputB
 
         private void SetLabelAriaDescription(TagBuilder labelBuilder)
         {
-            if (string.IsNullOrWhiteSpace(SuffixText))
+            if (labelBuilder is null || string.IsNullOrWhiteSpace(SuffixText))
                 return;
 
             labelBuilder.MergeAttribute(

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/InputBoxes/BookendedTextInputTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/InputBoxes/BookendedTextInputTagHelper.cs
@@ -52,6 +52,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.InputB
         {
             var formGroup = GetGovFormGroupBuilder();
             var label = TagHelperBuilders.GetLabelBuilder(ViewContext, For, htmlGenerator, null, LabelText);
+            SetLabelAriaDescription(label);
             var hint = TagHelperBuilders.GetLabelHintBuilder(For, LabelHint, null);
             var validation = TagHelperBuilders.GetValidationBuilder(ViewContext, For, htmlGenerator);
             var inputWrapper = GetInputWrapper();
@@ -100,12 +101,14 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.InputB
                 new
                 {
                     @class = $"{TagHelperConstants.NhsInput} {TextInputWidthClass}",
-                    aria_describedby = $"{For.Name}-info {For.Name}-summary",
                     spellcheck = "false",
                 });
 
             if (!builder.Attributes.Any(a => a.Key == "maxlength"))
                 builder.MergeAttribute("maxlength", DefaultMaxLength.ToString());
+
+            if (!string.IsNullOrWhiteSpace(LabelHint))
+                builder.MergeAttribute(TagHelperConstants.AriaDescribedBy, TagBuilder.CreateSanitizedId($"{For.Name}-hint", "_"));
 
             if (TagHelperFunctions.CheckIfModelStateHasErrors(ViewContext, For))
                 builder.AddCssClass(TagHelperConstants.NhsValidationInputError);
@@ -122,6 +125,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.InputB
             builder.AddCssClass(GovUkInputPrefixClass);
 
             builder.MergeAttribute(TagHelperConstants.AriaHidden, "true");
+            builder.GenerateId($"{For.Name}-prefix", "_");
 
             builder.InnerHtml.Append(PrefixText);
 
@@ -137,10 +141,21 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.InputB
             builder.AddCssClass(GovUkInputSuffixClass);
 
             builder.MergeAttribute(TagHelperConstants.AriaHidden, "true");
+            builder.GenerateId($"{For.Name}-suffix", "_");
 
             builder.InnerHtml.Append(SuffixText);
 
             return builder;
+        }
+
+        private void SetLabelAriaDescription(TagBuilder labelBuilder)
+        {
+            if (string.IsNullOrWhiteSpace(SuffixText))
+                return;
+
+            labelBuilder.MergeAttribute(
+                TagHelperConstants.AriaDescription,
+                TagBuilder.CreateSanitizedId($"{For.Name}-suffix", "_"));
         }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/InputBoxes/TextAreaTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/InputBoxes/TextAreaTagHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -72,14 +73,28 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
                 new
                 {
                     @class = NhsTextArea,
-                    aria_describedby = $"{For.Name}-info {For.Name}-summary",
                 });
 
             if (!builder.Attributes.Any(a => a.Key == "maxlength"))
                 builder.MergeAttribute("maxlength", DefaultMaxLength.ToString());
 
+            var describedBy = new List<string>();
+
+            if (!string.IsNullOrWhiteSpace(LabelHint))
+                describedBy.Add($"{For.Name}-hint");
+
             if (!TagHelperFunctions.IsCounterDisabled(For, CharacterCountEnabled))
+            {
+                describedBy.Add($"{For.Name}-info");
                 builder.AddCssClass(TagHelperConstants.GovUkJsCharacterCount);
+            }
+
+            if (describedBy.Any())
+            {
+                builder.MergeAttribute(
+                    TagHelperConstants.AriaDescribedBy,
+                    TagBuilder.CreateSanitizedId(string.Join(' ', describedBy), "_"));
+            }
 
             if (TagHelperFunctions.CheckIfModelStateHasErrors(ViewContext, For))
             {


### PR DESCRIPTION
Update fieldsets to only apply AriaDescribedBy when a hint exists.

update text inputs (area,normal and bookended) to correctly apply aria-describedby only if a label or the counter exists (and allows them to both be applied together)

update bookended inputs to add aria-description to the label pointing to the suffix if it has a label

update colour of the delete link to satisfy contrast issues.