### PR TITLE
Add Edit Solution and Existing Solution E2E Tests

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Models/CreateOrderItemModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Models/CreateOrderItemModel.cs
@@ -40,6 +40,8 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models
 
         public bool SkipPriceSelection { get; set; }
 
+        public bool HasHitEditSolution { get; set; }
+
         public string CurrencySymbol { get; set; }
 
         public string TimeUnitDescription

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Session/OrderSessionService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Session/OrderSessionService.cs
@@ -83,7 +83,11 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Session
             var state = GetOrderStateFromSession(callOffId);
 
             if (state is not null && state.IsNewSolution)
+            {
+                state.HasHitEditSolution = true;
+                SetOrderStateToSession(state);
                 return state;
+            }
 
             var orderItem = await orderItemService.GetOrderItem(callOffId, catalogueItemId);
 
@@ -140,7 +144,10 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Session
                 }
 
                 serviceRecipient.DeliveryDate ??= orderItem.DefaultDeliveryDate;
+                serviceRecipient.Quantity ??= state.Quantity;
             }
+
+            state.HasHitEditSolution = true;
 
             SetOrderStateToSession(state);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/CatalogueSolutionRecipientsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/CatalogueSolutionRecipientsController.cs
@@ -58,7 +58,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
 
             orderSessionService.SetOrderStateToSession(state);
 
