### PR TITLE
Features/16187 validation link for radios and checkboxes

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Radios/RadioButtonBuilders.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Radios/RadioButtonBuilders.cs
@@ -28,6 +28,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Radios
             ModelExpression aspFor,
             IHtmlGenerator htmlGenerator,
             object item,
+            int index,
             string valueName,
             string displayName)
         {
@@ -35,8 +36,8 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Radios
 
             builder.AddCssClass(TagHelperConstants.RadioItemClass);
 
-            var input = GetRadioInputBuilder(viewcontext, aspFor, htmlGenerator, item, valueName);
-            var label = GetRadioLabelBuilder(viewcontext, aspFor, htmlGenerator, item, displayName, valueName);
+            var input = GetRadioInputBuilder(viewcontext, aspFor, htmlGenerator, item, valueName, index);
+            var label = GetRadioLabelBuilder(viewcontext, aspFor, htmlGenerator, item, displayName, index);
 
             builder.InnerHtml.AppendHtml(input);
             builder.InnerHtml.AppendHtml(label);
@@ -50,15 +51,13 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Radios
             IHtmlGenerator htmlGenerator,
             object item,
             string displayName,
-            string valueName)
+            int index)
         {
             var itemText = GetGenericValueFromName(item, displayName);
 
-            var itemValue = GetGenericValueFromName(item, valueName);
-
             return string.IsNullOrWhiteSpace(itemText)
                 ? null
-                : GetRadioLabelBuilder(viewContext, aspFor, htmlGenerator, itemText, itemValue);
+                : GetRadioLabelBuilder(viewContext, aspFor, htmlGenerator, itemText, index);
         }
 
         public static TagBuilder GetRadioLabelBuilder(
@@ -66,12 +65,12 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Radios
             ModelExpression aspFor,
             IHtmlGenerator htmlGenerator,
             string display,
-            string value)
+            int index)
         {
             return htmlGenerator.GenerateLabel(
                 viewContext,
                 aspFor.ModelExplorer,
-                $"{aspFor.Name}_{value}",
+                $"{aspFor.Name}_{index}",
                 display,
                 new { @class = TagHelperConstants.RadioLabelClass });
         }
@@ -81,13 +80,14 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Radios
                 ModelExpression aspFor,
                 IHtmlGenerator htmlGenerator,
                 object item,
-                string valueName)
+                string valueName,
+                int index)
         {
             var itemValue = GetGenericValueFromName(item, valueName);
 
             return string.IsNullOrWhiteSpace(itemValue)
                 ? null
-                : GetRadioInputBuilder(viewContext, aspFor, htmlGenerator, itemValue);
+                : GetRadioInputBuilder(viewContext, aspFor, htmlGenerator, itemValue, index);
         }
 
         public static TagBuilder GetRadioInputBuilder(
@@ -95,6 +95,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Radios
             ModelExpression aspFor,
             IHtmlGenerator htmlGenerator,
             string value,
+            int index,
             bool? isChecked = null)
         {
             var builder = htmlGenerator.GenerateRadioButton(
@@ -105,7 +106,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Radios
                             isChecked,
                             new { @class = TagHelperConstants.RadioItemInputClass });
 
-            builder.Attributes["id"] = TagBuilder.CreateSanitizedId($"{aspFor.Name}_{value}", "_");
+            builder.Attributes["id"] = TagBuilder.CreateSanitizedId($"{aspFor.Name}_{index}", "_");
 
             return builder;
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Radios/RadioButtonTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Radios/RadioButtonTagHelper.cs
@@ -11,6 +11,8 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Radios
     {
         public const string TagHelperName = "nhs-radio-button";
 
+        private const string IndexName = "index";
+
         private readonly IHtmlGenerator htmlGenerator;
 
         public RadioButtonTagHelper(IHtmlGenerator htmlGenerator) => this.htmlGenerator = htmlGenerator;
@@ -31,6 +33,9 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Radios
         [HtmlAttributeName(TagHelperConstants.DisplayName)]
         public string DisplayName { get; set; }
 
+        [HtmlAttributeName(IndexName)]
+        public int Index { get; set; }
+
         public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             output.TagName = TagHelperConstants.Div;
@@ -38,8 +43,8 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Radios
 
             output.Attributes.Add(new TagHelperAttribute(TagHelperConstants.Class, TagHelperConstants.RadioItemClass));
 
-            var input = RadioButtonBuilders.GetRadioInputBuilder(ViewContext, For, htmlGenerator, Value, ValueName);
-            var label = RadioButtonBuilders.GetRadioLabelBuilder(ViewContext, For, htmlGenerator, Value, DisplayName, ValueName);
+            var input = RadioButtonBuilders.GetRadioInputBuilder(ViewContext, For, htmlGenerator, Value, ValueName, Index);
+            var label = RadioButtonBuilders.GetRadioLabelBuilder(ViewContext, For, htmlGenerator, Value, DisplayName, Index);
 
             var childContent = await output.GetChildContentAsync();
 

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Radios/RadioButtonsTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Radios/RadioButtonsTagHelper.cs
@@ -51,6 +51,6 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
         }
 
         private IEnumerable<TagBuilder> BuildRadiosFromValueList() =>
-            Values.Select(value => RadioButtonBuilders.BuildRadioItem(ViewContext, For, htmlGenerator, value, ValueName, DisplayName));
+            Values.Select((value, index) => RadioButtonBuilders.BuildRadioItem(ViewContext, For, htmlGenerator, value, index, ValueName, DisplayName));
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Radios/YesNoRadioButtonTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Radios/YesNoRadioButtonTagHelper.cs
@@ -36,6 +36,8 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
             output.Content
                 .AppendHtml(yesRadio)
                 .AppendHtml(noRadio);
+
+            TagHelperFunctions.TellParentTagIfThisTagIsInError(ViewContext, context, For);
         }
 
         private TagBuilder BuildYesRadio(bool isChecked)
