### PR TITLE
Add Suspended Solution Notice

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Solutions/SolutionsFilterService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Solutions/SolutionsFilterService.cs
@@ -56,7 +56,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Solutions
                 .Include(i => i.Supplier)
                 .Include(i => i.CatalogueItemCapabilities).ThenInclude(cic => cic.Capability)
                 .Where(i => i.CatalogueItemType == CatalogueItemType.Solution &&
-                    (i.PublishedStatus == PublicationStatus.Published || i.PublishedStatus == PublicationStatus.InRemediation));
+                    (i.PublishedStatus != PublicationStatus.Draft && i.PublishedStatus != PublicationStatus.Unpublished));
 
             if (!string.IsNullOrWhiteSpace(frameworkId) && frameworkId != AllSolutionsFrameworkKey)
                 query = query.Where(ci => ci.Solution.FrameworkSolutions.Any(fs => fs.FrameworkId == frameworkId));

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Controllers/SolutionsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Controllers/SolutionsController.cs
@@ -97,7 +97,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
             if (item is null)
                 return BadRequest($"No Catalogue Item found for Id: {solutionId}");
 
-            return View(new AssociatedServicesModel(item.Solution));
+            if (item.PublishedStatus == PublicationStatus.Suspended)
+                return RedirectToAction(nameof(Description), new { solutionId });
+
+            return View(new AssociatedServicesModel(item));
         }
 
         [HttpGet("{solutionId}/additional-services")]
@@ -106,6 +109,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
             var item = await solutionsService.GetSolutionWithAllAdditionalServices(solutionId);
             if (item is null)
                 return BadRequest($"No Catalogue Item found for Id: {solutionId}");
+
+            if (item.PublishedStatus == PublicationStatus.Suspended)
+                return RedirectToAction(nameof(Description), new { solutionId });
 
             return View(new AdditionalServicesModel(item));
         }
@@ -116,6 +122,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
             var item = await solutionsService.GetSolutionOverview(solutionId);
             if (item is null)
                 return BadRequest($"No Catalogue Item found for Id: {solutionId}");
+
+            if (item.PublishedStatus == PublicationStatus.Suspended)
+                return RedirectToAction(nameof(Description), new { solutionId });
 
             return View(new CapabilitiesViewModel(item));
         }
@@ -130,6 +139,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
             if (item is null)
                 return BadRequest($"No Catalogue Item found for Id: {solutionId}");
 
+            if (item.PublishedStatus == PublicationStatus.Suspended)
+                return RedirectToAction(nameof(Description), new { solutionId });
+
             return View(new CapabilitiesViewModel(item)
             {
                 Name = item.CatalogueItemName(additionalServiceId),
@@ -143,6 +155,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
             var item = await solutionsService.GetSolutionCapability(solutionId, capabilityId);
             if (item is null)
                 return BadRequest($"No Catalogue Item found for Id: {solutionId} with Capability Id: {capabilityId}");
+
+            if (item.PublishedStatus == PublicationStatus.Suspended)
+                return RedirectToAction(nameof(Description), new { solutionId });
 
             var solutionCapability = item.CatalogueItemCapability(capabilityId);
             var model = new SolutionCheckEpicsModel(solutionCapability);
@@ -163,6 +178,11 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
             if (item is null)
                 return BadRequest($"No Catalogue Item found for Id: {solutionId} with Capability Id: {capabilityId}");
 
+            var solution = await solutionsService.GetSolutionOverview(solutionId);
+
+            if (solution.PublishedStatus == PublicationStatus.Suspended)
+                return RedirectToAction(nameof(Description), new { solutionId });
+
             var solutionCapability = item.CatalogueItemCapability(capabilityId);
             var model = new SolutionCheckEpicsModel(solutionCapability);
 
@@ -179,7 +199,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
             if (item is null)
                 return BadRequest($"No Catalogue Item found for Id: {solutionId}");
 
-            var model = new ClientApplicationTypesModel(item.Solution);
+            if (item.PublishedStatus == PublicationStatus.Suspended)
+                return RedirectToAction(nameof(Description), new { solutionId });
+
+            var model = new ClientApplicationTypesModel(item);
 
             return View(model);
         }
@@ -191,7 +214,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
             if (item is null)
                 return BadRequest($"No Catalogue Item found for Id: {solutionId}");
 
-            return View(new SolutionDescriptionModel(item.Solution));
+            return View(new SolutionDescriptionModel(item));
         }
 
         [HttpGet("{solutionId}/features")]
