### PR TITLE
Fix Capabilities Filters

### DIFF
--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/CatalogueSolutions.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/CatalogueSolutions.cs
@@ -285,7 +285,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 
             await using var context = GetEndToEndDbContext();
 
-            var filterService = new SolutionsFilterService(context, Factory.GetMemoryCache);
+            var filterService = new SolutionsFilterService(context);
 
             var results = await filterService.GetAllCategoriesAndCountForFilter();
 
@@ -316,8 +316,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
         }
 
         [Theory]
-        [InlineData("C46", "C46E1")]
-        [InlineData("C46", "C46E2")]
+        [InlineData("C46", "C46E5")]
+        [InlineData("C46", "C46E6")]
         public void CatalogueSolutions_Filter_FilterByOneCapabilityWithEpic_CorrectResults(string capabilityId, string epicId)
         {
             CommonActions.WaitUntilElementExists(Objects.PublicBrowse.SolutionsObjects.FilterCapabilities);
@@ -333,6 +333,22 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
             CommonActions.PageLoadedCorrectGetIndex(typeof(SolutionsController), nameof(SolutionsController.Index)).Should().BeTrue();
 
             Driver.FindElements(ByExtensions.DataTestId("solutions-card")).Count.Should().Be(1);
+        }
+
+        [Fact]
+        public void CatalogueSolutions_Filter_MayEpicsOnly()
+        {
+            const string mayEpic = "C46E6";
+            const string mustEpic = "C46E1";
+
+            CommonActions.WaitUntilElementExists(Objects.PublicBrowse.SolutionsObjects.FilterCapabilities);
+
+            Driver.FindElement(Objects.PublicBrowse.SolutionsObjects.FilterSolutionsExpander).Click();
+            Driver.FindElement(Objects.PublicBrowse.SolutionsObjects.FilterCapabilities).Click();
+
+            CommonActions.ElementExists(By.XPath($"//input[@value='{mayEpic}']")).Should().BeTrue();
+
+            CommonActions.ElementExists(By.XPath($"//input[@value='{mustEpic}']")).Should().BeFalse();
         }
 
         [Fact]

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
@@ -688,6 +688,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                     CatalogueItemEpics = new List<CatalogueItemEpic>
                     {
                         new() { CapabilityId = 46, EpicId = "C46E6", LastUpdated = DateTime.UtcNow, StatusId = 1 },
+                        new() { CapabilityId = 46, EpicId = "C46E1", LastUpdated = DateTime.UtcNow, StatusId = 1 },
                     },
                     PublishedStatus = PublicationStatus.Published,
                     CataloguePrices = new List<CataloguePrice>

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
@@ -554,7 +554,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                     },
                     CatalogueItemEpics = new List<CatalogueItemEpic>
                     {
-                        new() { CapabilityId = 46, EpicId = "C46E1", LastUpdated = DateTime.UtcNow, StatusId = 1 },
+                        new() { CapabilityId = 46, EpicId = "C46E5", LastUpdated = DateTime.UtcNow, StatusId = 1 },
                     },
                     PublishedStatus = PublicationStatus.Published,
                     CataloguePrices = new List<CataloguePrice>
@@ -687,7 +687,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                     },
                     CatalogueItemEpics = new List<CatalogueItemEpic>
                     {
-                        new() { CapabilityId = 46, EpicId = "C46E2", LastUpdated = DateTime.UtcNow, StatusId = 1 },
+                        new() { CapabilityId = 46, EpicId = "C46E6", LastUpdated = DateTime.UtcNow, StatusId = 1 },
                     },
                     PublishedStatus = PublicationStatus.Published,
                     CataloguePrices = new List<CataloguePrice>


### PR DESCRIPTION
Update epics list to only include MAY epics and exclude MUST epics

Update epic ordering to order by number of subscribed solutions first them alphabetical

remove unneeded caching from the solutions filter results side since the cache is being held on the rendered html side.

update E2E to reflect this change, and add test to make sure MUST epics don't show on the front.

Change seed data from using MUST epics to MAY epics