### PR TITLE
Attempt to resolve flaky test

### DIFF
--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/CatalogueSolutions.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/CatalogueSolutions.cs
@@ -264,7 +264,9 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 
             CommonActions.ClickSave();
 
-            Driver.FindElements(CommonSelectors.BreadcrumbItem).Count.Should().Be(2);
+            Driver.Url.Should().Contain($"selectedframework={gpitFramework.Id}");
+
+            Wait.Until(driver => driver.FindElements(CommonSelectors.BreadcrumbItem)).Count.Should().Be(2);
         }
 
         [Fact]


### PR DESCRIPTION
This test seems to fail the most. The failure reason is on the assertion where it expects 2 breadcrumb elements but finds none. My presumption is that the test intermittently tries to assert before the page has finished loading. Unfortunately I can't accurately reproduce this test failure as it has only failed once locally.

I have added an assertion to confirm whether or not the page has actually loaded. On top of this I've wrapped the breadcrumb assertion in a Wait.