### PR TITLE
Add Fluent Validator Interceptor

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/ServiceCollectionExtensions.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO.Compression;
 using System.Threading.Tasks;
+using FluentValidation.AspNetCore;
 using MailKit;
 using MailKit.Net.Smtp;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -22,6 +23,8 @@ using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Email;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Identity;
 using NHSD.GPIT.BuyingCatalogue.Services.Email;
 using NHSD.GPIT.BuyingCatalogue.Services.Identity;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Validators;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Validation;
 
 namespace NHSD.GPIT.BuyingCatalogue.WebApp
 {
@@ -250,6 +253,15 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp
             });
 
             services.Configure<GzipCompressionProviderOptions>(options => options.Level = CompressionLevel.Fastest);
+        }
+
+        public static IServiceCollection AddFluentValidation(this IServiceCollection services)
+        {
+            return services.AddFluentValidation(
+                    options =>
+                    {
+                        options.RegisterValidatorsFromAssemblyContaining<SolutionModelValidator>();
+                    }).AddSingleton<IValidatorInterceptor, FluentValidatorInterceptor>();
         }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Startup.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Startup.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using FluentValidation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Hosting;
@@ -14,7 +13,6 @@ using Microsoft.Extensions.Logging;
 using NHSD.GPIT.BuyingCatalogue.Framework.Logging;
 using NHSD.GPIT.BuyingCatalogue.Services;
 using NHSD.GPIT.BuyingCatalogue.WebApp.ActionFilters;
-using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Validators;
 using Serilog;
 
 namespace NHSD.GPIT.BuyingCatalogue.WebApp
@@ -52,11 +50,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp
                         options.Filters.Add(new AutoValidateAntiforgeryTokenAttribute());
                     });
 