@@ -43,8 +45,8 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
             var yesBuilder = new TagBuilder(TagHelperConstants.Div);
             yesBuilder.AddCssClass(TagHelperConstants.RadioItemClass);
 
-            var input = RadioButtonBuilders.GetRadioInputBuilder(ViewContext, For, htmlGenerator, "Yes", isChecked);
-            var label = RadioButtonBuilders.GetRadioLabelBuilder(ViewContext, For, htmlGenerator, "Yes", "Yes");
+            var input = RadioButtonBuilders.GetRadioInputBuilder(ViewContext, For, htmlGenerator, "Yes", 0, isChecked);
+            var label = RadioButtonBuilders.GetRadioLabelBuilder(ViewContext, For, htmlGenerator, "Yes", 0);
 
             yesBuilder.InnerHtml
                 .AppendHtml(input)
@@ -58,8 +60,8 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
             var yesBuilder = new TagBuilder(TagHelperConstants.Div);
             yesBuilder.AddCssClass(TagHelperConstants.RadioItemClass);
 
-            var input = RadioButtonBuilders.GetRadioInputBuilder(ViewContext, For, htmlGenerator, "No", isChecked);
-            var label = RadioButtonBuilders.GetRadioLabelBuilder(ViewContext, For, htmlGenerator, "No", "No");
+            var input = RadioButtonBuilders.GetRadioInputBuilder(ViewContext, For, htmlGenerator, "No", 1, isChecked);
+            var label = RadioButtonBuilders.GetRadioLabelBuilder(ViewContext, For, htmlGenerator, "No", 1);
 
             yesBuilder.InnerHtml
                 .AppendHtml(input)

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/ValidationSummary/ValidationSummaryTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/ValidationSummary/ValidationSummaryTagHelper.cs
@@ -19,6 +19,8 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
         private const string NhsValidationSummary = "nhsuk-error-summary";
         private const string NhsValidationSummaryList = "nhsuk-error-summary__list";
 
+        private const string RadioIdName = "RadioId";
+
         private const string DefaultTitle = "There is a problem";
 
         [HtmlAttributeNotBound]
@@ -27,6 +29,9 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
 
         [HtmlAttributeName(TitleName)]
         public string Title { get; set; }
+
+        [HtmlAttributeName(RadioIdName)]
+        public string RadioId { get; set; }
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
@@ -61,12 +66,17 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
             attributes.ForEach(a => output.Attributes.Add(a));
         }
 
