### PR TITLE
Fix publish issue with non-published statuses

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/CapabilityModels/EditCapabilitiesModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/CapabilityModels/EditCapabilitiesModel.cs
@@ -19,7 +19,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.CapabilityModels
             : this()
         {
             Name = catalogueItem.Name;
-            SupplierName = catalogueItem.Supplier.Name;
+            SolutionName = catalogueItem.Name;
             CatalogueItemType = catalogueItem.CatalogueItemType.AsString(EnumFormat.DisplayName);
 
             CapabilityCategories = capabilityCategories.Select(cc => new CapabilityCategoryModel
@@ -45,7 +45,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.CapabilityModels
 
         public string Name { get; init; }
 
-        public string SupplierName { get; init; }
+        public string SolutionName { get; init; }
 
         public string CatalogueItemType { get; init; }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Validators/PublicationStatusValidation/EditAdditionalServiceModelValidator.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Validators/PublicationStatusValidation/EditAdditionalServiceModelValidator.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.AdditionalServices;
 
@@ -16,7 +17,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Validators.PublicationSta
 
         private bool HaveCompletedAllMandatorySections(EditAdditionalServiceModel model)
         {
-            if (model.SelectedPublicationStatus == model.AdditionalServicePublicationStatus)
+            if (model.SelectedPublicationStatus != PublicationStatus.Published || model.SelectedPublicationStatus == model.AdditionalServicePublicationStatus)
                 return true;
 
             return model.DetailsStatus == TaskProgress.Completed

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Validators/PublicationStatusValidation/EditAssociatedServiceModelValidator.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Validators/PublicationStatusValidation/EditAssociatedServiceModelValidator.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.AssociatedServices;
 
@@ -16,7 +17,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Validators.PublicationSta
 
         private bool HaveCompletedAllMandatorySections(EditAssociatedServiceModel model)
         {
-            if (model.SelectedPublicationStatus == model.AssociatedServicePublicationStatus)
+            if (model.SelectedPublicationStatus != PublicationStatus.Published || model.SelectedPublicationStatus == model.AssociatedServicePublicationStatus)
                 return true;
 
             return model.DetailsStatus == TaskProgress.Completed

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/EditCapabilities.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/EditCapabilities.cshtml
@@ -8,14 +8,14 @@
     <div class="nhsuk-grid-column-two-thirds">
         <nhs-validation-summary />
         <nhs-page-title title="@ViewBag.Title"
-                        caption="@Model.SupplierName"
+                        caption="@Model.SolutionName"
                         advice="Select the Capabilities and any May Epics met by your @Model.CatalogueItemType." />
 
         <form method="post">
             <input type="hidden" asp-for="BackLink" />
             <input type="hidden" asp-for="BackLinkText" />
             <input type="hidden" asp-for="Name" />
-            <input type="hidden" asp-for="SupplierName" />
+            <input type="hidden" asp-for="SolutionName" />
             <input type="hidden" asp-for="CatalogueItemType" />
             @for (int i = 0; i < Model.CapabilityCategories.Count; i++)
             {

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AdditionalServices/AdditionalServiceCapabilities.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AdditionalServices/AdditionalServiceCapabilities.cs
@@ -42,14 +42,14 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.Addition
             var capabilityCategories = await context.CapabilityCategories.ToListAsync();
             var additionalService = await context.CatalogueItems.Include(i => i.Supplier).SingleAsync(s => s.Id == AdditionalServiceId);
             var additionalServiceName = additionalService.Name;
-            var supplierName = additionalService.Supplier.Name;
+            var solutionName = additionalService.Name;
 
             CommonActions.GoBackLinkDisplayed().Should().BeTrue();
             CommonActions.SaveButtonDisplayed().Should().BeTrue();
 
             CommonActions.PageTitle()
                 .Should()
-                .BeEquivalentTo($"{additionalServiceName} Capabilities - {supplierName}".FormatForComparison());
+                .BeEquivalentTo($"{additionalServiceName} Capabilities - {solutionName}".FormatForComparison());
 
             CommonActions.ElementIsDisplayed(CommonSelectors.Header1)
                 .Should()

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/CapabilityModelsTests/EditCapabilitiesModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/CapabilityModelsTests/EditCapabilitiesModelTests.cs
@@ -20,7 +20,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.Capabili
             var model = new EditCapabilitiesModel(additionalService.CatalogueItem, capabilityCategories);
 
             model.Name.Should().Be(additionalService.CatalogueItem.Name);
-            model.SupplierName.Should().Be(additionalService.CatalogueItem.Supplier.Name);
+            model.SolutionName.Should().Be(additionalService.CatalogueItem.Supplier.Name);
             model.CatalogueItemType.Should().Be(additionalService.CatalogueItem.CatalogueItemType.AsString(EnumFormat.DisplayName));
         }
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/CapabilityModelsTests/EditCapabilitiesModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/CapabilityModelsTests/EditCapabilitiesModelTests.cs
@@ -20,7 +20,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.Capabili
             var model = new EditCapabilitiesModel(additionalService.CatalogueItem, capabilityCategories);
 
             model.Name.Should().Be(additionalService.CatalogueItem.Name);
-            model.SolutionName.Should().Be(additionalService.CatalogueItem.Supplier.Name);
+            model.SolutionName.Should().Be(additionalService.CatalogueItem.Name);
             model.CatalogueItemType.Should().Be(additionalService.CatalogueItem.CatalogueItemType.AsString(EnumFormat.DisplayName));
         }
 


### PR DESCRIPTION
Validation of additional and associated services shouldn't run if the user is setting the status to anything other than Published