### PR TITLE
Add Catalogue Solution E2E Tests

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/CatalogueSolutions/SelectSolutionPriceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/CatalogueSolutions/SelectSolutionPriceModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Extensions;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
@@ -23,6 +24,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.CatalogueSolutions
 
         public List<PriceModel> Prices { get; set; }
 
+        [Required(ErrorMessage = "Select a price")]
         public int? SelectedPrice { get; set; }
 
         public void SetPrices(List<CataloguePrice> prices)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/CatalogueSolutions/SelectSolutionPrice.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/CatalogueSolutions/SelectSolutionPrice.cshtml
@@ -8,6 +8,7 @@
 
     <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
+            <nhs-validation-summary />
             <nhs-page-title title="@Model.Title"
                             advice="Select the list price for this Catalogue Solution. If you’ve agreed a different price with the supplier, the values can be altered later." />
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Actions/Common/CommonActions.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Actions/Common/CommonActions.cs
@@ -88,9 +88,17 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Actions.Common
         internal int GetNumberOfRadioButtonsDisplayed() =>
             Driver.FindElements(By.ClassName("nhsuk-radios__input")).Count;
 
+        internal int GetNumberOfCheckBoxesDisplayed() =>
+            Driver.FindElements(By.ClassName("nhsuk-checkboxes__input")).Count;
+
         // Get Element Values
         internal string PageTitle() =>
             Driver.FindElement(CommonSelectors.Header1).Text.FormatForComparison();
+
+        internal int GetNumberOfSelectedCheckBoxes() =>
+            Driver.FindElements(By.ClassName("nhsuk-checkboxes__input")).Count(cb => cb.Selected);
+
+        internal bool AllCheckBoxesSelected() => Driver.FindElements(By.ClassName("nhsuk-checkboxes__input")).All(cb => cb.Selected);
 
         // Element Comparisons
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Actions/PublicBrowse/CommonActions.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Actions/PublicBrowse/CommonActions.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Actions.Common;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.PublicBrowse;
 using OpenQA.Selenium;
@@ -15,7 +16,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Actions.PublicBrowse
         internal string GetBreadcrumbNames(string breadcrumbItem)
         {
             var rows = Driver.FindElements(SolutionObjects.BreadcrumbsBanner);
-            var row = rows.Single(r => r.FindElement(By.TagName("a")).Text.Contains(breadcrumbItem, System.StringComparison.OrdinalIgnoreCase));
+            var row = rows.Single(r => r.FindElement(By.TagName("a")).Text.Contains(breadcrumbItem, StringComparison.OrdinalIgnoreCase));
             return row.FindElement(By.TagName("a")).Text;
         }
     }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/CatalogueSolutionSelectPrice.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/CatalogueSolutionSelectPrice.cs