-        private static TagBuilder GetListItemBuilder(string linkElement, string errorMessage)
+        private TagBuilder GetListItemBuilder(string linkElement, string errorMessage)
         {
+            if (!string.IsNullOrWhiteSpace(RadioId) && linkElement == RadioId)
+                linkElement = $"{RadioId}_0";
+
+            var sanitizedLinkElement = TagBuilder.CreateSanitizedId(linkElement, "_");
+
             var listItemBuilder = new TagBuilder(TagHelperConstants.ListItem);
 
             var linkBuilder = new TagBuilder(TagHelperConstants.Anchor);
-            linkBuilder.Attributes.Add(TagHelperConstants.Link, $"#{linkElement}");
+            linkBuilder.Attributes.Add(TagHelperConstants.Link, $"#{sanitizedLinkElement}");
             linkBuilder.InnerHtml.Append(errorMessage);
             listItemBuilder.InnerHtml.AppendHtml(linkBuilder);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Validators/SupportedBrowsersModelValidator.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Validators/SupportedBrowsersModelValidator.cs
@@ -12,7 +12,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Validators
         {
             RuleFor(m => m.Browsers)
                 .Must(b => b.Any(c => c.Checked == true))
-                .WithMessage(MandatoryRequiredMessage);
+                .WithMessage(MandatoryRequiredMessage)
+                .OverridePropertyName("Browsers[0].Checked");
         }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/AddCatalogueSolution/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/AddCatalogueSolution/Index.cshtml
@@ -5,7 +5,7 @@
 }
 <partial name="Partials/_BackLink" model="Model"/>
 <div class="nhsuk-grid-row">
-    <nhs-validation-summary/>
+    <nhs-validation-summary RadioId="Frameworks[0].Selected"/>
 
     <div class="nhsuk-grid-column-two-thirds">
         <nhs-page-title title="Add a solution"
