### PR TITLE
Add and edit additional services

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Catalogue/Configuration/CatalogueItemEntityTypeConfiguration.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Catalogue/Configuration/CatalogueItemEntityTypeConfiguration.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.ValueGenerators;
 
 namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Configuration
 {
@@ -15,7 +16,8 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Configuration
 
             builder.Property(i => i.Id)
                 .HasMaxLength(14)
-                .HasConversion(id => id.ToString(), id => CatalogueItemId.ParseExact(id));
+                .HasConversion(id => id.ToString(), id => CatalogueItemId.ParseExact(id))
+                .HasValueGenerator<CatalogueItemIdValueGenerator>();
 
             builder.Property(i => i.CatalogueItemType)
                 .HasConversion<int>()

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/CatalogueItemId.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/CatalogueItemId.cs
@@ -104,5 +104,17 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
 
             return new CatalogueItemId(SupplierId, $"S-{itemId + 1:D3}");
         }
+
+        public CatalogueItemId NextAdditionalServiceId()
+        {
+            var catalogueItemId = ItemId[..ItemId.IndexOf('-')];
+            var additionalServiceId = ItemId[(ItemId.IndexOf('A') + 1)..];
+
+            if (!int.TryParse(additionalServiceId, out var itemId))
+                throw new FormatException();
+
+            var newItemId = $"{catalogueItemId}-A{itemId + 1:D2}";
+            return new CatalogueItemId(SupplierId, newItemId);
+        }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/ValueGenerators/CatalogueItemIdValueGenerator.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/ValueGenerators/CatalogueItemIdValueGenerator.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+
+namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.ValueGenerators
+{
+    public sealed class CatalogueItemIdValueGenerator : ValueGenerator<CatalogueItemId>
+    {
+        public override bool GeneratesTemporaryValues => false;
+
+        public override CatalogueItemId Next(EntityEntry entry)
+            => NextAsync(entry).AsTask().GetAwaiter().GetResult();
+
+        public override async ValueTask<CatalogueItemId> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default)
+        {
+            if (entry.Entity is not CatalogueItem catalogueItem)
+                throw new ArgumentException($"Entity must be of type {typeof(CatalogueItem).Name}", nameof(entry));
+
+            if (catalogueItem.Id != default)
+                return catalogueItem.Id;
+
+            var latestCatalogueItem = await entry.Context.Set<CatalogueItem>()
+                .Where(i => i.CatalogueItemType == catalogueItem.CatalogueItemType && i.SupplierId == catalogueItem.SupplierId)
+                .OrderByDescending(i => i.Id)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            var incrementedCatalogueItemId = catalogueItem.CatalogueItemType switch
+            {
+                CatalogueItemType.AdditionalService => (latestCatalogueItem?.Id ?? new CatalogueItemId(latestCatalogueItem.SupplierId, $"{catalogueItem.Solution.CatalogueItemId.ItemId}-A00")).NextAdditionalServiceId(),
+                CatalogueItemType.AssociatedService => (latestCatalogueItem?.Id ?? new CatalogueItemId(latestCatalogueItem.SupplierId, "S-000")).NextAssociatedServiceId(),
+                CatalogueItemType.Solution or _ => (latestCatalogueItem?.Id ?? new CatalogueItemId(latestCatalogueItem.SupplierId, "000")).NextSolutionId(),
+            };
+
+            return incrementedCatalogueItemId;
+        }
+    }
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/AdditionalServices/IAdditionalServicesService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/AdditionalServices/IAdditionalServicesService.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models.AdditionalServices;
 
 namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.AdditionalServices
 {
@@ -12,5 +13,9 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.AdditionalServices
         Task<List<CatalogueItem>> GetAdditionalServicesBySolutionId(CatalogueItemId catalogueItemId);
 
         Task<List<CatalogueItem>> GetAdditionalServicesBySolutionIds(IEnumerable<CatalogueItemId> solutionIds);
+
+        Task<CatalogueItemId> AddAdditionalService(CatalogueItem solution, AdditionalServicesDetailsModel model);
+
+        Task EditAdditionalService(CatalogueItemId catalogueItemId, CatalogueItemId additionalServiceId, AdditionalServicesDetailsModel model);
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Models/AdditionalServices/AdditionalServicesDetailsModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Models/AdditionalServices/AdditionalServicesDetailsModel.cs
@@ -1,0 +1,11 @@
+﻿namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models.AdditionalServices
+{
+    public sealed class AdditionalServicesDetailsModel
+    {
+        public string Name { get; init; }
+
+        public string Description { get; init; }
+
+        public int UserId { get; init; }
+    }
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/AdditionalServices/AdditionalServicesService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/AdditionalServices/AdditionalServicesService.cs
@@ -7,6 +7,7 @@ using NHSD.GPIT.BuyingCatalogue.EntityFramework;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.AdditionalServices;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models.AdditionalServices;
 
 namespace NHSD.GPIT.BuyingCatalogue.Services.AdditionalServices
 {
@@ -17,6 +18,50 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.AdditionalServices
         public AdditionalServicesService(BuyingCatalogueDbContext dbContext)
         {
             this.dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        }
+
+        public async Task<CatalogueItemId> AddAdditionalService(CatalogueItem solution, AdditionalServicesDetailsModel model)
+        {
+            if (solution is null)
+                throw new ArgumentNullException(nameof(solution));
+
+            if (model is null)
+                throw new ArgumentNullException(nameof(model));
+
+            var additionalService = new CatalogueItem
+            {
+                Name = model.Name,
+                AdditionalService = new()
+                {
+                    FullDescription = model.Description,
+                    LastUpdated = DateTime.UtcNow,
+                    LastUpdatedBy = model.UserId,
+                    SolutionId = solution.Id,
+                },
+                CatalogueItemType = CatalogueItemType.AdditionalService,
+                SupplierId = solution.SupplierId,
+                PublishedStatus = PublicationStatus.Draft,
+            };
+
+            dbContext.Add(additionalService);
+            await dbContext.SaveChangesAsync();
+
+            return additionalService.Id;
+        }
+
+        public async Task EditAdditionalService(CatalogueItemId catalogueItemId, CatalogueItemId additionalServiceId, AdditionalServicesDetailsModel model)
+        {
+            if (model is null)
+                throw new ArgumentNullException(nameof(model));
+
+            var additionalService = await GetAdditionalService(catalogueItemId, additionalServiceId);
+
+            additionalService.Name = model.Name;
+            additionalService.AdditionalService.FullDescription = model.Description;
+            additionalService.AdditionalService.LastUpdated = DateTime.UtcNow;
+            additionalService.AdditionalService.LastUpdatedBy = model.UserId;
+
+            await dbContext.SaveChangesAsync();
         }
 
         public Task<CatalogueItem> GetAdditionalService(CatalogueItemId catalogueItemId, CatalogueItemId additionalServiceId)
@@ -43,6 +88,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.AdditionalServices
         private IQueryable<CatalogueItem> BaseQuery(CatalogueItemId catalogueItemId) => dbContext.CatalogueItems
                 .Include(i => i.AdditionalService)
                 .Include(i => i.CatalogueItemCapabilities)
+                .Include(i => i.Supplier)
                 .Where(i => i.AdditionalService.SolutionId == catalogueItemId && i.CatalogueItemType == CatalogueItemType.AdditionalService)
                 .OrderBy(i => i.Name);
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/AssociatedServices/AssociatedServicesService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/AssociatedServices/AssociatedServicesService.cs
@@ -14,14 +14,10 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.AssociatedServices
     public sealed class AssociatedServicesService : IAssociatedServicesService
     {
         private readonly BuyingCatalogueDbContext dbContext;
-        private readonly ICatalogueItemRepository catalogueItemRepository;
 
-        public AssociatedServicesService(
-            BuyingCatalogueDbContext dbContext,
-            ICatalogueItemRepository catalogueItemRepository)
+        public AssociatedServicesService(BuyingCatalogueDbContext dbContext)
         {
             this.dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
-            this.catalogueItemRepository = catalogueItemRepository ?? throw new ArgumentNullException(nameof(catalogueItemRepository));
         }
 
         public Task<List<CatalogueItem>> GetAssociatedServicesForSupplier(int? supplierId)
@@ -84,12 +80,8 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.AssociatedServices
             if (model is null)
                 throw new ArgumentNullException(nameof(model));
 
-            var latestAssociatedServiceCatalogueItemId = await catalogueItemRepository.GetLatestAssociatedServiceCatalogueItemIdFor(solution.SupplierId);
-            var catalogueItemId = latestAssociatedServiceCatalogueItemId.NextAssociatedServiceId();
-
             var associatedService = new CatalogueItem
             {
-                Id = catalogueItemId,
                 Name = model.Name,
                 AssociatedService = new AssociatedService
                 {
@@ -106,7 +98,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.AssociatedServices
             dbContext.Add(associatedService);
             await dbContext.SaveChangesAsync();
 
-            return catalogueItemId;
+            return associatedService.Id;
         }
 
         public async Task EditDetails(

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/CatalogueItemRepository.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/CatalogueItemRepository.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
-using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 
 namespace NHSD.GPIT.BuyingCatalogue.Services
 {
@@ -14,27 +13,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services
         {
         }
 
-        public async Task<CatalogueItemId> GetLatestCatalogueItemIdFor(int supplierId)
-        {
-            var catalogueSolution = await GetLatestCatalogueItem(supplierId, CatalogueItemType.Solution);
-
-            return catalogueSolution?.Id ?? new CatalogueItemId(supplierId, "000");
-        }
-
-        public async Task<CatalogueItemId> GetLatestAssociatedServiceCatalogueItemIdFor(int supplierId)
-        {
-            var associatedService = await GetLatestCatalogueItem(supplierId, CatalogueItemType.AssociatedService);
-
-            return associatedService?.Id ?? new CatalogueItemId(supplierId, "S-000");
-        }
-
         public Task<bool> SupplierHasSolutionName(int supplierId, string solutionName) =>
             DbSet.AnyAsync(i => i.SupplierId == supplierId && i.Name == solutionName);
-
-        private async Task<CatalogueItem> GetLatestCatalogueItem(int supplierId, CatalogueItemType catalogueItemType) =>
-            await DbSet
-                .Where(i => i.CatalogueItemType == catalogueItemType && i.SupplierId == supplierId)
-                .OrderByDescending(i => i.Id)
-                .FirstOrDefaultAsync();
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/ICatalogueItemRepository.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/ICatalogueItemRepository.cs
@@ -1,16 +1,11 @@
 ﻿using System.Threading.Tasks;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
-using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 
 namespace NHSD.GPIT.BuyingCatalogue.Services
 {
     public interface ICatalogueItemRepository : IDbRepository<CatalogueItem, BuyingCatalogueDbContext>
     {
-        Task<CatalogueItemId> GetLatestCatalogueItemIdFor(int supplierId);
-
-        Task<CatalogueItemId> GetLatestAssociatedServiceCatalogueItemIdFor(int supplierId);
-
         Task<bool> SupplierHasSolutionName(int supplierId, string solutionName);
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Solutions/SolutionsService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Solutions/SolutionsService.cs
@@ -370,9 +370,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Solutions
 
             model.Frameworks.ValidateNotNull(nameof(CreateSolutionModel.Frameworks));
 
-            var latestCatalogueItemId = await catalogueItemRepository.GetLatestCatalogueItemIdFor(model.SupplierId);
-            var catalogueItemId = latestCatalogueItemId.NextSolutionId();
-
             var dateTimeNow = DateTime.UtcNow;
 
             var frameworkSolutions = new List<FrameworkSolution>();
@@ -388,9 +385,8 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Solutions
                 });
             }
 
-            catalogueItemRepository.Add(new CatalogueItem
+            var catalogueItem = new CatalogueItem
             {
-                Id = catalogueItemId,
                 CatalogueItemType = CatalogueItemType.Solution,
                 Solution =
                         new Solution
@@ -402,11 +398,13 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Solutions
                 Name = model.Name,
                 PublishedStatus = PublicationStatus.Draft,
                 SupplierId = model.SupplierId,
-            });
+            };
+
+            catalogueItemRepository.Add(catalogueItem);
 
             await catalogueItemRepository.SaveChangesAsync();
 
-            return catalogueItemId;
+            return catalogueItem.Id;
         }
 
         public async Task<IList<EntityFramework.Catalogue.Models.Framework>> GetAllFrameworks()

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AdditionalServicesController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AdditionalServicesController.cs
@@ -3,7 +3,9 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.AdditionalServices;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models.AdditionalServices;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.AdditionalServices;
 
@@ -54,6 +56,88 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             };
 
             return View(model);
+        }
+
+        [HttpGet("add-additional-service")]
+        public async Task<IActionResult> AddAdditionalService(CatalogueItemId solutionId)
+        {
+            var solution = await solutionsService.GetSolution(solutionId);
+            if (solution is null)
+                return BadRequest($"No Solution found for Id: {solutionId}");
+
+            var model = new EditAdditionalServiceDetailsModel(solution)
+            {
+                BackLink = Url.Action(nameof(Index), new { solutionId }),
+            };
+
+            return View("EditAdditionalServiceDetails", model);
+        }
+
+        [HttpPost("add-additional-service")]
+        public async Task<IActionResult> AddAdditionalService(CatalogueItemId solutionId, EditAdditionalServiceDetailsModel model)
+        {
+            if (!ModelState.IsValid)
+                return View("EditAdditionalServiceDetails", model);
+
+            var solution = await solutionsService.GetSolution(solutionId);
+            if (solution is null)
+                return BadRequest($"No Solution found for Id: {solutionId}");
+
+            var additionalServiceDetailsModel = new AdditionalServicesDetailsModel
+            {
+                Name = model.Name,
+                Description = model.Description,
+                UserId = User.UserId(),
+            };
+
+            var additionalServiceId = await additionalServicesService.AddAdditionalService(solution, additionalServiceDetailsModel);
+
+            return RedirectToAction(nameof(EditAdditionalService), new { solutionId, additionalServiceId });
+        }
+
+        [HttpGet("{additionalServiceId}/edit-additional-service-details")]
+        public async Task<IActionResult> EditAdditionalServiceDetails(CatalogueItemId solutionId, CatalogueItemId additionalServiceId)
+        {
+            var solution = await solutionsService.GetSolution(solutionId);
+            if (solution is null)
+                return BadRequest($"No Solution found for Id: {solutionId}");
+
+            var additionalService = await additionalServicesService.GetAdditionalService(solutionId, additionalServiceId);
+            if (additionalService is null)
+                return BadRequest($"No Additional Service with Id {additionalServiceId} found for Solution {solutionId}");
+
+            var model = new EditAdditionalServiceDetailsModel(solution, additionalService)
+            {
+                BackLink = Url.Action(nameof(EditAdditionalService), new { solutionId, additionalServiceId }),
+            };
+
+            return View(model);
+        }
+
+        [HttpPost("{additionalServiceId}/edit-additional-service-details")]
+        public async Task<IActionResult> EditAdditionalServiceDetails(CatalogueItemId solutionId, CatalogueItemId additionalServiceId, EditAdditionalServiceDetailsModel model)
+        {
+            if (!ModelState.IsValid)
+                return View(model);
+
+            var solution = await solutionsService.GetSolution(solutionId);
+            if (solution is null)
+                return BadRequest($"No Solution found for Id: {solutionId}");
+
+            var additionalService = await additionalServicesService.GetAdditionalService(solutionId, additionalServiceId);
+            if (additionalService is null)
+                return BadRequest($"No Additional Service with Id {additionalServiceId} found for Solution {solutionId}");
+
+            var additionalServiceDetailsModel = new AdditionalServicesDetailsModel
+            {
+                Name = model.Name,
+                Description = model.Description,
+                UserId = User.UserId(),
+            };
+
+            await additionalServicesService.EditAdditionalService(solutionId, additionalServiceId, additionalServiceDetailsModel);
+
+            return RedirectToAction(nameof(EditAdditionalService), new { solutionId, additionalServiceId });
         }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AdditionalServices/EditAdditionalServiceDetailsModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AdditionalServices/EditAdditionalServiceDetailsModel.cs
@@ -1,0 +1,45 @@
+﻿using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Models;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.AdditionalServices
+{
+    public sealed class EditAdditionalServiceDetailsModel : NavBaseModel
+    {
+        public EditAdditionalServiceDetailsModel()
+        {
+            BackLinkText = "Go back";
+        }
+
+        public EditAdditionalServiceDetailsModel(CatalogueItem catalogueItem)
+            : this()
+        {
+            Title = "Additional service details";
+            SupplierId = catalogueItem.Supplier.Id;
+            SupplierName = catalogueItem.Supplier.Name;
+        }
+
+        public EditAdditionalServiceDetailsModel(CatalogueItem catalogueItem, CatalogueItem additionalServiceCatalogueItem)
+            : this()
+        {
+            Title = $"{Name} details";
+            Id = additionalServiceCatalogueItem.Id;
+            Name = additionalServiceCatalogueItem.Name;
+            Description = additionalServiceCatalogueItem.AdditionalService.FullDescription;
+            SupplierId = catalogueItem.Supplier.Id;
+            SupplierName = catalogueItem.Supplier.Name;
+        }
+
+        public string Title { get; init; }
+
+        public int SupplierId { get; init; }
+
+        public string SupplierName { get; init; }
+
+        public CatalogueItemId? Id { get; init; }
+
+        public string Name { get; init; }
+
+        public string Description { get; init; }
+    }
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Validators/EditAdditionalServiceDetailsModelValidator.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Validators/EditAdditionalServiceDetailsModelValidator.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentValidation;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Suppliers;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.AdditionalServices;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Validators
+{
+    public sealed class EditAdditionalServiceDetailsModelValidator : AbstractValidator<EditAdditionalServiceDetailsModel>
+    {
+        private readonly ISuppliersService suppliersService;
+
+        public EditAdditionalServiceDetailsModelValidator(ISuppliersService suppliersService)
+        {
+            this.suppliersService = suppliersService;
+
+            RuleFor(m => m)
+                .MustAsync(NotBeADuplicateService)
+                .WithMessage("Additional Service name already exists. Enter a different name")
+                .OverridePropertyName(m => m.Name);
+
+            RuleFor(m => m.Name)
+                .NotEmpty()
+                .WithMessage("Enter an Additional Service name");
+
+            RuleFor(m => m.Description)
+                .NotEmpty()
+                .WithMessage("Enter an Additional Service description");
+        }
+
+        private async Task<bool> NotBeADuplicateService(EditAdditionalServiceDetailsModel model, CancellationToken cancellationToken)
+        {
+            var allSolutions = await suppliersService.GetAllSolutionsForSupplier(model.SupplierId);
+
+            return model.Id is not null
+                ? allSolutions.All(s => s.Id != model.Id && !string.Equals(s.Name, model.Name, StringComparison.CurrentCultureIgnoreCase))
+                : allSolutions.All(s => !string.Equals(s.Name, model.Name, StringComparison.CurrentCultureIgnoreCase));
+        }
+    }
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/AdditionalServices/EditAdditionalService.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/AdditionalServices/EditAdditionalService.cshtml
@@ -1,4 +1,6 @@
-﻿@model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.AdditionalServices.EditAdditionalServiceModel;
+﻿@using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers;
+@using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
+@model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.AdditionalServices.EditAdditionalServiceModel;
 @{
     ViewBag.Title = $"{Model.AdditionalService.Name} information";
 }
@@ -19,7 +21,12 @@
                 <nhs-table-cell>Yes</nhs-table-cell>
                 <nhs-table-cell><nhs-tag status-enum="@Model.DetailsStatus()" /></nhs-table-cell>
                 <nhs-table-cell>
-                    <a href="#">Edit</a>
+                    <a asp-controller="@typeof(AdditionalServicesController).ControllerName()"
+                       asp-action="@nameof(AdditionalServicesController.EditAdditionalServiceDetails)"
+                       asp-route-solutionId="@Model.Solution.Id"
+                       asp-route-additionalServiceId="@Model.AdditionalService.Id">
+                        Edit
+                    </a>
                 </nhs-table-cell>
             </nhs-table-row-container>
             <nhs-table-row-container>
@@ -46,6 +53,5 @@
         <br />
 
         <vc:nhs-delete-button url="#" text="Delete Associated Service" />
-
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/AdditionalServices/EditAdditionalServiceDetails.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/AdditionalServices/EditAdditionalServiceDetails.cshtml
@@ -1,0 +1,33 @@
+﻿@model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.AdditionalServices.EditAdditionalServiceDetailsModel;
+@{
+    ViewBag.Title = Model.Title;
+}
+
+<partial name="Partials/_BackLink" model="Model" />
+<div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+        <nhs-validation-summary />
+        <nhs-page-title title="@ViewBag.Title"
+                        caption="@Model.SupplierName"
+                        advice="Provide details about the Additional Service." />
+
+        <form method="post">
+            <input type="hidden" asp-for="Id" />
+            <input type="hidden" asp-for="Title" />
+            <input type="hidden" asp-for="BackLink" />
+            <input type="hidden" asp-for="SupplierId" />
+            <input type="hidden" asp-for="SupplierName" />
+
+            <nhs-input asp-for="Name"
+                       label-text="Additional Service name"
+                       character-count="true"
+                       max-character-length="300" />
+            <nhs-textarea asp-for="Description"
+                          label-text="Additional Service description"
+                          label-hint="Describe the extra functionality provided by the Additional Service."
+                          character-count="true"
+                          maxlength="1000" />
+            <nhs-submit-button text="Save and continue" />
+        </form>
+    </div>
+</div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/AdditionalServices/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/AdditionalServices/Index.cshtml
@@ -11,7 +11,10 @@
                         caption="@Model.ItemName"
                         advice="Add any services that provide extra functionality to your Catalogue Solution." />
 
-        <vc:nhs-action-link url="#" text=" Add an Additional Service" />
+        <vc:nhs-action-link url="@Url.Action(
+            nameof(AdditionalServicesController.AddAdditionalService),
+            typeof(AdditionalServicesController).ControllerName(),
+            new { solutionId = Model.ItemId })" text=" Add an Additional Service" />
 
         <p>
             Use the link to add information on each of the Additional Services available with your Catalogue Solution.

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Solutions/SolutionsServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Solutions/SolutionsServiceTests.cs
@@ -358,22 +358,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Solutions
 
         [Theory]
         [CommonAutoData]
-        public static async Task AddCatalogueSolution_ModelValid_GetsLatestCatalogueItemId(
-            CreateSolutionModel model,
-            [Frozen] Mock<ICatalogueItemRepository> catalogueItemRepositoryMock,
-            SolutionsService service)
-        {
-            catalogueItemRepositoryMock
-                .Setup(c => c.GetLatestCatalogueItemIdFor(model.SupplierId))
-                .ReturnsAsync(new CatalogueItemId(model.SupplierId, "045"));
-
-            await service.AddCatalogueSolution(model);
-
-            catalogueItemRepositoryMock.Verify(c => c.GetLatestCatalogueItemIdFor(model.SupplierId));
-        }
-
-        [Theory]
-        [CommonAutoData]
         public static async Task AddCatalogueSolution_ModelValid_AddsCatalogueItemToRepository(
             CreateSolutionModel model,
             [Frozen] Mock<ICatalogueItemRepository> catalogueItemRepositoryMock,
@@ -381,17 +365,12 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Solutions
         {
             var catalogueItemId = new CatalogueItemId(model.SupplierId, "045");
 
-            catalogueItemRepositoryMock
-                .Setup(c => c.GetLatestCatalogueItemIdFor(model.SupplierId))
-                .ReturnsAsync(catalogueItemId);
-
             await service.AddCatalogueSolution(model);
 
             catalogueItemRepositoryMock.Verify(
                 repository => repository.Add(
                     It.Is<CatalogueItem>(
                         c =>
-                            c.Id == catalogueItemId.NextSolutionId() &&
                             c.CatalogueItemType == CatalogueItemType.Solution &&
                             c.Solution.LastUpdated > DateTime.UtcNow.AddMinutes(-2) &&
                             c.Solution.LastUpdatedBy == model.UserId &&

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/AdditionalServicesControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/AdditionalServicesControllerTests.cs
@@ -32,7 +32,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
 
         [Theory]
         [CommonAutoData]
-        public static async Task Index_WithInvalidSolutionId_ReturnsBadRequestObjectResult(
+        public static async Task Get_Index_WithInvalidSolutionId_ReturnsBadRequestObjectResult(
             CatalogueItemId catalogueItemId,
             [Frozen] Mock<ISolutionsService> solutionsService,
             AdditionalServicesController controller)
@@ -48,7 +48,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
 
         [Theory]
         [CommonAutoData]
-        public static async Task Index_WithValidSolutionId_ReturnsModel(
+        public static async Task Get_Index_WithValidSolutionId_ReturnsModel(
             CatalogueItem catalogueItem,
             List<CatalogueItem> additionalServices,
             [Frozen] Mock<ISolutionsService> solutionsService,
@@ -71,7 +71,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
 
         [Theory]
         [CommonAutoData]
-        public static async Task EditAdditionalService_InvalidSolutionId_ReturnsBadRequestObjectResult(
+        public static async Task Get_EditAdditionalService_InvalidSolutionId_ReturnsBadRequestObjectResult(
             CatalogueItemId catalogueItemId,
             CatalogueItemId additionalServiceId,
             [Frozen] Mock<ISolutionsService> solutionsService,
@@ -88,7 +88,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
 
         [Theory]
         [CommonAutoData]
-        public static async Task EditAdditionalService_InvalidAdditionalServiceId_ReturnsBadRequestObjectResult(
+        public static async Task Get_EditAdditionalService_InvalidAdditionalServiceId_ReturnsBadRequestObjectResult(
             CatalogueItemId catalogueItemId,
             CatalogueItemId additionalServiceId,
             [Frozen] Mock<IAdditionalServicesService> additionalServicesService,
@@ -105,7 +105,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
 
         [Theory]
         [CommonAutoData]
-        public static async Task EditAdditionalService_WithValidIds_ReturnsModel(
+        public static async Task Get_EditAdditionalService_WithValidIds_ReturnsModel(
             CatalogueItem catalogueItem,
             CatalogueItem additionalService,
             [Frozen] Mock<ISolutionsService> solutionsService,
@@ -124,6 +124,220 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
 
             result.As<ViewResult>().Should().NotBeNull();
             result.As<ViewResult>().Model.Should().BeEquivalentTo(expectedResult, opt => opt.Excluding(model => model.BackLink));
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Get_AddAdditionalService_InvalidId_ReturnsBadRequestObjectResult(
+            CatalogueItemId catalogueItemId,
+            [Frozen] Mock<ISolutionsService> mockSolutionsService,
+            AdditionalServicesController controller)
+        {
+            mockSolutionsService.Setup(s => s.GetSolution(catalogueItemId))
+                .ReturnsAsync(default(CatalogueItem));
+
+            var result = await controller.AddAdditionalService(catalogueItemId);
+
+            result.As<BadRequestObjectResult>().Should().NotBeNull();
+            result.As<BadRequestObjectResult>().Value.Should().Be($"No Solution found for Id: {catalogueItemId}");
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Get_AddAdditionalService_ValidId_ReturnsModel(
+            CatalogueItem catalogueItem,
+            [Frozen] Mock<ISolutionsService> solutionsService,
+            AdditionalServicesController controller)
+        {
+            var expectedModel = new EditAdditionalServiceDetailsModel(catalogueItem);
+
+            solutionsService.Setup(s => s.GetSolution(catalogueItem.Id))
+                .ReturnsAsync(catalogueItem);
+
+            var result = await controller.AddAdditionalService(catalogueItem.Id);
+
+            result.As<ViewResult>().Should().NotBeNull();
+            result.As<ViewResult>().Model.Should().BeEquivalentTo(expectedModel, opt => opt.Excluding(model => model.BackLink));
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Post_AddAdditionalService_InvalidModel_ReturnsViewWithModel(
+            CatalogueItemId catalogueItemId,
+            EditAdditionalServiceDetailsModel model,
+            AdditionalServicesController controller)
+        {
+            controller.ModelState.AddModelError("some-key", "some-error");
+
+            var result = await controller.AddAdditionalService(catalogueItemId, model);
+
+            result.As<ViewResult>().Should().NotBeNull();
+            result.As<ViewResult>().Model.Should().BeEquivalentTo(model, opt => opt.Excluding(m => m.BackLink));
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Post_AddAdditionalService_InvalidId_ReturnsBadRequestObjectResult(
+            CatalogueItemId catalogueItemId,
+            EditAdditionalServiceDetailsModel model,
+            [Frozen] Mock<ISolutionsService> solutionsService,
+            AdditionalServicesController controller)
+        {
+            solutionsService.Setup(s => s.GetSolution(catalogueItemId))
+                .ReturnsAsync(default(CatalogueItem));
+
+            var result = await controller.AddAdditionalService(catalogueItemId, model);
+
+            result.As<BadRequestObjectResult>().Should().NotBeNull();
+            result.As<BadRequestObjectResult>().Value.Should().Be($"No Solution found for Id: {catalogueItemId}");
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Post_AddAdditionalService_ValidId_RedirectsToEditAdditionalService(
+            CatalogueItem catalogueItem,
+            EditAdditionalServiceDetailsModel model,
+            [Frozen] Mock<ISolutionsService> solutionsService,
+            AdditionalServicesController controller)
+        {
+            solutionsService.Setup(s => s.GetSolution(catalogueItem.Id))
+                .ReturnsAsync(catalogueItem);
+
+            var result = await controller.AddAdditionalService(catalogueItem.Id, model);
+
+            result.As<RedirectToActionResult>().Should().NotBeNull();
+            result.As<RedirectToActionResult>().ActionName.Should().Be(nameof(AdditionalServicesController.EditAdditionalService));
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Get_EditAdditionalServiceDetails_InvalidCatalogueItemId_ReturnsBadRequestObjectResult(
+            CatalogueItemId catalogueItemId,
+            CatalogueItemId additionalServiceId,
+            [Frozen] Mock<ISolutionsService> solutionsService,
+            AdditionalServicesController controller)
+        {
+            solutionsService.Setup(s => s.GetSolution(catalogueItemId))
+                .ReturnsAsync(default(CatalogueItem));
+
+            var result = await controller.EditAdditionalServiceDetails(catalogueItemId, additionalServiceId);
+
+            result.As<BadRequestObjectResult>().Should().NotBeNull();
+            result.As<BadRequestObjectResult>().Value.Should().Be($"No Solution found for Id: {catalogueItemId}");
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Get_EditAdditionalServiceDetails_InvalidAdditionalServiceId_ReturnsBadRequestObjectResult(
+            CatalogueItemId catalogueItemId,
+            CatalogueItemId additionalServiceId,
+            [Frozen] Mock<IAdditionalServicesService> additionalServicesService,
+            AdditionalServicesController controller)
+        {
+            additionalServicesService.Setup(s => s.GetAdditionalService(catalogueItemId, additionalServiceId))
+                .ReturnsAsync(default(CatalogueItem));
+
+            var result = await controller.EditAdditionalServiceDetails(catalogueItemId, additionalServiceId);
+
+            result.As<BadRequestObjectResult>().Should().NotBeNull();
+            result.As<BadRequestObjectResult>().Value.Should().Be($"No Additional Service with Id {additionalServiceId} found for Solution {catalogueItemId}");
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Get_EditAdditionalServiceDetails_ValidIds_ReturnsModel(
+            CatalogueItem catalogueItem,
+            CatalogueItem additionalService,
+            [Frozen] Mock<ISolutionsService> solutionsService,
+            [Frozen] Mock<IAdditionalServicesService> additionalServicesService,
+            AdditionalServicesController controller)
+        {
+            var expectedModel = new EditAdditionalServiceDetailsModel(catalogueItem, additionalService);
+
+            solutionsService.Setup(s => s.GetSolution(catalogueItem.Id))
+                .ReturnsAsync(catalogueItem);
+
+            additionalServicesService.Setup(s => s.GetAdditionalService(catalogueItem.Id, additionalService.Id))
+                .ReturnsAsync(additionalService);
+
+            var result = await controller.EditAdditionalServiceDetails(catalogueItem.Id, additionalService.Id);
+
+            result.As<ViewResult>().Should().NotBeNull();
+            result.As<ViewResult>().Model.Should().BeEquivalentTo(expectedModel, opt => opt.Excluding(m => m.BackLink));
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Post_EditAdditionalServiceDetails_InvalidModel_ReturnsViewWithModel(
+            CatalogueItemId catalogueItemId,
+            CatalogueItemId additionalServiceId,
+            EditAdditionalServiceDetailsModel model,
+            AdditionalServicesController controller)
+        {
+            controller.ModelState.AddModelError("some-key", "some-error");
+
+            var result = await controller.EditAdditionalServiceDetails(catalogueItemId, additionalServiceId, model);
+
+            result.As<ViewResult>().Should().NotBeNull();
+            result.As<ViewResult>().Model.Should().BeEquivalentTo(model, opt => opt.Excluding(m => m.BackLink));
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Post_EditAdditionalServiceDetails_InvalidCatalogueItemId_ReturnsBadRequestObjectResult(
+            CatalogueItemId catalogueItemId,
+            CatalogueItemId additionalServiceId,
+            EditAdditionalServiceDetailsModel model,
+            [Frozen] Mock<ISolutionsService> solutionsService,
+            AdditionalServicesController controller)
+        {
+            solutionsService.Setup(s => s.GetSolution(catalogueItemId))
+                .ReturnsAsync(default(CatalogueItem));
+
+            var result = await controller.EditAdditionalServiceDetails(catalogueItemId, additionalServiceId, model);
+
+            result.As<BadRequestObjectResult>().Should().NotBeNull();
+            result.As<BadRequestObjectResult>().Value.Should().Be($"No Solution found for Id: {catalogueItemId}");
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Post_EditAdditionalServiceDetails_InvalidAdditionalServiceId_ReturnsBadRequestObjectResult(
+            CatalogueItemId catalogueItemId,
+            CatalogueItemId additionalServiceId,
+            EditAdditionalServiceDetailsModel model,
+            [Frozen] Mock<IAdditionalServicesService> additionalServicesService,
+            AdditionalServicesController controller)
+        {
+            additionalServicesService.Setup(s => s.GetAdditionalService(catalogueItemId, additionalServiceId))
+                .ReturnsAsync(default(CatalogueItem));
+
+            var result = await controller.EditAdditionalServiceDetails(catalogueItemId, additionalServiceId, model);
+
+            result.As<BadRequestObjectResult>().Should().NotBeNull();
+            result.As<BadRequestObjectResult>().Value.Should().Be($"No Additional Service with Id {additionalServiceId} found for Solution {catalogueItemId}");
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Post_EditAdditionalServiceDetails_ValidModel_RedirectsToEditAdditionalService(
+            CatalogueItem catalogueItem,
+            CatalogueItem additionalService,
+            EditAdditionalServiceDetailsModel model,
+            [Frozen] Mock<ISolutionsService> solutionsService,
+            [Frozen] Mock<IAdditionalServicesService> additionalServicesService,
+            AdditionalServicesController controller)
+        {
+            solutionsService.Setup(s => s.GetSolution(catalogueItem.Id))
+                .ReturnsAsync(catalogueItem);
+
+            additionalServicesService.Setup(s => s.GetAdditionalService(catalogueItem.Id, additionalService.Id))
+                .ReturnsAsync(additionalService);
+
+            var result = await controller.EditAdditionalServiceDetails(catalogueItem.Id, additionalService.Id, model);
+
+            result.As<RedirectToActionResult>().Should().NotBeNull();
+            result.As<RedirectToActionResult>().ActionName.Should().Be(nameof(AdditionalServicesController.EditAdditionalService));
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Validators/EditAdditionalServiceDetailsModelValidatorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Validators/EditAdditionalServiceDetailsModelValidatorTests.cs
@@ -1,0 +1,81 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using AutoFixture.Xunit2;
+using FluentValidation.TestHelper;
+using Moq;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Suppliers;
+using NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.AdditionalServices;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Validators;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Validators
+{
+    public static class EditAdditionalServiceDetailsModelValidatorTests
+    {
+        [Theory]
+        [CommonAutoData]
+        public static async Task Validate_ValidModel_NoValidationErrors(
+            EditAdditionalServiceDetailsModel model,
+            EditAdditionalServiceDetailsModelValidator validator)
+        {
+            var result = await validator.TestValidateAsync(model);
+
+            result.ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Validate_NameNotEntered_HasError(
+            CatalogueItem catalogueItem,
+            CatalogueItem additionalService,
+            EditAdditionalServiceDetailsModelValidator validator)
+        {
+            additionalService.Name = null;
+
+            var model = new EditAdditionalServiceDetailsModel(catalogueItem, additionalService);
+
+            var result = await validator.TestValidateAsync(model);
+
+            result.ShouldHaveValidationErrorFor(m => m.Name)
+                .WithErrorMessage("Enter an Additional Service name");
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Validate_DescriptionNotEntered_HasError(
+            CatalogueItem catalogueItem,
+            CatalogueItem additionalService,
+            EditAdditionalServiceDetailsModelValidator validator)
+        {
+            additionalService.AdditionalService.FullDescription = null;
+
+            var model = new EditAdditionalServiceDetailsModel(catalogueItem, additionalService);
+
+            var result = await validator.TestValidateAsync(model);
+
+            result.ShouldHaveValidationErrorFor(m => m.Description)
+                .WithErrorMessage("Enter an Additional Service description");
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Validate_ExistingServiceName_HasError(
+            CatalogueItem catalogueItem,
+            CatalogueItem additionalService,
+            [Frozen] Mock<ISuppliersService> suppliersService,
+            EditAdditionalServiceDetailsModelValidator validator)
+        {
+            suppliersService.Setup(s => s.GetAllSolutionsForSupplier(catalogueItem.Supplier.Id))
+                .ReturnsAsync(new List<CatalogueItem> { additionalService });
+
+            var model = new EditAdditionalServiceDetailsModel(catalogueItem, additionalService);
+
+            var result = await validator.TestValidateAsync(model);
+
+            result.ShouldHaveValidationErrorFor(m => m.Name)
+                .WithErrorMessage("Additional Service name already exists. Enter a different name");
+        }
+    }
+}


### PR DESCRIPTION
Adds the code required for adding and editing additional services.

Also introduces a `CatalogueItemIdValueConverter` to allow Entity Framework to generate the `CatalogueItemId` values without having to explicitly do this every time. This is backwards compatible in case I have missed any other assignments to `CatalogueItemId`.

Unfortunately it doesn't look like the `ValueConverter` can be unit tested since Microsoft's implementation of `EntityEntry` depends on an `InternalEntityEntry` type which has a protected constructor. I'll review the E2E tests for creating solutions, associate and additional services to ensure we have coverage of the IDs.