### PR TITLE
Add interoperability E2E tests

### DIFF
--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Description.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Description.cs
@@ -34,7 +34,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution
         {
             var summary = TextGenerators.TextInputAddText(CommonSelectors.Summary, 350);
             var fullDescription = TextGenerators.TextInputAddText(CommonSelectors.Description, 1000);
-            var link = TextGenerators.UrlInputAddText(CommonSelectors.Link, 1000);
+            var link = TextGenerators.UrlInputAddText(Objects.Common.CommonSelectors.LinkTextBox, 1000);
 
             CommonActions.ClickSave();
 
@@ -56,7 +56,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution
             await context.SaveChangesAsync();
 
             TextGenerators.TextInputAddText(CommonSelectors.Description, 1000);
-            TextGenerators.UrlInputAddText(CommonSelectors.Link, 1000);
+            TextGenerators.UrlInputAddText(Objects.Common.CommonSelectors.LinkTextBox, 1000);
 
             AdminPages.CommonActions.ClickGoBack();
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/DevelopmentPlans.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/DevelopmentPlans.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
-using NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.Marketing;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
@@ -17,7 +16,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution
         public DevelopmentPlans(LocalWebApplicationFactory factory)
             : base(factory, "/admin/catalogue-solutions/manage/99999-002/development-plans")
         {
-            ClearRoadMap(new CatalogueItemId(99999, "003"));
+            ClearRoadMap(new CatalogueItemId(99999, "002"));
             AuthorityLogin();
         }
 
@@ -35,7 +34,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution
         [Fact]
         public async Task DevelopmentPlans_EnterRoadMapLinkAsync()
         {
-            var link = TextGenerators.UrlInputAddText(CommonSelectors.Link, 1000);
+            var link = TextGenerators.UrlInputAddText(Objects.Common.CommonSelectors.LinkTextBox, 1000);
 
             CommonActions.ClickSave();
 
@@ -47,7 +46,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution
         [Fact]
         public async Task DevelopmentPlans_GoBackWithoutSaving()
         {
-            TextGenerators.UrlInputAddText(CommonSelectors.Link, 1000);
+            TextGenerators.UrlInputAddText(Objects.Common.CommonSelectors.LinkTextBox, 1000);
 
             AdminPages.CommonActions.ClickGoBack();
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Interoperability.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Interoperability.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution
+{
+    public sealed class Interoperability : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    {
+        private static readonly CatalogueItemId SolutionId = new(99999, "002");
+
+        private static readonly Dictionary<string, string> Parameters = new()
+        {
+            {
+                nameof(SolutionId), SolutionId.ToString()
+            },
+        };
+
+        public Interoperability(LocalWebApplicationFactory factory)
+            : base(factory, typeof(CatalogueSolutionsController), nameof(CatalogueSolutionsController.Interoperability), Parameters)
+        {
+        }
+
+        [Fact]
+        public async Task Interoperability_SaveLink()
+        {
+            var url = TextGenerators.UrlInputAddText(Objects.Common.CommonSelectors.LinkTextBox, 1000);
+
+            CommonActions.ClickSave();
+
+            CommonActions.PageLoadedCorrectGetIndex(
+                typeof(CatalogueSolutionsController),
+                nameof(CatalogueSolutionsController.ManageCatalogueSolution)).Should().BeTrue();
+
+            await using var context = GetEndToEndDbContext();
+            var solution = await context.Solutions.SingleAsync(s => s.Id == SolutionId);
+
+            solution.IntegrationsUrl.Should().Be(url);
+        }
+
+        [Fact]
+        public async Task Interoperability_GoBackDoesNotSave()
+        {
+            TextGenerators.UrlInputAddText(Objects.Common.CommonSelectors.LinkTextBox, 1000);
+
+            CommonActions.ClickGoBackLink();
+
+            CommonActions.PageLoadedCorrectGetIndex(
+                typeof(CatalogueSolutionsController),
+                nameof(CatalogueSolutionsController.ManageCatalogueSolution)).Should().BeTrue();
+
+            await using var context = GetEndToEndDbContext();
+            var solution = await context.Solutions.SingleAsync(s => s.Id == SolutionId);
+
+            solution.IntegrationsUrl.Should().BeNullOrWhiteSpace();
+        }
+
+        public void Dispose()
+        {
+            using var context = GetEndToEndDbContext();
+            var solution = context.Solutions.Single(s => s.Id == SolutionId);
+            solution.Integrations = null;
+            solution.IntegrationsUrl = null;
+            context.SaveChanges();
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/Dashboard/AboutSolution.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/Dashboard/AboutSolution.cs
@@ -23,7 +23,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Marketing.Dashboard
         {
             var summary = TextGenerators.TextInputAddText(CommonSelectors.Summary, 350);
             var description = TextGenerators.TextInputAddText(CommonSelectors.Description, 1100);
-            var link = TextGenerators.UrlInputAddText(CommonSelectors.Link, 1000);
+            var link = TextGenerators.UrlInputAddText(Objects.Common.CommonSelectors.LinkTextBox, 1000);
 
             CommonActions.ClickSave();
 
@@ -39,7 +39,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Marketing.Dashboard
         {
             TextGenerators.TextInputAddText(CommonSelectors.Summary, 350);
             TextGenerators.TextInputAddText(CommonSelectors.Description, 1100);
-            TextGenerators.UrlInputAddText(CommonSelectors.Link, 1000);
+            TextGenerators.UrlInputAddText(Objects.Common.CommonSelectors.LinkTextBox, 1000);
 
             CommonActions.ClickSave();
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/Dashboard/Integrations.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/Dashboard/Integrations.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
-using NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.Marketing;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
@@ -27,7 +26,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Marketing.Dashboard
         [Fact]
         public async Task Integrations_AddUrl()
         {
-            var link = TextGenerators.UrlInputAddText(CommonSelectors.Link, 1000);
+            var link = TextGenerators.UrlInputAddText(Objects.Common.CommonSelectors.LinkTextBox, 1000);
 
             CommonActions.ClickSave();
 
@@ -41,7 +40,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Marketing.Dashboard
         {
             Driver.Navigate().Refresh();
 
-            TextGenerators.UrlInputAddText(CommonSelectors.Link, 1000);
+            TextGenerators.UrlInputAddText(Objects.Common.CommonSelectors.LinkTextBox, 1000);
             CommonActions.ClickSave();
 
             MarketingPages.DashboardActions.SectionMarkedComplete("Integrations").Should().BeTrue();

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/Dashboard/SupplierDetails.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Marketing/Dashboard/SupplierDetails.cs
@@ -29,7 +29,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Marketing.Dashboard
         public async Task SupplierDetails_EnterDescription()
         {
             var summary = TextGenerators.TextInputAddText(CommonSelectors.Description, 1000);
-            var link = TextGenerators.UrlInputAddText(CommonSelectors.Link, 1000);
+            var link = TextGenerators.UrlInputAddText(Objects.Common.CommonSelectors.LinkTextBox, 1000);
 
             CommonActions.ClickSave();
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Objects/Common/CommonSelectors.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Objects/Common/CommonSelectors.cs
@@ -17,5 +17,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.Common
         internal static By CheckboxItem => By.CssSelector(".nhsuk-checkboxes__item");
 
         internal static By NhsErrorSection => By.ClassName("nhsuk-error-summary");
+
+        internal static By LinkTextBox => By.Id("Link");
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Objects/Marketing/CommonSelectors.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Objects/Marketing/CommonSelectors.cs
@@ -4,8 +4,6 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.Marketing
 {
     internal static class CommonSelectors
     {
-        internal static By Link => By.Id("Link");
-
         internal static By Description => By.Id("Description");
 
         internal static By Summary => By.Id("Summary");

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/TestBases/AuthorityTestBase.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/TestBases/AuthorityTestBase.cs
@@ -1,4 +1,7 @@
-﻿namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases
+﻿using System;
+using System.Collections.Generic;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases
 {
     public abstract class AuthorityTestBase : TestBase
     {
@@ -9,5 +12,18 @@
         {
             AuthorityLogin();
         }
+
+        protected AuthorityTestBase(
+            LocalWebApplicationFactory factory,
+            Type controller,
+            string methodName,
+            IDictionary<string, string> parameters)
+            : base(
+                  factory,
+                  GenerateUrlFromMethod(controller, methodName, parameters))
+        {
+            AuthorityLogin();
+        }
+
     }
 }


### PR DESCRIPTION
Did a little tidy up and added an alternate constructor to the AuthorityTestBase to accept typeof controller and method to use Lee's excellent work in the ordering tests