-            if (!state.IsNewSolution)
+            if (state.HasHitEditSolution)
             {
                 return RedirectToAction(
                     nameof(CatalogueSolutionsController.EditSolution),

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Actions/Common/CommonActions.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Actions/Common/CommonActions.cs
@@ -53,6 +53,17 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Actions.Common
             return Driver.FindElements(targetField)[index].FindElement(By.TagName("label")).Text;
         }
 
+        internal void ClickCheckboxByLabel(string labelText)
+        {
+            var targetId =
+            Driver
+            .FindElements(By.ClassName("nhsuk-checkboxes__label"))
+            .FirstOrDefault(label => label.Text == labelText)
+            .GetAttribute("for");
+
+            Driver.FindElement(By.Id(targetId)).Click();
+        }
+
         internal void ClickRadioButtonWithValue(string value)
         {
             Driver.FindElements(CommonSelectors.RadioButtonItems)
@@ -142,6 +153,17 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Actions.Common
             Driver
             .FindElements(By.ClassName("nhsuk-checkboxes__input"))
             .Count(cb => cb.Selected);
+
+        internal bool CheckBoxSelectedByLabelText(string labelText)
+        {
+            var targetId =
+            Driver
+            .FindElements(By.ClassName("nhsuk-checkboxes__label"))
+            .FirstOrDefault(label => label.Text == labelText)
+            .GetAttribute("for");
+
+            return Driver.FindElement(By.Id(targetId)).Selected;
+        }
 
         internal bool AllCheckBoxesSelected() =>
             Driver

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/DeleteSolution/CatalogueSolutionsDeleteSolution.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/DeleteSolution/CatalogueSolutionsDeleteSolution.cs
@@ -1,0 +1,101 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers;
+using OpenQA.Selenium;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.CatalogueSolutions.DeleteSolution
+{
+    public sealed class CatalogueSolutionsDeleteSolution
+        : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IAsyncLifetime
+    {
+        private static readonly CallOffId CallOffId = new(90006, 1);
+        private static readonly string OdsCode = "03F";
+        private static readonly CatalogueItemId CatalogueItemId = new(99998, "002");
+        private static readonly string CatalogueItemName = "E2E With Contact With Single Price";
+
+        private static readonly Dictionary<string, string> Parameters =
+            new()
+            {
+                { nameof(OdsCode), OdsCode },
+                { nameof(CallOffId), CallOffId.ToString() },
+                { nameof(CatalogueItemId), CatalogueItemId.ToString() },
+                { nameof(CatalogueItemName), CatalogueItemName },
+            };
+
+        public CatalogueSolutionsDeleteSolution(
+            LocalWebApplicationFactory factory)
+            : base(
+                  factory,
+                  typeof(CatalogueSolutionsController),
+                  nameof(CatalogueSolutionsController.SelectSolution),
+                  Parameters)
+        {
+        }
+
+        [Fact]
+        public void CatalogueSolutionsDeleteSolution_AllSectionsDisplayed()
+        {
+            CommonActions.SaveButtonDisplayed().Should().BeTrue();
+
+            CommonActions.ElementIsDisplayed(
+                Objects.Ordering.CatalogueSolutions.CatalogueSolutionsDeleteSolutionCancelLink).Should().BeTrue();
+        }
+
+        [Fact]
+        public void CatalogueSolutionsDeleteSolution_CancelDelete_ExpectedResult()
+        {
+            CommonActions.ClickLinkElement(Objects.Ordering.CatalogueSolutions.CatalogueSolutionsDeleteSolutionCancelLink);
+
+            CommonActions.PageLoadedCorrectGetIndex(
+                typeof(CatalogueSolutionsController),
+                nameof(CatalogueSolutionsController.EditSolution))
+                .Should()
+                .BeTrue();
+        }
+
+        [Fact]
+        public void CatalogueSolutionsDeleteSolution_DeleteSolution_ExpectedResult()
+        {
+            CommonActions.ClickSave();
+
+            CommonActions.PageLoadedCorrectGetIndex(
+                typeof(CatalogueSolutionsController),
+                nameof(CatalogueSolutionsController.Index))
+                .Should()
+                .BeTrue();
+
+            CommonActions.ElementIsDisplayed(By.LinkText(CatalogueItemName)).Should().BeFalse();
+
+            Driver
+                .FindElements(Objects.Ordering.CatalogueSolutions.CatalogueSolutionsAnySolutionRow)
+                .Any()
+                .Should()
+                .BeFalse();
+        }
+
+        public Task InitializeAsync()
+        {
+            InitializeSessionHandler();
+
+            InitializeMemoryCacheHander(OdsCode);
+
+            NavigateToUrl(
+                typeof(DeleteCatalogueSolutionController),
+                nameof(DeleteCatalogueSolutionController.DeleteSolution),
+                Parameters);
+
+            return Task.CompletedTask;
+        }
+
+        public Task DisposeAsync()
+        {
+            return DisposeSession();
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/EditRecipients/CatalogueSolutionsEditRecipients.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/EditRecipients/CatalogueSolutionsEditRecipients.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers;
+using OpenQA.Selenium;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.CatalogueSolutions.EditRecipients
+{
+    public sealed class CatalogueSolutionsEditRecipients
+        : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IAsyncLifetime
+    {
+        private static readonly CallOffId CallOffId = new(90006, 01);
+        private static readonly string OdsCode = "03F";
+        private static readonly CatalogueItemId CatalogueItemId = new(99998, "002");
+        private static readonly string CatalogueItemName = "E2E With Contact Multiple Prices";
+
+        private static readonly Dictionary<string, string> Parameters =
+        new()
+        {
+            { nameof(OdsCode), OdsCode },
+            { nameof(CallOffId), CallOffId.ToString() },
+        };
+
+        public CatalogueSolutionsEditRecipients(
+            LocalWebApplicationFactory factory)
+            : base(
+                  factory,
+                  typeof(CatalogueSolutionsController),
+                  nameof(CatalogueSolutionsController.SelectSolution),
+                  Parameters)
+        {
+        }
+
+        [Fact]
+        public void CatalogueSolutionsEditRecipients_AllSectionsDisplayed()
+        {
+            CommonActions.SaveButtonDisplayed().Should().BeTrue();
+
+            CommonActions
+                .ElementIsDisplayed(Objects.Ordering.CatalogueSolutions.CatalogueSolutionsRecipientsSelectAllButton)
+                .Should()
+                .BeTrue();
+
+            CommonActions
+                .ElementIsDisplayed(Objects.Ordering.CatalogueSolutions.CatalogueSolutionsRecipientsTable)
+                .Should()
+                .BeTrue();
+
+            var serviceRecipients = MemoryCache.GetServiceRecipients();
+
+            CommonActions.GetNumberOfCheckBoxesDisplayed().Should().Be(serviceRecipients.Count());
+
+            var model = Session.GetOrderStateFromSession(CallOffId.ToString());
+
+            var selectedRecipientName = model.ServiceRecipients.FirstOrDefault(sr => sr.Selected).Name;
+
+            CommonActions.CheckBoxSelectedByLabelText(selectedRecipientName).Should().BeTrue();
+        }
+
+        [Fact]
+        public void CatalogueSolutionsEditRecipients_DeselectAll_ThrowsError()
+        {
+            CommonActions.ClickFirstCheckbox();
+
+            CommonActions.ClickSave();
+
+            CommonActions.PageLoadedCorrectGetIndex(
+                typeof(CatalogueSolutionRecipientsController),
+                nameof(CatalogueSolutionRecipientsController.SelectSolutionServiceRecipients)).Should().BeTrue();
+
+            CommonActions.AllCheckBoxesSelected().Should().BeFalse();
+
+            CommonActions.GetNumberOfSelectedCheckBoxes().Should().Be(0);
+
+            CommonActions.ElementShowingCorrectErrorMessage(
+                Objects.Ordering.CatalogueSolutions.CatalogueSolutionsRecipientsErrorMessage,
+                "Error: Select a service recipient").Should().BeTrue();
+        }
+
+        [Fact]
+        public void CatalogueSolutionsEditRecipients_DeselectFirst_SelectAnother_ExpectedResult()
+        {
+            CommonActions.ClickFirstCheckbox();
+
+            CommonActions.ClickCheckboxByLabel("Test Service Recipient Two");
+
+            CommonActions.ClickSave();
+
+            CommonActions.PageLoadedCorrectGetIndex(
+                typeof(CatalogueSolutionsController),
+                nameof(CatalogueSolutionsController.EditSolution)).Should().BeTrue();
+
+            var numberOfRecipients =
+                Session
+                .GetOrderStateFromSession(CallOffId.ToString())
+                .ServiceRecipients
+                .Where(sr => sr.Selected)
+                .Count();
+
+            Driver
+            .FindElements(By.ClassName("nhsuk-input"))
+            .Count(input => input.GetAttribute("id").EndsWith("Quantity"))
+            .Should()
+            .Be(numberOfRecipients);
+
+            Driver
+            .FindElements(By.ClassName("nhsuk-input"))
+            .Where(input => input.GetAttribute("id").EndsWith("Quantity"))
+            .All(input => !string.IsNullOrWhiteSpace(input.GetAttribute("value")))
+            .Should()
+            .BeTrue();
+        }
+
+        [Fact]
+        public void CatalogueSolutionsEditRecipients_NoChange_ExpectedResult()
+        {
+            CommonActions.ClickSave();
+
+            CommonActions.PageLoadedCorrectGetIndex(
+                typeof(CatalogueSolutionsController),
+                nameof(CatalogueSolutionsController.EditSolution)).Should().BeTrue();
+
+            var numberOfRecipients =
+                Session
+                .GetOrderStateFromSession(CallOffId.ToString())
+                .ServiceRecipients
+                .Where(sr => sr.Selected)
+                .Count();
+
+            Driver
+            .FindElements(By.ClassName("nhsuk-input"))
+            .Count(input => input.GetAttribute("id").EndsWith("Quantity"))
+            .Should()
+            .Be(numberOfRecipients);
+        }
+
+        public Task InitializeAsync()
+        {
+            InitializeSessionHandler();
+
+            InitializeMemoryCacheHander(OdsCode);
+
+            using var context = GetEndToEndDbContext();
+            var price = context
+                .CataloguePrices
+                .Include(cp => cp.PricingUnit)
+                .SingleOrDefault(cp => cp.CataloguePriceId == 3);
+
+            var serviceRecipients = MemoryCache.GetServiceRecipients();
+
+            var model = new CreateOrderItemModel
+            {
+                CallOffId = CallOffId,
+                CatalogueItemId = CatalogueItemId,
+                CommencementDate = DateTime.UtcNow.AddDays(1),
+                CatalogueItemName = CatalogueItemName,
+                CataloguePrice = price,
+                ServiceRecipients = new List<OrderItemRecipientModel>(),
+                Quantity = 123,
+                EstimationPeriod = EntityFramework.Catalogue.Models.TimeUnit.PerMonth,
+                IsNewSolution = false,
+                HasHitEditSolution = true,
+                CurrencySymbol = "£",
+                AgreedPrice = 100,
+            };
+
+            foreach (var recipient in serviceRecipients)
+            {
+                model.ServiceRecipients
+                    .Add(new OrderItemRecipientModel
+                    {
+                        Name = recipient.Name,
+                        OdsCode = recipient.OrgId,
+                    });
+            }
+
+            model.ServiceRecipients[0].Selected = true;
+            model.ServiceRecipients[0].Quantity = 123;
+            model.ServiceRecipients[0].DeliveryDate = DateTime.UtcNow.AddDays(2);
+
+            Session.SetOrderStateToSessionAsync(model);
+
+            NavigateToUrl(
+                typeof(CatalogueSolutionRecipientsController),
+                nameof(CatalogueSolutionRecipientsController.SelectSolutionServiceRecipients),
+                Parameters);
+
+            return Task.CompletedTask;
+        }
+
+        public Task DisposeAsync()
+        {
+            return DisposeSession();
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/EditSolution/CatalogueSolutionsEditSolution.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/EditSolution/CatalogueSolutionsEditSolution.cs
@@ -66,6 +66,11 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.CatalogueSolutions.E
                 .BeTrue();
 
             CommonActions
+                .ElementIsDisplayed(Objects.Ordering.CatalogueSolutions.CatalogueSolutionsEditSolutionFirstQuantityInput)
+                .Should()
+                .BeTrue();
+
+            CommonActions
                 .ElementIsDisplayed(Objects.Ordering.CatalogueSolutions.CatalogueSolutionsEditSolutionFirstDateDayInput)
                 .Should()
                 .BeTrue();

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/Home/CatalogueSolutions.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/Home/CatalogueSolutions.cs
@@ -1,9 +1,13 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers;
+using OpenQA.Selenium;
 using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.CatalogueSolutions
@@ -11,7 +15,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.CatalogueSolutions
     public sealed class CatalogueSolutions
         : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
     {
-        private static readonly CallOffId CallOffId = new(90004, 1);
+        private static readonly CallOffId CallOffId = new(90006, 1);
 
         private static readonly Dictionary<string, string> Parameters =
             new() { { "OdsCode", "03F" }, { "CallOffId", CallOffId.ToString() } };
@@ -38,7 +42,12 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.CatalogueSolutions
         {
             CommonActions.ClickLinkElement(Objects.Ordering.CatalogueItems.AddItemButton("Catalogue Solution"));
 
-            CommonActions.PageLoadedCorrectGetIndex(typeof(CatalogueSolutionsController), nameof(CatalogueSolutionsController.SelectSolution)).Should().BeTrue();
+            CommonActions
+                .PageLoadedCorrectGetIndex(
+                typeof(CatalogueSolutionsController),
+                nameof(CatalogueSolutionsController.SelectSolution))
+                .Should()
+                .BeTrue();
         }
 
         [Fact]
@@ -46,7 +55,32 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.CatalogueSolutions
         {
             CommonActions.ClickLinkElement(Objects.Ordering.CatalogueItems.ContinueButton);
 
-            CommonActions.PageLoadedCorrectGetIndex(typeof(OrderController), nameof(OrderController.Order));
+            CommonActions.PageLoadedCorrectGetIndex(
+                typeof(OrderController),
+                nameof(OrderController.Order))
+                .Should()
+                .BeTrue();
+        }
+
+        [Fact]
+        public async Task CatalogueSolutions_ClickSolution_GoToEditPage()
+        {
+            using var context = GetEndToEndDbContext();
+
+            var catalogueItemName =
+                 await context.Orders
+                 .Include(o => o.OrderItems).ThenInclude(oi => oi.CatalogueItem)
+                 .Where(o => o.Id == CallOffId.Id)
+                 .Select(o => o.OrderItems[0].CatalogueItem.Name)
+                 .SingleAsync();
+
+            CommonActions.ClickLinkElement(By.LinkText(catalogueItemName));
+
+            CommonActions.PageLoadedCorrectGetIndex(
+                typeof(CatalogueSolutionsController),
+                nameof(CatalogueSolutionsController.EditSolution))
+                .Should()
+                .BeTrue();
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/SelectPrice/CatalogueSolutionSelectPrice.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/SelectPrice/CatalogueSolutionSelectPrice.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/SelectRecipients/CatalogueSolutionsSelectRecipients.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/SelectRecipients/CatalogueSolutionsSelectRecipients.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
-using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/SelectRecipients/CatalogueSolutionsSelectRecipientsDate.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/SelectRecipients/CatalogueSolutionsSelectRecipientsDate.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.Common;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
-using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/SelectRecipients/CatalogueSolutionsSelectRecipientsDateDeclarative.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/SelectRecipients/CatalogueSolutionsSelectRecipientsDateDeclarative.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
-using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/SelectRecipients/CatalogueSolutionsSelectRecipientsDateOnDemand.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/SelectRecipients/CatalogueSolutionsSelectRecipientsDateOnDemand.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
-using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/SelectSolution/CatalogueSolutionSelectSolution.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CatalogueSolutions/SelectSolution/CatalogueSolutionSelectSolution.cs
@@ -14,7 +14,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.CatalogueSolutions
     public sealed class CatalogueSolutionSelectSolution
         : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IAsyncLifetime
     {
-        private static readonly CallOffId CallOffId = new(90004, 01);
+        private static readonly CallOffId CallOffId = new(90006, 1);
 
         private static readonly Dictionary<string, string> Parameters =
             new() { { "OdsCode", "03F" }, { nameof(CallOffId), CallOffId.ToString() } };
@@ -91,16 +91,10 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.CatalogueSolutions
             CommonActions.ClickSave();
 
             CommonActions.PageLoadedCorrectGetIndex(
-                typeof(CatalogueSolutionRecipientsController),
-                nameof(CatalogueSolutionRecipientsController.SelectSolutionServiceRecipients)).Should().BeTrue();
-
-            CreateOrderItemModel cacheModel = Session.GetOrderStateFromSession(CallOffId.ToString());
-
-            cacheModel.CallOffId.Should().Be(CallOffId);
-            cacheModel.CatalogueItemId.Should().Be(expectedCatalogueItemId);
-            cacheModel.CatalogueItemName.Should().BeEquivalentTo(expectedCatalogueItemName);
-            cacheModel.SkipPriceSelection.Should().BeTrue();
-            cacheModel.AgreedPrice.Should().NotBeNull();
+                typeof(CatalogueSolutionsController),
+                nameof(CatalogueSolutionsController.EditSolution))
+                .Should()
+                .BeTrue();
         }
 
         public Task DisposeAsync()

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Objects/Ordering/CatalogueSolutions.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Objects/Ordering/CatalogueSolutions.cs
@@ -1,9 +1,12 @@
-﻿using OpenQA.Selenium;
+﻿using NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.Common;
+using OpenQA.Selenium;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.Ordering
 {
     public static class CatalogueSolutions
     {
+        public static By CatalogueSolutionsAnySolutionRow => By.ClassName("nhsuk-table__row");
+
         public static By SelectCatalogueSolutionErrorMessage => By.Id("select-solution-error");
 
         public static By SelectCatalogueSolutionPriceErrorMessage => By.Id("select-solution-price-error");
@@ -43,5 +46,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.Ordering
         public static By CatalogueSolutionsEditSolutionEditServiceRecipientsButton => By.ClassName("nhsuk-button--secondary");
 
         public static By CatalogueSolutionsEditSolutionDeleteSolutionLink => By.LinkText("Delete Catalogue Solution");
+
+        public static By CatalogueSolutionsDeleteSolutionCancelLink => By.LinkText("Cancel delete");
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
@@ -526,6 +526,27 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             new() { CapabilityId = 43, LastUpdated = DateTime.UtcNow, StatusId = 1 },
                         },
                     PublishedStatus = PublicationStatus.Published,
+                    CataloguePrices = new List<CataloguePrice>
+                    {
+                        new()
+                        {
+                            CataloguePriceId = 5,
+                            CatalogueItemId = new CatalogueItemId(99997, "001"),
+                            ProvisioningType = ProvisioningType.Patient,
+                            CataloguePriceType = CataloguePriceType.Flat,
+                            PricingUnit = new PricingUnit
+                            {
+                                Id = 5,
+                                Name = "Test Pricing Patient",
+                                TierName = "Test Tier",
+                                Description = "per test patient",
+                            },
+                            TimeUnit = TimeUnit.PerYear,
+                            CurrencyCode = "GBP",
+                            Price = 999.9999M,
+                            LastUpdated = DateTime.UtcNow,
+                        },
+                    },
                 },
                 new CatalogueItem
                 {

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
@@ -537,7 +537,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             PricingUnit = new PricingUnit
                             {
                                 Id = 5,
-                                Name = "Test Pricing Patient",
+                                Name = "Test Pricing Patient No Contact",
                                 TierName = "Test Tier",
                                 Description = "per test patient",
                             },

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/CatalogueSolutionRecipientsControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/CatalogueSolutionRecipientsControllerTests.cs
@@ -182,6 +182,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
         {
             serviceRecipients.First().Selected = true;
             state.IsNewSolution = false;
+            state.HasHitEditSolution = true;
 
             orderSessionServiceMock.Setup(s => s.GetOrderStateFromSession(state.CallOffId)).Returns(state);
 


### PR DESCRIPTION
Add Delete Solution Tests

Update Order Session State Model to have "HasHitEditSolution" to mark if we have been to the edit solution page. this is so that we can redirect correctly from the select recipients page to the correct target depending on where the logic journey came from.

Update InitialiseStateForEdit to set the above value when the Edit solution page is loaded.

Remove unneeded Usings.