@@ -1,0 +1,112 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.Common;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.CatalogueSolutions
+{
+    public sealed class CatalogueSolutionSelectPrice
+        : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IAsyncLifetime
+    {
+        private static readonly CallOffId CallOffId = new(90004, 01);
+        private static readonly CatalogueItemId CatalogueItemId = new(99998, "001");
+
+        private static readonly Dictionary<string, string> Parameters =
+            new() { { "OdsCode", "03F" }, { nameof(CallOffId), CallOffId.ToString() } };
+
+        // We navigate to the catalogue solution selection page to initialize a session
+        // but the InitializeAsync will always redirect us to SelectSolutionPrice
+        public CatalogueSolutionSelectPrice(
+            LocalWebApplicationFactory factory)
+            : base(
+                  factory,
+                  typeof(CatalogueSolutionsController),
+                  nameof(CatalogueSolutionsController.SelectSolution),
+                  Parameters)
+        {
+        }
+
+        [Fact]
+        public async Task CatalogueSolutionsSelectPrice_AllSectionsDisplayed()
+        {
+            CommonActions.SaveButtonDisplayed().Should().BeTrue();
+            CommonActions.ElementIsDisplayed(CommonSelectors.RadioButtonItems).Should().BeTrue();
+            CommonActions.ElementIsDisplayed(CommonSelectors.Header1).Should().BeTrue();
+
+            await using var context = GetEndToEndDbContext();
+            var numberOfPrices = await context.CataloguePrices.Where(cp => cp.CatalogueItemId == CatalogueItemId).CountAsync();
+
+            CommonActions.GetNumberOfRadioButtonsDisplayed().Should().Equals(numberOfPrices);
+        }
+
+        [Fact]
+        public void CatalogueSolutionsSelectPrice_DontSelectPrice_ThrowsError()
+        {
+            CommonActions.ClickSave();
+
+            CommonActions.PageLoadedCorrectGetIndex(
+                  typeof(CatalogueSolutionsController),
+                  nameof(CatalogueSolutionsController.SelectSolutionPrice)).Should().BeTrue();
+
+            CommonActions.ErrorSummaryDisplayed().Should().BeTrue();
+
+            CommonActions
+                .ElementShowingCorrectErrorMessage(Objects.Ordering.CatalogueSolutions.SelectCatalogueSolutionPriceErrorMessage, "Error: Select a price")
+                .Should()
+                .BeTrue();
+        }
+
+        [Theory]
+        [InlineData("£999.9999 per test patient per year")]
+        [InlineData("£999.9999 per test declarative per year")]
+        [InlineData("£999.9999 per test on demand per year")]
+        public void CatalogueSolutionsSelectPrice_SelectPrice_ExpectedResult(string priceSelection)
+        {
+            CommonActions.ClickRadioButtonWithText(priceSelection);
+
+            CommonActions.ClickSave();
+
+            CommonActions.PageLoadedCorrectGetIndex(
+                typeof(CatalogueSolutionRecipientsController),
+                nameof(CatalogueSolutionRecipientsController.SelectSolutionServiceRecipients)).Should().BeTrue();
+
+            var model = Session.GetOrderStateFromSession(CallOffId.ToString());
+
+            model.AgreedPrice.Should().NotBeNull();
+        }
+
+        public Task InitializeAsync()
+        {
+            InitializeSessionHandler();
+
+            var model = new CreateOrderItemModel
+            {
+                CallOffId = CallOffId,
+                CatalogueItemId = CatalogueItemId,
+                CatalogueItemName = "E2E With Contact Multiple Prices",
+            };
+
+            Session.SetOrderStateToSessionAsync(model);
+
+            NavigateToUrl(
+                typeof(CatalogueSolutionsController),
+                nameof(CatalogueSolutionsController.SelectSolutionPrice),
+                Parameters);
+
+            return Task.CompletedTask;
+        }
+
+        public Task DisposeAsync()
+        {
+            return DisposeSession();
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/CatalogueSolutionsSelectRecipients.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/CatalogueSolutionsSelectRecipients.cs
@@ -1,0 +1,150 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.CatalogueSolutions
+{
+    public sealed class CatalogueSolutionsSelectRecipients
+        : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IAsyncLifetime
+    {
+        private static readonly CallOffId CallOffId = new(90004, 01);
+        private static readonly string OdsCode = "03F";
+        private static readonly CatalogueItemId CatalogueItemId = new(99998, "001");
+
+        private static readonly Dictionary<string, string> Parameters =
+            new() { { nameof(OdsCode), OdsCode }, { nameof(CallOffId), CallOffId.ToString() } };
+
+        // We navigate to the catalogue solution selection page to initialize a session
+        // but the initializeAsync will always redirect us to SelectSolutionRecipients
+        public CatalogueSolutionsSelectRecipients(
+            LocalWebApplicationFactory factory)
+            : base(
+                  factory,
+                  typeof(CatalogueSolutionsController),
+                  nameof(CatalogueSolutionsController.SelectSolution),
+                  Parameters)
+        {
+        }
+
+        [Fact]
+        public void CatalogueSolutionsSelectRecipient_AllSectionsDisplayed()
+        {
+            CommonActions.SaveButtonDisplayed().Should().BeTrue();
+
+            CommonActions
+                .ElementIsDisplayed(Objects.Ordering.CatalogueSolutions.CatalogueSolutionsRecipientsSelectAllButton)
+                .Should()
+                .BeTrue();
+
+            CommonActions
+                .ElementIsDisplayed(Objects.Ordering.CatalogueSolutions.CatalogueSolutionsRecipientsTable)
+                .Should()
+                .BeTrue();
+
+            Factory.GetMemoryCache.TryGetValue(
+                $"ServiceRecipients-ODS-{OdsCode}",
+                out IEnumerable<ServiceContracts.Models.ServiceRecipient> cachedResults);
+
+            CommonActions.GetNumberOfCheckBoxesDisplayed().Should().Be(cachedResults.Count());
+        }
+
+        [Fact]
+        public void CatalogueSolutionsSelectRecipient_DontSelectRecipients_ThrowsError()
+        {
+            CommonActions.ClickSave();
+
+            CommonActions.PageLoadedCorrectGetIndex(
+                typeof(CatalogueSolutionRecipientsController),
+                nameof(CatalogueSolutionRecipientsController.SelectSolutionServiceRecipients)).Should().BeTrue();
+
+            CommonActions.ErrorSummaryDisplayed().Should().BeTrue();
+
+            CommonActions.ElementShowingCorrectErrorMessage(
+                Objects.Ordering.CatalogueSolutions.CatalogueSolutionsRecipientsErrorMessage,
+                "Error: Select a service recipient").Should().BeTrue();
+        }
+
+        [Fact]
+        public void CatalogueSolutionsSelectRecipient_SelectAll_ExpectedResult()
+        {
+            CommonActions.ClickLinkElement(Objects.Ordering.CatalogueSolutions.CatalogueSolutionsRecipientsSelectAllButton);
+
+            CommonActions.PageLoadedCorrectGetIndex(
+                typeof(CatalogueSolutionRecipientsController),
+                nameof(CatalogueSolutionRecipientsController.SelectSolutionServiceRecipients)).Should().BeTrue();
+
+            CommonActions.AllCheckBoxesSelected().Should().BeTrue();
+
+            CommonActions.ElementTextEqualToo(
+                Objects.Ordering.CatalogueSolutions.CatalogueSolutionsRecipientsSelectAllButton,
+                "Deselect all").Should().BeTrue();
+        }
+
+        [Fact]
+        public void CatalogueSolutionsSelectRecipient_DeselectAll_ExpectedResult()
+        {
+            var queryParameters = new Dictionary<string, string>
+            {
+                { "selectionMode", "all" },
+            };
+
+            NavigateToUrl(
+                typeof(CatalogueSolutionRecipientsController),
+                nameof(CatalogueSolutionRecipientsController.SelectSolutionServiceRecipients),
+                Parameters,
+                queryParameters);
+
+            CommonActions.ClickLinkElement(Objects.Ordering.CatalogueSolutions.CatalogueSolutionsRecipientsSelectAllButton);
+
+            CommonActions.PageLoadedCorrectGetIndex(
+                typeof(CatalogueSolutionRecipientsController),
+                nameof(CatalogueSolutionRecipientsController.SelectSolutionServiceRecipients)).Should().BeTrue();
+
+            CommonActions.AllCheckBoxesSelected().Should().BeFalse();
+
+            CommonActions.GetNumberOfSelectedCheckBoxes().Should().Be(0);
+
+            CommonActions.ElementTextEqualToo(
+                Objects.Ordering.CatalogueSolutions.CatalogueSolutionsRecipientsSelectAllButton,
+                "Select all").Should().BeTrue();
+        }
+
+        public Task InitializeAsync()
+        {
+            InitializeSessionHandler();
+
+            using var context = GetEndToEndDbContext();
+            var price = context.CataloguePrices.SingleOrDefault(cp => cp.CataloguePriceId == 1);
+
+            var model = new CreateOrderItemModel
+            {
+                CallOffId = CallOffId,
+                CatalogueItemId = CatalogueItemId,
+                CatalogueItemName = "E2E With Contact Multiple Prices",
+                CataloguePrice = price,
+            };
+
+            Session.SetOrderStateToSessionAsync(model);
+
+            NavigateToUrl(
+                typeof(CatalogueSolutionRecipientsController),
+                nameof(CatalogueSolutionRecipientsController.SelectSolutionServiceRecipients),
+                Parameters);
+
+            return Task.CompletedTask;
+        }
+
+        public Task DisposeAsync()
+        {
+            return DisposeSession();
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Objects/Ordering/CatalogueSolutions.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Objects/Ordering/CatalogueSolutions.cs
@@ -5,5 +5,13 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.Ordering
     public static class CatalogueSolutions
     {
         public static By SelectCatalogueSolutionErrorMessage => By.Id("select-solution-error");
+
+        public static By SelectCatalogueSolutionPriceErrorMessage => By.Id("select-solution-price-error");
+
+        public static By CatalogueSolutionsRecipientsSelectAllButton => By.ClassName("nhsuk-button--secondary");
+
+        public static By CatalogueSolutionsRecipientsTable => By.ClassName("nhsuk-table-responsive");
+
+        public static By CatalogueSolutionsRecipientsErrorMessage => By.ClassName("nhsuk-error-message");
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/LocalWebApplicationFactory.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/LocalWebApplicationFactory.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Database;
@@ -118,7 +119,9 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils
             }
         }
 
-        internal IDistributedCache GetCache => host.Services.GetRequiredService<IDistributedCache>();
+        internal IDistributedCache GetDistributedCache => host.Services.GetRequiredService<IDistributedCache>();
+
+        internal IMemoryCache GetMemoryCache => host.Services.GetRequiredService<IMemoryCache>();
 
         internal IDataProtectionProvider GetDataProtectionProvider => host.Services.GetRequiredService<IDataProtectionProvider>();
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
@@ -645,15 +645,16 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                     {
                         new()
                         {
+                            CataloguePriceId = 1,
                             CatalogueItemId = new CatalogueItemId(99998, "001"),
                             ProvisioningType = ProvisioningType.Patient,
                             CataloguePriceType = CataloguePriceType.Flat,
-                            PricingUnit = new()
+                            PricingUnit = new PricingUnit
                             {
                                 PricingUnitId = Guid.NewGuid(),
-                                Name = "Test Pricing",
+                                Name = "Test Pricing Patient",
                                 TierName = "Test Tier",
-                                Description = "Per Test",
+                                Description = "per test patient",
                             },
                             TimeUnit = TimeUnit.PerYear,
                             CurrencyCode = "GBP",
@@ -662,15 +663,16 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                         },
                         new()
                         {
+                            CataloguePriceId = 2,
                             CatalogueItemId = new CatalogueItemId(99998, "001"),
                             ProvisioningType = ProvisioningType.OnDemand,
                             CataloguePriceType = CataloguePriceType.Flat,
-                            PricingUnit = new()
+                            PricingUnit = new PricingUnit
                             {
                                 PricingUnitId = Guid.NewGuid(),
-                                Name = "Test Pricing",
+                                Name = "Test Pricing On Demand",
                                 TierName = "Test Tier",
-                                Description = "Per Test",
+                                Description = "per test on demand",
                             },
                             TimeUnit = TimeUnit.PerYear,
                             CurrencyCode = "GBP",
@@ -679,15 +681,16 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                         },
                         new()
                         {
+                            CataloguePriceId = 3,
                             CatalogueItemId = new CatalogueItemId(99998, "001"),
-                            ProvisioningType = ProvisioningType.OnDemand,
+                            ProvisioningType = ProvisioningType.Declarative,
                             CataloguePriceType = CataloguePriceType.Flat,
-                            PricingUnit = new()
+                            PricingUnit = new PricingUnit
                             {
                                 PricingUnitId = Guid.NewGuid(),
-                                Name = "Test Pricing",
+                                Name = "Test Pricing Declarative",
                                 TierName = "Test Tier",
-                                Description = "Per Test",
+                                Description = "per test declarative",
                             },
                             TimeUnit = TimeUnit.PerYear,
                             CurrencyCode = "GBP",
@@ -802,6 +805,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                     {
                         new()
                         {
+                            CataloguePriceId = 4,
                             CatalogueItemId = new CatalogueItemId(99998, "002"),
                             ProvisioningType = ProvisioningType.Declarative,
                             CataloguePriceType = CataloguePriceType.Flat,

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/TestBases/TestBase.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/TestBases/TestBase.cs
@@ -152,7 +152,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases
         {
             Session = new SessionHandler(
                 Factory.GetDataProtectionProvider,
-                Factory.GetCache,
+                Factory.GetDistributedCache,
                 Factory.Driver,
                 Factory.GetLoggerFactory);
         }


### PR DESCRIPTION
Add SelectSolutionPrice and SelectSolutionRecipient tests

Add reference to Factory for IMemoryCache for getting Recipient Cached values

Update SelectSolutionPrice page to have an error summary, and add an error to SelectSolutionPriceModel if no price is selected.

Update Catalogue Solution Seeddata to have CataloguePriceId's set on CataloguePrices

Rename GetCache to GetDistributedCache to differential between the distrubuted and normal memorycaches