-            services.AddFluentValidation(
-                    options =>
-                    {
-                        options.RegisterValidatorsFromAssemblyContaining<SolutionModelValidator>();
-                    });
+            services.AddFluentValidation();
 
             services.AddApplicationInsightsTelemetry();
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Validation/FluentValidationExtensions.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Validation/FluentValidationExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Linq.Expressions;
+using FluentValidation;
+using FluentValidation.Internal;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.Validation
+{
+    [ExcludeFromCodeCoverage(Justification = "Contains extension methods for FluentValidation's IRuleBuilderOptions")]
+    public static class FluentValidationExtensions
+    {
+        public static IRuleBuilderOptions<T, TProperty> OverridePropertyName<T, TProperty>(
+            this IRuleBuilderOptions<T, TProperty> rule,
+            params Expression<Func<T, object>>[] expressions)
+        {
+            if (expressions == null) throw new ArgumentNullException(nameof(expressions));
+            var propertyName = string.Join('|', expressions.Select(expr => expr.GetMember()?.Name));
+            return rule.OverridePropertyName(propertyName);
+        }
+    }
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Validation/FluentValidatorInterceptor.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Validation/FluentValidatorInterceptor.cs
@@ -1,0 +1,47 @@
+﻿using System.Linq;
+using FluentValidation;
+using FluentValidation.AspNetCore;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Mvc;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.Validation
+{
+    public class FluentValidatorInterceptor : IValidatorInterceptor
+    {
+        public ValidationResult AfterAspNetValidation(ActionContext actionContext, IValidationContext validationContext, ValidationResult result)
+        {
+            if (!result.Errors.Any())
+                return result;
+
+            var delimitedErrors = result.Errors.Where(e => e.PropertyName.Contains('|')).ToList();
+            if (!delimitedErrors.Any())
+                return result;
+
+            var validationErrors = result.Errors.Except(delimitedErrors).ToList();
+            foreach (var delimitedError in delimitedErrors)
+            {
+                foreach (var propertyName in delimitedError.PropertyName.Split('|'))
+                {
+                    var validationError = new ValidationFailure(propertyName, delimitedError.ErrorMessage)
+                    {
+                        AttemptedValue = delimitedError.AttemptedValue,
+                        CustomState = delimitedError.CustomState,
+                        ErrorCode = delimitedError.ErrorCode,
+                        FormattedMessagePlaceholderValues = delimitedError.FormattedMessagePlaceholderValues?.ToDictionary(k => k.Key, v => v.Value),
+                        Severity = delimitedError.Severity,
+                    };
+
+                    validationErrors.Add(validationError);
+                }
+            }
+
+            result.Errors.Clear();
+            result.Errors.AddRange(validationErrors);
+
+            return result;
+        }
+
+        public IValidationContext BeforeAspNetValidation(ActionContext actionContext, IValidationContext commonContext)
+            => commonContext;
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.Test.Framework/AutoFixtureCustomisations/ActionContextCustomization.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Test.Framework/AutoFixtureCustomisations/ActionContextCustomization.cs
@@ -1,0 +1,23 @@
+﻿using AutoFixture;
+using AutoFixture.Dsl;
+using AutoFixture.Kernel;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Routing;
+
+namespace NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations
+{
+    public sealed class ActionContextCustomization : ICustomization
+    {
+        public void Customize(IFixture fixture)
+        {
+            static ISpecimenBuilder ComposerTransformation(ICustomizationComposer<ActionContext> composer) => composer
+                .With(c => c.ActionDescriptor, new ActionDescriptor())
+                .With(c => c.HttpContext, new DefaultHttpContext())
+                .With(c => c.RouteData, new RouteData());
+
+            fixture.Customize<ActionContext>(ComposerTransformation);
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.Test.Framework/AutoFixtureCustomisations/FixtureFactory.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Test.Framework/AutoFixtureCustomisations/FixtureFactory.cs
@@ -38,6 +38,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations
             new HostingTypeSectionModelCustomization(),
             new ClientApplicationTypeSectionModelCustomization(),
             new ServiceLevelAgreementCustomization(),
+            new ActionContextCustomization(),
         };
 
         internal static IFixture Create() => Create(Customizations);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Validation/FluentValidatorInterceptorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Validation/FluentValidatorInterceptorTests.cs
@@ -1,0 +1,131 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Mvc;
+using NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Validation;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Validation
+{
+    public static class FluentValidatorInterceptorTests
+    {
+        [Theory]
+        [CommonAutoData]
+        public static void BeforeValidation_ReturnsContext(
+            ActionContext actionContext,
+            IValidationContext validationContext,
+            FluentValidatorInterceptor interceptor)
+        {
+            var actualValidationContext = interceptor.BeforeAspNetValidation(actionContext, validationContext);
+
+            actualValidationContext.Should().BeEquivalentTo(validationContext);
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static void AfterValidation_NoErrors_ReturnsResult(
+            ActionContext actionContext,
+            IValidationContext validationContext,
+            ValidationResult validationResult,
+            FluentValidatorInterceptor interceptor)
+        {
+            validationResult.Errors.Clear();
+
+            var result = interceptor.AfterAspNetValidation(actionContext, validationContext, validationResult);
+
+            result.Should().BeEquivalentTo(validationResult);
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static void AfterValidation_NoDelimitedErrors_ReturnsResult(
+            ActionContext actionContext,
+            IValidationContext validationContext,
+            ValidationResult validationResult,
+            FluentValidatorInterceptor interceptor)
+        {
+            validationResult.Errors.Clear();
+            validationResult.Errors.Add(new ValidationFailure("SomeProperty", "some-error"));
+
+            var result = interceptor.AfterAspNetValidation(actionContext, validationContext, validationResult);
+
+            result.Should().BeEquivalentTo(validationResult);
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static void AfterValidation_DelimitedErrors_AddsModelErrorForEach(
+            ActionContext actionContext,
+            IValidationContext validationContext,
+            ValidationResult validationResult,
+            FluentValidatorInterceptor interceptor)
+        {
+            var expectedValidationErrors = new List<ValidationFailure>
+            {
+                new("SomeProperty1", "some-error"),
+                new("SomeProperty2", "some-error"),
+            };
+
+            validationResult.Errors.Clear();
+            validationResult.Errors.Add(new ValidationFailure("SomeProperty1|SomeProperty2", "some-error"));
+
+            var result = interceptor.AfterAspNetValidation(actionContext, validationContext, validationResult);
+
+            result.Errors.Should().HaveCount(2);
+            result.Errors.Should().BeEquivalentTo(expectedValidationErrors);
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static void AfterValidation_DelimitedErrors_PreservesNonDelimitedErrors(
+            ActionContext actionContext,
+            IValidationContext validationContext,
+            ValidationResult validationResult,
+            FluentValidatorInterceptor interceptor)
+        {
+            var expectedValidationErrors = new List<ValidationFailure>
+            {
+                new("SomeProperty1", "some-error1"),
+                new("SomeProperty2", "some-error1"),
+                new("SomeProperty3", "some-error3"),
+            };
+
+            validationResult.Errors.Clear();
+            validationResult.Errors.Add(new ValidationFailure("SomeProperty1|SomeProperty2", "some-error1"));
+            validationResult.Errors.Add(new ValidationFailure("SomeProperty3", "some-error3"));
+
+            var result = interceptor.AfterAspNetValidation(actionContext, validationContext, validationResult);
+
+            result.Errors.Should().HaveCount(3);
+            result.Errors.Should().BeEquivalentTo(expectedValidationErrors);
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static void AfterValidation_FormattedMessagePlaceholderValues(
+            ActionContext actionContext,
+            IValidationContext validationContext,
+            ValidationResult validationResult,
+            FluentValidatorInterceptor interceptor)
+        {
+            var formattedMessagePlaceholderValues = new Dictionary<string, object>
+            {
+                ["some-placeholder"] = "some-value",
+            };
+            var validationFailure = new ValidationFailure("SomeProperty", "some-error")
+            {
+                FormattedMessagePlaceholderValues = formattedMessagePlaceholderValues,
+            };
+
+            validationResult.Errors.Clear();
+            validationResult.Errors.Add(validationFailure);
+
+            var result = interceptor.AfterAspNetValidation(actionContext, validationContext, validationResult);
+
+            result.Errors.Should().HaveCount(1);
+            result.Errors[0].FormattedMessagePlaceholderValues.Should().BeEquivalentTo(formattedMessagePlaceholderValues);
+        }
+    }
+}


### PR DESCRIPTION
Adds an OverridePropertyName extension method that overrides a rule's property name with a pipe-delimited set.

Adds a Fluent Validator Interceptor that splits the delimited property names and adds an error for each key.

Due to the nature of the design spec, the validation summary must link to all contributing inputs when validation is performed where the validation rule checks all values for existing duplicate records. One way around this is to create multiple rules on the top-level model with different property names which would result in duplication checking code being called multiple times (e.g: multiple database calls).

This workaround uses delimited property names to duplicate the error message for each property that contributed to this validation error.

Example:
```csharp
public UserValidator()
{
    RuleFor(model => model)
        .Must(() => NotDuplicateAnotherUser())
        .OverridePropertyName(
            model => model.FirstName,
            model => model.LastName);
}

public bool NotDuplicateAnotherUser(UserModel model)
{
    var existingUser = userService.GetByFirstAndLastName(model.FirstName, model.LastName);
    return existingUser is null;
}
```