@@ -200,6 +223,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
             var item = await solutionsService.GetSolutionOverview(solutionId);
             if (item is null)
                 return BadRequest($"No Catalogue Item found for Id: {solutionId}");
+
+            if (item.PublishedStatus == PublicationStatus.Suspended)
+                return RedirectToAction(nameof(Description), new { solutionId });
 
             return View(new SolutionFeaturesModel(item));
         }
@@ -211,6 +237,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
             if (item is null)
                 return BadRequest($"No Catalogue Item found for Id: {solutionId}");
 
+            if (item.PublishedStatus == PublicationStatus.Suspended)
+                return RedirectToAction(nameof(Description), new { solutionId });
+
             return View(new HostingTypesModel(item));
         }
 
@@ -220,6 +249,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
             var item = await solutionsService.GetSolutionOverview(solutionId);
             if (item is null)
                 return BadRequest($"No Catalogue Item found for Id: {solutionId}");
+
+            if (item.PublishedStatus == PublicationStatus.Suspended)
+                return RedirectToAction(nameof(Description), new { solutionId });
+
             return View(new ImplementationTimescalesModel(item));
         }
 
@@ -229,6 +262,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
             var item = await solutionsService.GetSolutionOverview(solutionId);
             if (item is null)
                 return BadRequest($"No Catalogue Item found for Id: {solutionId}");
+
+            if (item.PublishedStatus == PublicationStatus.Suspended)
+                return RedirectToAction(nameof(Description), new { solutionId });
+
             return View(new InteroperabilityModel(item));
         }
 
@@ -238,6 +275,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
             var item = await solutionsService.GetSolutionOverview(solutionId);
             if (item is null)
                 return BadRequest($"No Catalogue Item found for Id: {solutionId}");
+
+            if (item.PublishedStatus == PublicationStatus.Suspended)
+                return RedirectToAction(nameof(Description), new { solutionId });
+
             return View(new ListPriceModel(item));
         }
 
@@ -247,6 +288,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
             var item = await solutionsService.GetSolutionOverview(solutionId);
             if (item is null)
                 return BadRequest($"No Catalogue Item found for Id: {solutionId}");