@@ -28,7 +28,7 @@
                     {
                         @if (Model.Frameworks[i].Name == "GP IT Futures Framework")
                         {
-                            <nhs-checkbox asp-for="@Model.Frameworks[i].Selected"
+                            <nhs-checkbox asp-for="Frameworks[i].Selected"
                                           label-text="@Model.Frameworks[i].Name"
                                           hidden-input="@Model.Frameworks[i].FrameworkId"
                                           data-test-id="framework-names">

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/AddApplicationType.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/AddApplicationType.cshtml
@@ -9,7 +9,7 @@
         <partial name="Partials/_BackLink" model="Model" />
         <div class="nhsuk-grid-row">
             <div class="nhsuk-grid-column-two-thirds">
-                <nhs-validation-summary />
+                <nhs-validation-summary RadioId="SelectedApplicationType"/>
                 <nhs-page-title title="Add an application type"
                                 advice="@(anyApplicationTypes ? "Select an application type that supports your Catalogue Solution. You can add other options later." : "All application types already added.")" />
                 <form method="post">
@@ -19,7 +19,7 @@
                     {
                         <div class="nhsuk-form-group">
                             <nhs-fieldset-form-label asp-for="@Model">
-                                <nhs-radio-buttons asp-for="@Model.SelectedApplicationType"
+                                <nhs-radio-buttons asp-for="SelectedApplicationType"
                                                    values="@Model.ApplicationTypesToAddRadioItems"
                                                    value-name="Value"
                                                    display-name="Text" />

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/AddHostingType.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/AddHostingType.cshtml
@@ -8,7 +8,7 @@
 <partial name="Partials/_BackLink" model="Model" />
 <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-        <nhs-validation-summary />
+        <nhs-validation-summary RadioId="SelectedHostingType"/>
                 <nhs-page-title title="Add a hosting type"
                                 advice="@(anyHostingTypes ? "Select a hosting type that supports your Catalogue Solution. You can add other options later." : "All hosting types already added.")" />
         <form method="post">
@@ -18,7 +18,7 @@
             {
                 <div class="nhsuk-form-group">
                     <nhs-fieldset-form-label asp-for="@Model">
-                        <nhs-radio-buttons asp-for="@Model.SelectedHostingType"
+                        <nhs-radio-buttons asp-for="SelectedHostingType"
                                            values="@Model.HostingTypesToAddRadioItems"
                                            value-name="Value"
                                            display-name="Text" />

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/PlugInsOrExtensions.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/PlugInsOrExtensions.cshtml
@@ -9,7 +9,7 @@
             <partial name="Partials/_BackLink" model="Model" />
         </div>
         <div class="nhsuk-grid-column-full">
-            <nhs-validation-summary />
+            <nhs-validation-summary RadioId="PlugInsRequired"/>
             <nhs-page-title title="Browser-based application – plug-ins or extensions required"
                             advice="Let buyers know if any plug-ins or extensions are needed to use your Catalogue Solution." />
             <form method="post">
@@ -18,7 +18,7 @@
                 <nhs-fieldset-form-label asp-for="@Model"
                                          label-text="Plug-ins or extensions required"
                                          label-hint="Does a device using your Catalogue Solution require plug-ins or extensions that customise its browsers or software to function?">
-                    <nhs-yesno-radio-buttons asp-for="@Model.PlugInsRequired" />
+                    <nhs-yesno-radio-buttons asp-for="PlugInsRequired" />
                 </nhs-fieldset-form-label>
                 <nhs-textarea asp-for="AdditionalInformation"
                               label-text="Additional information (optional)"

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/SupportedBrowsers.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/SupportedBrowsers.cshtml
@@ -9,7 +9,7 @@
             <partial name="Partials/_BackLink" model="Model" />
         </div>
         <div class="nhsuk-grid-column-full">
-            <nhs-validation-summary />
+            <nhs-validation-summary RadioId="MobileResponsive"/>
             <nhs-page-title title="Browser-based application – supported browsers"
                             advice="Let buyers know which types of browser will work with your Catalogue Solution." />
             <form method="post">

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Organisations/AddAnOrganisation.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Organisations/AddAnOrganisation.cshtml
@@ -18,7 +18,7 @@
                     asp-for="@Model"
                     label-text="Which organisation are you looking for?"
                     label-hint="Select one option.">
-                    <nhs-radio-buttons asp-for="@Model.SelectedOrganisation"
+                    <nhs-radio-buttons asp-for="SelectedOrganisation"
                                        values="@Model.AvailableOrganisations"
                                        value-name="@nameof(Organisation.Id)"
                                        display-name="@nameof(Organisation.Name)" />

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Marketing/Views/BrowserBased/MobileFirstApproach.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Marketing/Views/BrowserBased/MobileFirstApproach.cshtml
@@ -6,7 +6,7 @@
 <partial name="Partials/_BackLink" model="Model" />
 <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-        <nhs-validation-summary />
+        <nhs-validation-summary RadioId="MobileFirstApproach"/>
         <nhs-page-title title="@ViewData["Title"]"
                         advice="Let buyers know about the design concepts of your Catalogue Solution." />
         <form method="post">
@@ -15,7 +15,7 @@
             <nhs-fieldset-form-label asp-for="@Model"
                                      label-text="Mobile first approach"
                                      label-hint="Is your Catalogue Solution designed with a mobile first approach?">
-                <nhs-yesno-radio-buttons asp-for="@Model.MobileFirstApproach" />
+                <nhs-yesno-radio-buttons asp-for="MobileFirstApproach" />
             </nhs-fieldset-form-label>
             <nhs-submit-button />
         </form>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Marketing/Views/BrowserBased/PlugInsOrExtensions.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Marketing/Views/BrowserBased/PlugInsOrExtensions.cshtml
@@ -6,7 +6,7 @@
 <partial name="Partials/_BackLink" model="Model" />
 <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-        <nhs-validation-summary />
+        <nhs-validation-summary RadioId="AdditionalInformation"/>
         <nhs-page-title title="@ViewData["Title"]"
                         advice="Let buyers know if any plug-ins or extensions are needed to use your Catalogue Solution." />
         <form method="post">

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Marketing/Views/BrowserBased/SupportedBrowsers.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Marketing/Views/BrowserBased/SupportedBrowsers.cshtml
@@ -6,7 +6,7 @@
 <partial name="Partials/_BackLink" model="Model" />
 <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-        <nhs-validation-summary />
+        <nhs-validation-summary RadioId="MobileResponsive"/>
         <nhs-page-title title="@ViewData["Title"]"
                         advice="Let buyers know which types of browser will work with your Catalogue Solution." />
         <form method="post">

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Marketing/Views/NativeMobile/MobileFirstApproach.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Marketing/Views/NativeMobile/MobileFirstApproach.cshtml
@@ -6,7 +6,7 @@
 <partial name="Partials/_BackLink" model="Model" />
 <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-        <nhs-validation-summary />
+        <nhs-validation-summary RadioId="MobileFirstApproach"/>
         <nhs-page-title title="@ViewData["Title"]"
                         advice="Let buyers know about the design concepts of your Catalogue Solution." />
         <form method="post">

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/AssociatedServicesController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/AssociatedServicesController.cs
@@ -182,7 +182,12 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
                 ModelState.AddModelError("OrderItem.Price", "Price cannot be greater than list price");
 
             if (state.CataloguePrice.ProvisioningType == ProvisioningType.OnDemand)
+            {
                 state.EstimationPeriod = model.EstimationPeriod;
+
+                if (model.EstimationPeriod is null)
+                    ModelState.AddModelError(nameof(model.EstimationPeriod), "Estimation period is required");
+            }
 
             if (!ModelState.IsValid)
             {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/AdditionalServices/SelectAdditionalService.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/AdditionalServices/SelectAdditionalService.cshtml
@@ -7,7 +7,7 @@
     <partial name="Partials/_BackLink" model="Model" />
     <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
-            <nhs-validation-summary />
+            <nhs-validation-summary RadioId="SelectedAdditionalServiceId"/>
             <nhs-page-title title="@Model.Title" advice="These are the Additional Services for the Catalogue Solutions you've added to this order. Select the one you want to purchase from the list." />
 
             <form method="post">

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/AdditionalServices/SelectAdditionalServicePrice.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/AdditionalServices/SelectAdditionalServicePrice.cshtml
@@ -8,7 +8,7 @@
 
     <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
-            <nhs-validation-summary />
+            <nhs-validation-summary RadioId="SelectedPrice"/>
             <nhs-page-title title="@Model.Title"
                             advice="Select the list price for this Additional Service. If you’ve agreed a different price with the supplier, the values can be altered later." />
 
@@ -19,7 +19,7 @@
                 <input type="hidden" asp-for="@Model.Title" />
                 <nhs-fieldset-form-label asp-for="@Model"
                                          label-text="Select list price">
-                    <nhs-radio-buttons asp-for="@Model.SelectedPrice"
+                    <nhs-radio-buttons asp-for="SelectedPrice"
                                        values="@Model.Prices"
                                        value-name="CataloguePriceId"
                                        display-name="Description" />

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/AdditionalServices/SelectFlatOnDemandQuantity.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/AdditionalServices/SelectFlatOnDemandQuantity.cshtml
@@ -6,7 +6,7 @@
 <div data-test-id="order-item-provisiontype-page">
     <partial name="Partials/_BackLink" model="Model" />
     <div class="nhsuk-grid-row">
-        <nhs-validation-summary />
+        <nhs-validation-summary RadioId="EstimationPeriod"/>
         <nhs-page-title title="Quantity of @Model.SolutionName for @Model.CallOffId"
                         advice="Enter the quantity you think you'll need and over what period" />
         <div class="nhsuk-grid-column-full">
@@ -23,7 +23,7 @@
                 <nhs-fieldset-form-label asp-for="@Model"
                                          label-text="Which organisation are you looking for?"
                                          label-hint="Select one option.">
-                    <nhs-radio-buttons asp-for="@Model.EstimationPeriod"
+                    <nhs-radio-buttons asp-for="EstimationPeriod"
                                        values="@Model.TimeUnits.Cast<object>()"
                                        value-name="EnumMemberName"
                                        display-name="Description" />

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/AssociatedServices/EditAssociatedService.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/AssociatedServices/EditAssociatedService.cshtml
@@ -10,7 +10,7 @@
     <partial name="Partials/_BackLink" model="Model" />
     <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
-            <nhs-validation-summary />
+            <nhs-validation-summary RadioId="EstimationPeriod"/>
             <nhs-page-title title="@Model.Title"
                             advice="Provide the price you've agreed with the supplier and the quantity you want to order." />
         </div>
@@ -40,7 +40,7 @@
                                     <nhs-fieldset-form-label asp-for="@Model"
                                                              label-text="Over what period did you estimate the quantity?"
                                                              label-hint="Select one option.">
-                                        <nhs-radio-buttons asp-for="@Model.EstimationPeriod"
+                                        <nhs-radio-buttons asp-for="EstimationPeriod"
                                                            values="@Model.TimeUnits.Cast<object>()"
                                                            value-name="EnumMemberName"
                                                            display-name="Description" />

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/AssociatedServices/SelectAssociatedService.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/AssociatedServices/SelectAssociatedService.cshtml
@@ -7,7 +7,7 @@
     <partial name="Partials/_BackLink" model="Model" />
     <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
-            <nhs-validation-summary />
+            <nhs-validation-summary RadioId="SelectedSolutionId"/>
             <nhs-page-title title="@Model.Title" advice="These are the Associated Services provided by this supplier. Select the one you want to purchase from the list." />
             <form method="post">
                 <input type="hidden" asp-for="@Model.BackLink" />

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/AssociatedServices/SelectAssociatedServicePrice.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/AssociatedServices/SelectAssociatedServicePrice.cshtml
@@ -8,7 +8,7 @@
 
     <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
-            <nhs-validation-summary />
+            <nhs-validation-summary RadioId="SelectedPrice"/>
             <nhs-page-title title="@Model.Title"
                             advice="Select the list price for this Associated Service. If you’ve agreed a different price with the supplier, the values can be altered later." />
 
@@ -19,7 +19,7 @@
                 <input type="hidden" asp-for="@Model.Title" />
                 <nhs-fieldset-form-label asp-for="@Model"
                                          label-text="Select list price">
-                    <nhs-radio-buttons asp-for="@Model.SelectedPrice"
+                    <nhs-radio-buttons asp-for="SelectedPrice"
                                        values="@Model.Prices"
                                        value-name="CataloguePriceId"
                                        display-name="Description" />

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/CatalogueSolutions/SelectFlatOnDemandQuantity.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/CatalogueSolutions/SelectFlatOnDemandQuantity.cshtml
@@ -6,7 +6,7 @@
 <div data-test-id="order-item-provisiontype-page">
     <partial name="Partials/_BackLink" model="Model" />
     <div class="nhsuk-grid-row">
-        <nhs-validation-summary />
+        <nhs-validation-summary RadioId="EstimationPeriod"/>
         <nhs-page-title title="Quantity of @Model.SolutionName for @Model.CallOffId"
                         advice="Enter the quantity you think you'll need and over what period" />
         <div class="nhsuk-grid-column-full">
@@ -23,7 +23,7 @@
                 <nhs-fieldset-form-label asp-for="@Model"
                                          label-text="Over what period did you estimate the quantity?"
                                          label-hint="Select one option.">
-                    <nhs-radio-buttons asp-for="@Model.EstimationPeriod"
+                    <nhs-radio-buttons asp-for="EstimationPeriod"
                                        values="@Model.TimeUnits.Cast<object>()"
                                        value-name="EnumMemberName"
                                        display-name="Description" />

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/CatalogueSolutions/SelectSolution.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/CatalogueSolutions/SelectSolution.cshtml
@@ -9,7 +9,7 @@
 
     <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
-            <nhs-validation-summary />
+            <nhs-validation-summary RadioId="SelectedSolutionId"/>
             <nhs-page-title title="@Model.Title" advice="These are the Catalogue Solutions provided by the supplier you’ve chosen. Select the one you want to purchase from the list." />
 
             <form method="post">

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/CatalogueSolutions/SelectSolutionPrice.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/CatalogueSolutions/SelectSolutionPrice.cshtml
@@ -8,7 +8,7 @@
 
     <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
-            <nhs-validation-summary />
+            <nhs-validation-summary RadioId="SelectedPrice"/>
             <nhs-page-title title="@Model.Title"
                             advice="Select the list price for this Catalogue Solution. If you’ve agreed a different price with the supplier, the values can be altered later." />
 
@@ -19,7 +19,7 @@
                 <input type="hidden" asp-for="@Model.Title" />
                 <nhs-fieldset-form-label asp-for="@Model"
                                     label-text="Select list price">
-                    <nhs-radio-buttons asp-for="@Model.SelectedPrice"
+                    <nhs-radio-buttons asp-for="SelectedPrice"
                                         values="@Model.Prices"
                                         value-name="CataloguePriceId"
                                         display-name="Description" />

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/Dashboard/SelectOrganisation.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/Dashboard/SelectOrganisation.cshtml
@@ -7,6 +7,7 @@
     <partial name="Partials/_BackLink" model="Model" />
     <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
+            <nhs-validation-summary RadioId="SelectedOrganisation" />
             <nhs-page-title title="@Model.Title" advice="Select the organisation you want to act on behalf of." />
         </div>
         <div class="nhsuk-grid-column-full">
@@ -16,7 +17,11 @@
                 <input type="hidden" asp-for="@Model.OdsCode" />
                 <input type="hidden" asp-for="@Model.Title" />
                 <nhs-fieldset-form-label asp-for="@Model">
-                    <nhs-radio-buttons asp-for="@Model.SelectedOrganisation" values="@Model.AvailableOrganisations" value-name="OdsCode" display-name="Name" />
+                    <nhs-radio-buttons
+                        asp-for="SelectedOrganisation"
+                        values="@Model.AvailableOrganisations"
+                        value-name="OdsCode"
+                        display-name="Name" />
                 </nhs-fieldset-form-label>
                 <nhs-submit-button text="Continue" />
             </form>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/FundingSource/FundingSource.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/FundingSource/FundingSource.cshtml
@@ -6,7 +6,7 @@
 <partial name="Partials/_BackLink" model="Model" />
 <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-        <nhs-validation-summary />
+        <nhs-validation-summary RadioId="FundingSourceOnlyGms"/>
         <nhs-page-title title="@Model.Title" advice="Explain how you’re paying for this order" />
         <form method="post">
             <input type="hidden" asp-for="@Model.BackLink" />
@@ -15,7 +15,7 @@
             <input type="hidden" asp-for="@Model.Title" />
                         <nhs-fieldset-form-label asp-for="@Model"
                                            label-text="Are you paying for this order in full using your GP IT Futures centrally held funding allocation?">
-                            <nhs-yesno-radio-buttons asp-for="@Model.FundingSourceOnlyGms" />
+                            <nhs-yesno-radio-buttons asp-for="FundingSourceOnlyGms" />
                         </nhs-fieldset-form-label>
             <nhs-inset-text>
                 <p>Only answer ‘Yes’ if you’re using your central funding allocation to pay for the entire value of this order. It’ll then be centrally processed and paid for out of your allocation.</p>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/Supplier/SupplierSearchSelect.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/Supplier/SupplierSearchSelect.cshtml
@@ -13,7 +13,7 @@
                 <input type="hidden" asp-for="@Model.BackLinkText" />
                 <input type="hidden" asp-for="@Model.OdsCode" />
                 <input type="hidden" asp-for="@Model.Title" />
-                <nhs-validation-summary />
+                <nhs-validation-summary RadioId="SelectedSupplierId" />
                 <nhs-page-title title="@Model.Title" advice="These are the suppliers that match the search terms you provided. Select the one you're looking for." />
 
                 <nhs-fieldset-form-label asp-for="@Model"

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Validators/SupportedBrowsersModelValidatorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Validators/SupportedBrowsersModelValidatorTests.cs
@@ -18,7 +18,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Validators
 
             var result = validator.TestValidate(model);
 
-            result.ShouldHaveValidationErrorFor(m => m.Browsers)
+            result.ShouldHaveValidationErrorFor("Browsers[0].Checked")
                 .WithErrorMessage(SupportedBrowsersModelValidator.MandatoryRequiredMessage);
         }
 


### PR DESCRIPTION
Update Radio buttons to have their Id built using their index in the list, and not using their values for making their ID's unique

Update ValidationSummaryTagHelper to take in a RadioId from the referenced page, so if it sees that ID in the ModelState ErrorList, is can correctly Transform it to the correct Id

Update ValidationSummaryTagHelper to pass all the link Ids through an Id Sanitizer so it will match the Sanitized Ids on the components.

Update Certain validators to throw the errors on the first item in a list instead of the list itself (which is not referenced on the page)

Update Pages with Radio buttons to mark the name of the selected Field on the validation-summary so it can transform the link to a corrected version.

Update AssociatedServicesController to throw an error when an OnDemand price type doesn't have an estimation period selected.