+
+            if (item.PublishedStatus == PublicationStatus.Suspended)
+                return RedirectToAction(nameof(Description), new { solutionId });
 
             return View(new SolutionSupplierDetailsModel(item));
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/AdditionalServicesModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/AdditionalServicesModel.cs
@@ -6,10 +6,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
 {
     public sealed class AdditionalServicesModel : SolutionDisplayBaseModel
     {
-        public AdditionalServicesModel(CatalogueItem solution)
-            : base(solution.Solution)
+        public AdditionalServicesModel(CatalogueItem catalogueItem)
+            : base(catalogueItem)
         {
-            Services = solution.Supplier.CatalogueItems
+            Services = catalogueItem.Supplier.CatalogueItems
                 .Where(ci => ci.CatalogueItemType == CatalogueItemType.AdditionalService)
                 .OrderBy(ci => ci.Name)
                 .Select(ci => new AdditionalServiceModel(ci))

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/AssociatedServicesModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/AssociatedServicesModel.cs
@@ -6,11 +6,11 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
 {
     public sealed class AssociatedServicesModel : SolutionDisplayBaseModel
     {
-        public AssociatedServicesModel(Solution solution)
-            : base(solution)
+        public AssociatedServicesModel(CatalogueItem catalogueItem)
+            : base(catalogueItem)
         {
             // TODO: make use of new nav property on catalogue item once merged
-            Services = solution.CatalogueItem.Supplier.CatalogueItems
+            Services = catalogueItem.Supplier.CatalogueItems
                 .Where(c => c.CatalogueItemType == CatalogueItemType.AssociatedService)
                 .OrderBy(c => c.Name)
                 .Select(c => new AssociatedServiceModel(c.AssociatedService))

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/ClientApplicationTypesModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/ClientApplicationTypesModel.cs
@@ -13,8 +13,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
         private const string KeyNativeDesktop = "native-desktop";
         private const string KeyNativeMobile = "native-mobile";
 
-        public ClientApplicationTypesModel(Solution solution)
-            : base(solution)
+        public ClientApplicationTypesModel(CatalogueItem catalogueItem)
+            : base(catalogueItem)
         {
             BrowserBasedApplication = GetBrowserBasedApplication(ClientApplication);
             NativeDesktopApplication = GetNativeDesktopApplication(ClientApplication);

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/SolutionDescriptionModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/SolutionDescriptionModel.cs
@@ -11,16 +11,17 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
         {
         }
 
-        public SolutionDescriptionModel(Solution solution)
-            : base(solution)
+        public SolutionDescriptionModel(CatalogueItem catalogueItem)
+            : base(catalogueItem)
         {
+            var solution = catalogueItem.Solution;
+
             Description = solution.FullDescription;
             Summary = solution.Summary;
 
-            var item = solution.CatalogueItem;
-            Frameworks = item.Frameworks().ToArray();
-            IsFoundation = item.IsFoundation().ToYesNo();
-            SupplierName = item.Supplier.Name;
+            Frameworks = catalogueItem.Frameworks().ToArray();
+            IsFoundation = catalogueItem.IsFoundation().ToYesNo();
+            SupplierName = catalogueItem.Supplier.Name;
         }
 
         public string Description { get; init; }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/SolutionDisplayBaseModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/SolutionDisplayBaseModel.cs
@@ -119,21 +119,17 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
         {
         }
 
-        protected SolutionDisplayBaseModel(Solution solution)
-            : this(solution.CatalogueItem)
-        {
-            ClientApplication = solution.ClientApplication == null
-                ? new ClientApplication()
-                : JsonDeserializer.Deserialize<ClientApplication>(solution.ClientApplication);
-
-            LastReviewed = solution.LastUpdated;
-        }
-
         protected SolutionDisplayBaseModel(CatalogueItem catalogueItem)
         {
             SolutionId = catalogueItem.Id;
             SolutionName = catalogueItem.Name;
             PublicationStatus = catalogueItem.PublishedStatus;
+
+            ClientApplication = catalogueItem.Solution.ClientApplication == null
+                ? new ClientApplication()
+                : JsonDeserializer.Deserialize<ClientApplication>(catalogueItem.Solution.ClientApplication);
+
+            LastReviewed = catalogueItem.Solution.LastUpdated;
 
             SetVisibleSections(catalogueItem);
             SetPaginationFooter();
@@ -185,6 +181,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
         public void SetShowTrue(int index) => sections[index].Show = true;
 
         public bool IsInRemediation() => PublicationStatus == PublicationStatus.InRemediation;
+
+        public bool IsSuspended() => PublicationStatus == PublicationStatus.Suspended;
 
         private void SetVisibleSections(CatalogueItem solution)
         {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/Description.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/Description.cshtml
@@ -31,18 +31,26 @@
             </nhs-summary-list-row>
         </nhs-summary-list>
 
-        @if (Model.HasSummary())
+        @if (Model.IsSuspended())
         {
-            <h2>Summary</h2>
-
-            <p style="white-space: pre-line">@Model.Summary</p>
+            <p data-test-id="solution-suspended-notice">This Catalogue Solution has been suspended from the Buying Catalogue and is not available at this time.</p>
+            <p>The supplier did not satisfy an agreed remedial plan to meet outstanding compliance with required standards.</p>
         }
+        else 
+        { 
+            @if (Model.HasSummary())
+            {
+                <h2>Summary</h2>
 
-        @if (Model.HasDescription())
-        {
-            <h2>Full description</h2>
+                <p style="white-space: pre-line">@Model.Summary</p>
+            }
 
-            <p style="white-space: pre-line">@Model.Description</p>
+            @if (Model.HasDescription())
+            {
+                <h2>Full description</h2>
+
+                <p style="white-space: pre-line">@Model.Description</p>
+            }
         }
     </div>
 </article>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/Layouts/_SolutionsLayout.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/Layouts/_SolutionsLayout.cshtml
@@ -70,49 +70,53 @@
                     </div>
                 </div>
             }
-
-            <nav class="nhsuk-contents-list" role="navigation" aria-label="Pages in this guide">
-                <h2 class="nhsuk-u-visually-hidden">Contents</h2>
-                <ol class="nhsuk-contents-list__list">
-                    @foreach (var sectionModel in Model.GetSections())
-                    {
-                        @if (sectionModel.Selected)
+            @if (!Model.IsSuspended())
+            {
+                <nav class="nhsuk-contents-list" role="navigation" aria-label="Pages in this guide">
+                    <h2 class="nhsuk-u-visually-hidden">Contents</h2>
+                    <ol class="nhsuk-contents-list__list">
+                        @foreach (var sectionModel in Model.GetSections())
                         {
-                            <li class="nhsuk-contents-list__item" aria-current="page">
-                                <span class="nhsuk-contents-list__current">@sectionModel.Name</span>
-                            </li>
+                            @if (sectionModel.Selected)
+                            {
+                                <li class="nhsuk-contents-list__item" aria-current="page">
+                                    <span class="nhsuk-contents-list__current">@sectionModel.Name</span>
+                                </li>
+                            }
+                            else
+                            {
+                                <li class="nhsuk-contents-list__item">
+                                    <a asp-action="@sectionModel.Action"
+                                        asp-controller="@sectionModel.Controller"
+                                        asp-route-solutionId="@sectionModel.Id"
+                                        class="nhsuk-contents-list__link">
+                                        @sectionModel.Name
+                                    </a>
+                                </li>
+                            }
                         }
-                        else
-                        {
-                            <li class="nhsuk-contents-list__item">
-                                <a asp-action="@sectionModel.Action"
-                                    asp-controller="@sectionModel.Controller"
-                                    asp-route-solutionId="@sectionModel.Id"
-                                    class="nhsuk-contents-list__link">
-                                    @sectionModel.Name
-                                </a>
-                            </li>
-                        }
-                    }
-                </ol>
-            </nav>
+                    </ol>
+                </nav>
+            }
 
             @RenderBody()
 
             <nhs-endnote>
                 Solution information last reviewed: @Model.LastReviewed.ToLongDateString()
             </nhs-endnote>
-
-            <nhs-page-link-pagination next-url="@Url.Action(
-                        Model.PaginationFooter?.Next?.Action,
-                        Model.PaginationFooter?.Next?.Controller,
-                        new { solutionId = Model.PaginationFooter?.Next?.Id })"
-                        next-subtext="@Model.PaginationFooter?.Next?.Name"
-                        previous-url="@Url.Action(
-                        Model.PaginationFooter?.Previous?.Action,
-                        Model.PaginationFooter?.Previous?.Controller,
-                        new { solutionId = Model.PaginationFooter?.Previous?.Id })"
-                        previous-subtext="@Model.PaginationFooter?.Previous?.Name" />
+            @if (!Model.IsSuspended())
+            {
+                <nhs-page-link-pagination next-url="@Url.Action(
+                    Model.PaginationFooter?.Next?.Action,
+                    Model.PaginationFooter?.Next?.Controller,
+                    new { solutionId = Model.PaginationFooter?.Next?.Id })"
+                next-subtext="@Model.PaginationFooter?.Next?.Name"
+                previous-url="@Url.Action(
+                    Model.PaginationFooter?.Previous?.Action,
+                    Model.PaginationFooter?.Previous?.Controller,
+                    new { solutionId = Model.PaginationFooter?.Previous?.Id })"
+                previous-subtext="@Model.PaginationFooter?.Previous?.Name" />
+            }
         </main>
     </div>
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/AdditionalServiceEpics.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/AdditionalServiceEpics.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers;
@@ -13,7 +14,7 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class AdditionalServiceEpics : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>
+    public sealed class AdditionalServiceEpics : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
     {
         private static readonly int CapabilityId = 2;
 
@@ -55,6 +56,31 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 
             PublicBrowsePages.SolutionAction.GetNhsSolutionEpics().Should().BeEquivalentTo(epics.Where(e => !e.Epic.SupplierDefined).Select(e => e.Epic.Name));
             PublicBrowsePages.SolutionAction.GetSupplierSolutionEpics().Should().BeEquivalentTo(epics.Where(e => e.Epic.SupplierDefined).Select(e => e.Epic.Name));
+        }
+
+        [Fact]
+        public async Task AdditionalServiceEpics_SolutionIsSuspended_Redirect()
+        {
+            await using var context = GetEndToEndDbContext();
+            var solution = await context.CatalogueItems.SingleAsync(ci => ci.Id == SolutionId);
+            solution.PublishedStatus = PublicationStatus.Suspended;
+            await context.SaveChangesAsync();
+
+            Driver.Navigate().Refresh();
+
+            CommonActions
+                .PageLoadedCorrectGetIndex(
+                    typeof(SolutionsController),
+                    nameof(SolutionsController.Description))
+                .Should()
+                .BeTrue();
+        }
+
+        public void Dispose()
+        {
+            using var context = GetEndToEndDbContext();
+            context.CatalogueItems.Single(ci => ci.Id == SolutionId).PublishedStatus = PublicationStatus.Published;
+            context.SaveChanges();
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/AdditionalServicesCapabilities.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/AdditionalServicesCapabilities.cs
@@ -1,17 +1,19 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers;
 using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class AdditionalServicesCapabilities : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>
+    public sealed class AdditionalServicesCapabilities : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 
@@ -43,6 +45,31 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 
             capabilitiesNames.Should().HaveCount(dbCapabilities.Count);
             numberEpicLinks.Should().HaveCount(dbCapabilities.Count);
+        }
+
+        [Fact]
+        public async Task AdditionalServicesCapabilities_SolutionIsSuspended_Redirect()
+        {
+            await using var context = GetEndToEndDbContext();
+            var solution = await context.CatalogueItems.SingleAsync(ci => ci.Id == SolutionId);
+            solution.PublishedStatus = PublicationStatus.Suspended;
+            await context.SaveChangesAsync();
+
+            Driver.Navigate().Refresh();
+
+            CommonActions
+                .PageLoadedCorrectGetIndex(
+                    typeof(SolutionsController),
+                    nameof(SolutionsController.Description))
+                .Should()
+                .BeTrue();
+        }
+
+        public void Dispose()
+        {
+            using var context = GetEndToEndDbContext();
+            context.CatalogueItems.Single(ci => ci.Id == SolutionId).PublishedStatus = PublicationStatus.Published;
+            context.SaveChanges();
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/CapabilitiesDetails.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/CapabilitiesDetails.cs
@@ -1,17 +1,19 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers;
 using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class CapabilitiesDetails : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>
+    public sealed class CapabilitiesDetails : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 
@@ -78,6 +80,31 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
             var supplierEpicsInfo = (await context.CatalogueItems.Include(s => s.CatalogueItemEpics).ThenInclude(s => s.Epic).SingleAsync(s => s.Id == new CatalogueItemId(99999, "001"))).CatalogueItemEpics.Select(s => s.Epic);
 
             supplierEpicsList.Should().BeEquivalentTo(supplierEpicsInfo.Where(e => e.SupplierDefined).Select(c => c.Name));
+        }
+
+        [Fact]
+        public async Task CapabilitiesDetails_SolutionIsSuspended_Redirect()
+        {
+            await using var context = GetEndToEndDbContext();
+            var solution = await context.CatalogueItems.SingleAsync(ci => ci.Id == SolutionId);
+            solution.PublishedStatus = PublicationStatus.Suspended;
+            await context.SaveChangesAsync();
+
+            Driver.Navigate().Refresh();
+
+            CommonActions
+                .PageLoadedCorrectGetIndex(
+                    typeof(SolutionsController),
+                    nameof(SolutionsController.Description))
+                .Should()
+                .BeTrue();
+        }
+
+        public void Dispose()
+        {
+            using var context = GetEndToEndDbContext();
+            context.CatalogueItems.Single(ci => ci.Id == SolutionId).PublishedStatus = PublicationStatus.Published;
+            context.SaveChanges();
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/FeatureDetails.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/FeatureDetails.cs
@@ -1,17 +1,19 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers;
 using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class FeatureDetails : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>
+    public sealed class FeatureDetails : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 
@@ -41,6 +43,31 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
                 var dbList = featureInfo.Replace("[", string.Empty).Replace("\"", string.Empty).Replace("]", string.Empty).Split(',').ToList().Select(s => s.Trim());
                 featureList.Should().BeEquivalentTo(dbList);
             }
+        }
+
+        [Fact]
+        public async Task FeatureDetails_SolutionIsSuspended_Redirect()
+        {
+            await using var context = GetEndToEndDbContext();
+            var solution = await context.CatalogueItems.SingleAsync(ci => ci.Id == SolutionId);
+            solution.PublishedStatus = PublicationStatus.Suspended;
+            await context.SaveChangesAsync();
+
+            Driver.Navigate().Refresh();
+
+            CommonActions
+                .PageLoadedCorrectGetIndex(
+                    typeof(SolutionsController),
+                    nameof(SolutionsController.Description))
+                .Should()
+                .BeTrue();
+        }
+
+        public void Dispose()
+        {
+            using var context = GetEndToEndDbContext();
+            context.CatalogueItems.Single(ci => ci.Id == SolutionId).PublishedStatus = PublicationStatus.Published;
+            context.SaveChanges();
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/ImplementationDetails.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/ImplementationDetails.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers;
@@ -13,7 +14,7 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class ImplementationDetails : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>
+    public sealed class ImplementationDetails : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 
@@ -54,6 +55,31 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
             implementationContent
                 .Any(s => s.Contains(info, StringComparison.CurrentCultureIgnoreCase))
                 .Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task ImplementationDetails_SolutionIsSuspended_Redirect()
+        {
+            await using var context = GetEndToEndDbContext();
+            var solution = await context.CatalogueItems.SingleAsync(ci => ci.Id == SolutionId);
+            solution.PublishedStatus = PublicationStatus.Suspended;
+            await context.SaveChangesAsync();
+
+            Driver.Navigate().Refresh();
+
+            CommonActions
+                .PageLoadedCorrectGetIndex(
+                    typeof(SolutionsController),
+                    nameof(SolutionsController.Description))
+                .Should()
+                .BeTrue();
+        }
+
+        public void Dispose()
+        {
+            using var context = GetEndToEndDbContext();
+            context.CatalogueItems.Single(ci => ci.Id == SolutionId).PublishedStatus = PublicationStatus.Published;
+            context.SaveChanges();
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/ListPriceDetails.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/ListPriceDetails.cs
@@ -1,17 +1,19 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers;
 using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class ListPriceDetails : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>
+    public sealed class ListPriceDetails : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 
@@ -44,6 +46,31 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
             var dbPrices = await context.CataloguePrices.Where(s => s.CatalogueItemId == new CatalogueItemId(99999, "001")).ToListAsync();
 
             prices.Should().Contain(dbPrices.Select(s => s.Price.ToString()));
+        }
+
+        [Fact]
+        public async Task ListPriceDetails_SolutionIsSuspended_Redirect()
+        {
+            await using var context = GetEndToEndDbContext();
+            var solution = await context.CatalogueItems.SingleAsync(ci => ci.Id == SolutionId);
+            solution.PublishedStatus = PublicationStatus.Suspended;
+            await context.SaveChangesAsync();
+
+            Driver.Navigate().Refresh();
+
+            CommonActions
+                .PageLoadedCorrectGetIndex(
+                    typeof(SolutionsController),
+                    nameof(SolutionsController.Description))
+                .Should()
+                .BeTrue();
+        }
+
+        public void Dispose()
+        {
+            using var context = GetEndToEndDbContext();
+            context.CatalogueItems.Single(ci => ci.Id == SolutionId).PublishedStatus = PublicationStatus.Published;
+            context.SaveChanges();
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/SolutionDescription.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/SolutionDescription.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.Common;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
@@ -54,6 +55,51 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
                 .ElementExists(Objects.PublicBrowse.SolutionObjects.InRemediationNotice)
                 .Should()
                 .BeFalse();
+        }
+
+        [Fact]
+        public async Task Description_IsSuspended_SuspendedNoticeDisplayed()
+        {
+            await using var context = GetEndToEndDbContext();
+            var solution = await context.CatalogueItems.SingleAsync(ci => ci.Id == SolutionId);
+            solution.PublishedStatus = PublicationStatus.Suspended;
+            await context.SaveChangesAsync();
+
+            Driver.Navigate().Refresh();
+
+            CommonActions
+                .ElementExists(Objects.PublicBrowse.SolutionObjects.SolutionSuspendedNotice)
+                .Should()
+                .BeTrue();
+
+            CommonActions
+                .ElementExists(Objects.PublicBrowse.SolutionObjects.SolutionNavigationMenu)
+                .Should()
+                .BeFalse();
+
+            CommonActions
+                .ElementExists(CommonSelectors.PaginationNext)
+                .Should()
+                .BeFalse();
+        }
+
+        [Fact]
+        public void Description_NotSuspended_SuspendedNoticeNotDisplayed()
+        {
+            CommonActions
+                .ElementExists(Objects.PublicBrowse.SolutionObjects.SolutionSuspendedNotice)
+                .Should()
+                .BeFalse();
+
+            CommonActions
+                .ElementExists(Objects.PublicBrowse.SolutionObjects.SolutionNavigationMenu)
+                .Should()
+                .BeTrue();
+
+            CommonActions
+                .ElementExists(CommonSelectors.PaginationNext)
+                .Should()
+                .BeTrue();
         }
 
         public void Dispose()

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/SupplierDetails.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/SupplierDetails.cs
@@ -1,16 +1,19 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers;
 using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class SupplierDetails : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>
+    public sealed class SupplierDetails : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 
@@ -45,6 +48,31 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
             var supplierInfo = PublicBrowsePages.SolutionAction.GetSummaryAndDescriptions();
 
             supplierInfo.Should().Contain(info);
+        }
+
+        [Fact]
+        public async Task SupplierDetails_SolutionIsSuspended_Redirect()
+        {
+            await using var context = GetEndToEndDbContext();
+            var solution = await context.CatalogueItems.SingleAsync(ci => ci.Id == SolutionId);
+            solution.PublishedStatus = PublicationStatus.Suspended;
+            await context.SaveChangesAsync();
+
+            Driver.Navigate().Refresh();
+
+            CommonActions
+                .PageLoadedCorrectGetIndex(
+                    typeof(SolutionsController),
+                    nameof(SolutionsController.Description))
+                .Should()
+                .BeTrue();
+        }
+
+        public void Dispose()
+        {
+            using var context = GetEndToEndDbContext();
+            context.CatalogueItems.Single(ci => ci.Id == SolutionId).PublishedStatus = PublicationStatus.Published;
+            context.SaveChanges();
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Objects/PublicBrowse/SolutionObjects.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Objects/PublicBrowse/SolutionObjects.cs
@@ -46,5 +46,9 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.PublicBrowse
         internal static By CapabilityName => ByExtensions.DataTestId("capability-name");
 
         internal static By InRemediationNotice => By.ClassName("nhsuk-warning-callout");
+
+        internal static By SolutionSuspendedNotice => ByExtensions.DataTestId("solution-suspended-notice");
+
+        internal static By SolutionNavigationMenu => By.ClassName("nhsuk-contents-list");
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Solutions/Controllers/SolutionsControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Solutions/Controllers/SolutionsControllerTests.cs
@@ -190,20 +190,19 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Controllers
         [Theory]
         [CommonAutoData]
         public static async Task Get_AssociatedServices_ValidSolutionForId_ReturnsExpectedViewResult(
-            [Frozen] CatalogueItemId id,
-            [Frozen] ClientApplication clientApplication,
-            [Frozen] Solution solution,
             [Frozen] Mock<ISolutionsService> solutionsServiceMock,
+            CatalogueItemId id,
+            ClientApplication clientApplication,
+            CatalogueItem catalogueItem,
             SolutionsController controller)
         {
-            solution.ClientApplication = JsonSerializer.Serialize(clientApplication);
-            solution.CatalogueItem.Solution = solution;
+            catalogueItem.Solution.ClientApplication = JsonSerializer.Serialize(clientApplication);
 
             // TODO: add AutoFixture customization (exclude certain base properties)
-            var associatedServicesModel = new AssociatedServicesModel(solution);
+            var associatedServicesModel = new AssociatedServicesModel(catalogueItem);
 
             solutionsServiceMock.Setup(s => s.GetSolutionWithAllAssociatedServices(id))
-                .ReturnsAsync(solution.CatalogueItem);
+                .ReturnsAsync(catalogueItem);
 
             var actual = (await controller.AssociatedServices(id)).As<ViewResult>();
 
@@ -305,15 +304,14 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Controllers
         public static async Task Get_ClientApplicationTypes_ValidSolutionForId_ReturnsExpectedViewResult(
             CatalogueItemId id,
             [Frozen] ClientApplication clientApplication,
-            [Frozen] Solution solution,
+            [Frozen] CatalogueItem catalogueItem,
             [Frozen] Mock<ISolutionsService> solutionsService,
             SolutionsController controller)
         {
-            solution.ClientApplication = JsonSerializer.Serialize(clientApplication);
-            solution.CatalogueItem.Solution = solution;
+            catalogueItem.Solution.ClientApplication = JsonSerializer.Serialize(clientApplication);
 
-            var expectedModel = new ClientApplicationTypesModel(solution);
-            solutionsService.Setup(s => s.GetSolutionOverview(id)).ReturnsAsync(solution.CatalogueItem);
+            var expectedModel = new ClientApplicationTypesModel(catalogueItem);
+            solutionsService.Setup(s => s.GetSolutionOverview(id)).ReturnsAsync(catalogueItem);
 
             var actual = (await controller.ClientApplicationTypes(id)).As<ViewResult>();
 
@@ -474,10 +472,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Controllers
         public static async Task Get_Description_ValidSolutionForId_ReturnsExpectedViewResult(
             [Frozen] Mock<ISolutionsService> mockService,
             SolutionsController controller,
-            [Frozen] Solution solution,
             CatalogueItem catalogueItem)
         {
-            var solutionDescriptionModel = new SolutionDescriptionModel(solution);
+            var solutionDescriptionModel = new SolutionDescriptionModel(catalogueItem);
 
             mockService.Setup(s => s.GetSolutionOverview(catalogueItem.Id))
                 .ReturnsAsync(catalogueItem);
@@ -652,11 +649,13 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Controllers
         public static async Task Get_ListPrice_ValidId_GetsSolutionFromService(
             [Frozen] Mock<ISolutionsService> mockService,
             SolutionsController controller,
-            CatalogueItemId id)
+            CatalogueItem catalogueItem)
         {
-            await controller.ListPrice(id);
+            mockService.Setup(s => s.GetSolutionOverview(It.IsAny<CatalogueItemId>())).ReturnsAsync(catalogueItem);
 
-            mockService.Verify(s => s.GetSolutionOverview(id));
+            await controller.ListPrice(catalogueItem.Id);
+
+            mockService.Verify(s => s.GetSolutionOverview(catalogueItem.Id));
         }
 
         [Theory]

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Solutions/Models/AssociatedServicesModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Solutions/Models/AssociatedServicesModelTests.cs
@@ -21,13 +21,13 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Models
         [CommonAutoData]
         public static void HasServices_ValidServices_ReturnsTrue(
             [Frozen] AssociatedService service,
-            Solution solution)
+            CatalogueItem catalogueItem)
         {
             service.CatalogueItem.AssociatedService = service;
             service.CatalogueItem.CatalogueItemType = CatalogueItemType.AssociatedService;
-            solution.CatalogueItem.Supplier.CatalogueItems.Add(service.CatalogueItem);
+            catalogueItem.Supplier.CatalogueItems.Add(service.CatalogueItem);
 
-            var model = new AssociatedServicesModel(solution);
+            var model = new AssociatedServicesModel(catalogueItem);
 
             model.Services.Count.Should().BeGreaterThan(0);
             model.HasServices().Should().BeTrue();
@@ -35,11 +35,11 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Models
 
         [Theory]
         [CommonAutoData]
-        public static void HasServices_NoService_ReturnsFalse(Solution solution)
+        public static void HasServices_NoService_ReturnsFalse(CatalogueItem catalogueItem)
         {
-            solution.CatalogueItem.Supplier.CatalogueItems.Clear();
+            catalogueItem.Supplier.CatalogueItems.Clear();
 
-            var model = new AssociatedServicesModel(solution);
+            var model = new AssociatedServicesModel(catalogueItem);
 
             model.HasServices().Should().BeFalse();
         }


### PR DESCRIPTION
Add Suspended Solution Notice to Description Page and Hide the Menu/Pagination

Add Logic to all the Public Browse Solution Endpoints to redirect back to description if you attempt to go to them directly and the solution is suspended.

Update some of the Public Browse Models to no longer take in a Solution but to instead take in the CatalogueItem itself (was silly to have two paths)

Add E2E Tests