### PR TITLE
Remove unneeded "Go back" and "Save and Continue" content

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AdditionalServicesController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AdditionalServicesController.cs
@@ -188,7 +188,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                     nameof(EditAdditionalService),
                     typeof(AdditionalServicesController).ControllerName(),
                     new { solutionId, additionalServiceId }),
-                BackLinkText = "Go back",
             };
 
             return View(model);
@@ -212,7 +211,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                     nameof(ManageListPrices),
                     typeof(AdditionalServicesController).ControllerName(),
                     new { solutionId, additionalServiceId }),
-                BackLinkText = "Go back",
             };
 
             return View("EditListPrice", model);
@@ -249,7 +247,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             var editListPriceModel = new EditListPriceModel(additionalService, cataloguePrice, solutionId)
             {
                 BackLink = Url.Action(nameof(ManageListPrices), new { solutionId, additionalServiceId }),
-                BackLinkText = "Go back",
                 Title = $"{additionalService.Name} price",
             };
 
@@ -285,7 +282,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             var model = new DeleteListPriceModel(additionalService)
             {
                 BackLink = Url.Action(nameof(EditListPrice), new { solutionId, additionalServiceId, listPriceId }),
-                BackLinkText = "Go back",
             };
 
             return View(model);

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AssociatedServicesController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AssociatedServicesController.cs
@@ -197,7 +197,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                     nameof(EditAssociatedService),
                     typeof(AssociatedServicesController).ControllerName(),
                     new { solutionId, associatedServiceId }),
-                BackLinkText = "Go back",
             };
 
             return View(model);
@@ -221,7 +220,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                     nameof(ManageListPrices),
                     typeof(AssociatedServicesController).ControllerName(),
                     new { solutionId, associatedServiceId }),
-                BackLinkText = "Go back",
             };
 
             return View("EditListPrice", model);
@@ -258,7 +256,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             var editListPriceModel = new EditListPriceModel(associatedService, cataloguePrice, solutionId)
             {
                 BackLink = Url.Action(nameof(ManageListPrices), new { solutionId, associatedServiceId }),
-                BackLinkText = "Go back",
                 Title = $"{associatedService.Name} price",
             };
 
@@ -294,7 +291,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             var model = new DeleteListPriceModel(associatedService)
             {
                 BackLink = Url.Action(nameof(EditListPrice), new { solutionId, associatedServiceId, listPriceId }),
-                BackLinkText = "Go back",
             };
 
             return View(model);

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/CatalogueSolutionsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/CatalogueSolutionsController.cs
@@ -77,12 +77,23 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             if (solution is null)
                 return BadRequest($"No Solution found for Id: {solutionId}");
 
-            return View(new FeaturesModel().FromCatalogueItem(solution));
+            var model = new FeaturesModel(solution)
+            {
+                BackLink = Url.Action(
+                    nameof(ManageCatalogueSolution),
+                    typeof(CatalogueSolutionsController).ControllerName(),
+                    new { solutionId }),
+            };
+
+            return View(model);
         }
 
         [HttpPost("manage/{solutionId}/features")]
         public async Task<IActionResult> Features(CatalogueItemId solutionId, FeaturesModel model)
         {
+            if (!ModelState.IsValid)
+                return View(model);
+
             await solutionsService.SaveSolutionFeatures(solutionId, model.AllFeatures);
 
             return RedirectToAction(nameof(ManageCatalogueSolution), new { solutionId });
@@ -234,7 +245,15 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             if (solution is null)
                 return BadRequest($"No Solution found for Id: {solutionId}");
 
-            return View(new RoadmapModel().FromCatalogueItem(solution));
+            var model = new RoadmapModel(solution)
+            {
+                BackLink = Url.Action(
+                    nameof(ManageCatalogueSolution),
+                    typeof(CatalogueSolutionsController).ControllerName(),
+                    new { solutionId }),
+            };
+
+            return View(model);
         }
 
         [HttpPost("manage/{solutionId}/development-plans")]
@@ -243,7 +262,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             if (!ModelState.IsValid)
             {
                 var solution = await solutionsService.GetSolution(solutionId);
-                return View(model.FromCatalogueItem(solution));
+                return View(model);
             }
 
             await solutionsService.SaveRoadMap(solutionId, model.Link);
@@ -309,7 +328,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
         }
 
         [HttpGet("manage/{solutionId}/hosting-type/hosting-type-public-cloud")]
-        public async Task<IActionResult> PublicCloud(CatalogueItemId solutionId, [FromQuery]bool? isNewHostingType = false)
+        public async Task<IActionResult> PublicCloud(CatalogueItemId solutionId, [FromQuery] bool? isNewHostingType = false)
         {
             var catalogueItem = await solutionsService.GetSolution(solutionId);
             if (catalogueItem is null)
@@ -463,15 +482,19 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                 case ServiceContracts.Solutions.HostingType.Hybrid:
                     hosting.HybridHostingType = new HybridHostingType();
                     break;
+
                 case ServiceContracts.Solutions.HostingType.OnPremise:
                     hosting.OnPremise = new OnPremise();
                     break;
+
                 case ServiceContracts.Solutions.HostingType.PrivateCloud:
                     hosting.PrivateCloud = new PrivateCloud();
                     break;
+
                 case ServiceContracts.Solutions.HostingType.PublicCloud:
                     hosting.PublicCloud = new PublicCloud();
                     break;
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(hostingType));
             }
@@ -713,7 +736,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             var model = new EditSupplierDetailsModel(catalogueItem)
             {
                 BackLink = Url.Action(nameof(ManageCatalogueSolution), new { solutionId }),
-                BackLinkText = "Go back",
             };
 
             return View(model);

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/ListPriceController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/ListPriceController.cs
@@ -42,7 +42,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                     nameof(CatalogueSolutionsController.ManageCatalogueSolution),
                     typeof(CatalogueSolutionsController).ControllerName(),
                     new { solutionId }),
-                BackLinkText = "Go back",
             };
 
             return View(model);
@@ -59,7 +58,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             var model = new EditListPriceModel(solution)
             {
                 BackLink = Url.Action(nameof(Index), new { solutionId }),
-                BackLinkText = "Go back",
             };
 
             return View("EditListPrice", model);
@@ -96,7 +94,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             var editListPriceModel = new EditListPriceModel(solution, cataloguePrice)
             {
                 BackLink = Url.Action(nameof(Index), new { solutionId }),
-                BackLinkText = "Go back",
             };
 
             return View("EditListPrice", editListPriceModel);
@@ -131,7 +128,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             var model = new DeleteListPriceModel(solution)
             {
                 BackLink = Url.Action(nameof(EditListPrice), new { solutionId, listPriceId }),
-                BackLinkText = "Go back",
             };
 
             return View(model);

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/ServiceLevelAgreementsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/ServiceLevelAgreementsController.cs
@@ -279,7 +279,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             var model = new Models.ServiceLevelAgreements.EditSLAContactModel(catalogueItem)
             {
                 BackLink = Url.Action(nameof(EditServiceLevelAgreement), new { solutionId }),
-                BackLinkText = "Go back",
             };
 
             return View("EditSLAContact", model);
@@ -328,7 +327,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             var model = new Models.ServiceLevelAgreements.EditSLAContactModel(catalogueItem, contact, serviceLevelAgreements)
             {
                 BackLink = Url.Action(nameof(EditServiceLevelAgreement), new { solutionId }),
-                BackLinkText = "Go back",
             };
 
             return View("EditSLAContact", model);
@@ -379,7 +377,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             var model = new Models.ServiceLevelAgreements.EditSLAContactModel(catalogueItem, contact)
             {
                 BackLink = Url.Action(nameof(EditContact), new { solutionId, contactId }),
-                BackLinkText = "Go back",
             };
 
             return View("DeleteSLAContact", model);

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/SuppliersController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/SuppliersController.cs
@@ -41,7 +41,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
 
             var model = new EditSupplierModel(supplier)
             {
-                BackLinkText = "Go back",
                 BackLink = Url.Action(
                     nameof(Index),
                     typeof(SuppliersController).ControllerName()),
@@ -60,7 +59,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
 
             var supplierStatus = new EditSupplierModel(supplier)
             {
-                BackLinkText = "Go back",
                 BackLink = Url.Action(
                     nameof(Index),
                     typeof(SuppliersController).ControllerName()),
@@ -97,7 +95,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                 BackLink = Url.Action(
                     nameof(Index),
                     typeof(SuppliersController).ControllerName()),
-                BackLinkText = "Go back",
             };
 
             return View("EditSupplierDetails", model);
@@ -136,7 +133,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
 
             var model = new EditSupplierDetailsModel(supplier)
             {
-                BackLinkText = "Go back",
                 BackLink = Url.Action(nameof(EditSupplier), typeof(SuppliersController).ControllerName(), new { supplierId }),
             };
 
@@ -216,7 +212,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
 
             var model = new ManageSupplierContactsModel(supplier)
             {
-                BackLinkText = "Go back",
                 BackLink = Url.Action(
                     nameof(EditSupplier),
                     typeof(SuppliersController).ControllerName(),
@@ -233,7 +228,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
 
             var model = new EditContactModel(supplier)
             {
-                BackLinkText = "Go back",
                 BackLink = Url.Action(
                     nameof(ManageSupplierContacts),
                     typeof(SuppliersController).ControllerName(),
@@ -280,7 +274,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
 
             var model = new EditContactModel(contact, supplier)
             {
-                BackLinkText = "Go back",
                 BackLink = Url.Action(
                     nameof(ManageSupplierContacts),
                     typeof(SuppliersController).ControllerName(),
@@ -328,7 +321,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
 
             var model = new DeleteContactModel(contact, supplier.Name)
             {
-                BackLinkText = "Go back",
                 BackLink = Url.Action(
                     nameof(EditSupplierContact),
                     typeof(SuppliersController).ControllerName(),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AdditionalServices/AdditionalServicesModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AdditionalServices/AdditionalServicesModel.cs
@@ -11,7 +11,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.AdditionalServices
     {
         public AdditionalServicesModel()
         {
-            BackLinkText = "Go back";
         }
 
         public AdditionalServicesModel(CatalogueItem catalogueItem, IReadOnlyList<CatalogueItem> additionalServices)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AdditionalServices/EditAdditionalServiceDetailsModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AdditionalServices/EditAdditionalServiceDetailsModel.cs
@@ -8,7 +8,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.AdditionalServices
     {
         public EditAdditionalServiceDetailsModel()
         {
-            BackLinkText = "Go back";
         }
 
         public EditAdditionalServiceDetailsModel(CatalogueItem catalogueItem)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AdditionalServices/EditAdditionalServiceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AdditionalServices/EditAdditionalServiceModel.cs
@@ -13,7 +13,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.AdditionalServices
     {
         public EditAdditionalServiceModel()
         {
-            BackLinkText = "Go back";
         }
 
         public EditAdditionalServiceModel(CatalogueItem solution, CatalogueItem additionalService)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ApplicationTypeBaseModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ApplicationTypeBaseModel.cs
@@ -14,8 +14,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models
 
         public ApplicationTypeBaseModel(CatalogueItem catalogueItem)
         {
-            BackLink = "./";
-            BackLinkText = "Go back";
             ClientApplication = catalogueItem?.Solution?.GetClientApplication() ?? new ClientApplication();
             SolutionId = catalogueItem?.Id;
             SolutionName = catalogueItem?.Name;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AssociatedServices/AddAssociatedServiceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AssociatedServices/AddAssociatedServiceModel.cs
@@ -13,7 +13,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.AssociatedServices
         public AddAssociatedServiceModel(CatalogueItem catalogueItem)
         {
             BackLink = $"/admin/catalogue-solutions/manage/{catalogueItem.Id}/associated-services";
-            BackLinkText = "Go back";
             Solution = catalogueItem;
         }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AssociatedServices/AssociatedServicesModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AssociatedServices/AssociatedServicesModel.cs
@@ -15,7 +15,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.AssociatedServices
         public AssociatedServicesModel(CatalogueItem catalogueItem, IReadOnlyList<CatalogueItem> associatedServices)
         {
             BackLink = $"/admin/catalogue-solutions/manage/{catalogueItem.Id}";
-            BackLinkText = "Go back";
             Solution = catalogueItem;
             SelectableAssociatedServices = associatedServices.Select(s => new SelectableAssociatedService
             {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AssociatedServices/DeleteAssociatedServiceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AssociatedServices/DeleteAssociatedServiceModel.cs
@@ -17,7 +17,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.AssociatedServices
                 throw new ArgumentNullException(nameof(associatedService));
 
             BackLink = $"/admin/catalogue-solutions/manage/{solutionId}/associated-services/{associatedService.Id}/edit-associated-service";
-            BackLinkText = "Go back";
             AssociatedService = associatedService;
         }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AssociatedServices/EditAssociatedServiceDetailsModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AssociatedServices/EditAssociatedServiceDetailsModel.cs
@@ -13,7 +13,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.AssociatedServices
         public EditAssociatedServiceDetailsModel(CatalogueItem solution, CatalogueItem associatedServiceItem)
         {
             BackLink = $"/admin/catalogue-solutions/manage/{solution.Id}/associated-services/{associatedServiceItem.Id}/edit-associated-service/";
-            BackLinkText = "Go back";
             AssociatedService = associatedServiceItem;
             Name = associatedServiceItem.Name;
             Description = associatedServiceItem.AssociatedService.Description;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AssociatedServices/EditAssociatedServiceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AssociatedServices/EditAssociatedServiceModel.cs
@@ -13,7 +13,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.AssociatedServices
     {
         public EditAssociatedServiceModel()
         {
-            BackLinkText = "Go back";
         }
 
         public EditAssociatedServiceModel(CatalogueItem solution, CatalogueItem associatedService)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/BrowserBasedModels/PlugInsOrExtensionsModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/BrowserBasedModels/PlugInsOrExtensionsModel.cs
@@ -9,7 +9,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.BrowserBasedModels
         public PlugInsOrExtensionsModel()
             : base()
         {
-            BackLinkText = "Go back";
         }
 
         public PlugInsOrExtensionsModel(CatalogueItem catalogueItem)
@@ -17,7 +16,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.BrowserBasedModels
         {
             AdditionalInformation = ClientApplication?.Plugins?.AdditionalInformation;
             PlugInsRequired = ClientApplication?.Plugins?.Required.ToYesNo();
-            BackLinkText = "Go back";
         }
 
         [StringLength(500)]

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/BrowserBasedModels/SupportedBrowsersModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/BrowserBasedModels/SupportedBrowsersModel.cs
@@ -23,7 +23,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.BrowserBasedModels
         public SupportedBrowsersModel()
             : base()
         {
-            BackLinkText = "Go back";
         }
 
         public SupportedBrowsersModel(CatalogueItem catalogueItem)
@@ -38,8 +37,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.BrowserBasedModels
 
             if (ClientApplication.MobileResponsive.HasValue)
                 MobileResponsive = ClientApplication.MobileResponsive.ToYesNo();
-
-            BackLinkText = "Go back";
         }
 
         public SupportedBrowserModel[] Browsers { get; set; }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/CapabilityModels/EditCapabilitiesModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/CapabilityModels/EditCapabilitiesModel.cs
@@ -12,7 +12,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.CapabilityModels
     {
         public EditCapabilitiesModel()
         {
-            BackLinkText = "Go back";
         }
 
         public EditCapabilitiesModel(CatalogueItem catalogueItem, IReadOnlyList<CapabilityCategory> capabilityCategories)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/DeleteApplicationTypeModels/DeleteApplicationTypeConfirmationModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/DeleteApplicationTypeModels/DeleteApplicationTypeConfirmationModel.cs
@@ -12,8 +12,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.DeleteApplicationT
 
         public DeleteApplicationTypeConfirmationModel(CatalogueItem solution, ClientApplicationType clientApplicationType)
         {
-            BackLinkText = "Go back";
-
             if (clientApplicationType == ClientApplicationType.BrowserBased)
             {
                 BackLink = $"/admin/catalogue-solutions/manage/{solution.Id}/client-application-type/browser-based";

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/DesktopBasedModels/ConnectivityModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/DesktopBasedModels/ConnectivityModel.cs
@@ -11,8 +11,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.DesktopBasedModels
         public ConnectivityModel()
         {
             ConnectionSpeeds = Framework.Constants.SelectLists.ConnectionSpeeds;
-
-            BackLinkText = "Go back";
         }
 
         public ConnectivityModel(CatalogueItem catalogueItem)
@@ -26,8 +24,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.DesktopBasedModels
             ConnectionSpeeds = Framework.Constants.SelectLists.ConnectionSpeeds;
 
             SelectedConnectionSpeed = ClientApplication?.NativeDesktopMinimumConnectionSpeed;
-
-            BackLinkText = "Go back";
         }
 
         [Required(ErrorMessage = "Select a connection speed")]

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/DesktopBasedModels/MemoryAndStorageModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/DesktopBasedModels/MemoryAndStorageModel.cs
@@ -12,8 +12,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.DesktopBasedModels
         {
             MemorySizes = Framework.Constants.SelectLists.MemorySizes;
             Resolutions = Framework.Constants.SelectLists.ScreenResolutions;
-
-            BackLinkText = "Go back";
         }
 
         public MemoryAndStorageModel(CatalogueItem catalogueItem)
@@ -30,8 +28,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.DesktopBasedModels
             StorageSpace = ClientApplication?.NativeDesktopMemoryAndStorage?.StorageRequirementsDescription;
             ProcessingPower = ClientApplication?.NativeDesktopMemoryAndStorage?.MinimumCpu;
             SelectedResolution = ClientApplication?.NativeDesktopMemoryAndStorage?.RecommendedResolution;
-
-            BackLinkText = "Go back";
         }
 
         [Required(ErrorMessage = "Select a minimum memory size")]

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/FeaturesModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/FeaturesModel.cs
@@ -1,15 +1,43 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Models;
 
 namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models
 {
-    public class FeaturesModel
+    public class FeaturesModel : NavBaseModel
     {
+        public FeaturesModel()
+        {
+        }
+
+        public FeaturesModel(CatalogueItem catalogueItem)
+        {
+            catalogueItem.ValidateNotNull(nameof(catalogueItem));
+
+            SolutionId = catalogueItem.Id;
+            SolutionName = catalogueItem.Name;
+
+            var featuresToSet = catalogueItem.Features();
+
+            if (featuresToSet is not null)
+            {
+                Feature01 = featuresToSet.ElementAtOrDefault(0);
+                Feature02 = featuresToSet.ElementAtOrDefault(1);
+                Feature03 = featuresToSet.ElementAtOrDefault(2);
+                Feature04 = featuresToSet.ElementAtOrDefault(3);
+                Feature05 = featuresToSet.ElementAtOrDefault(4);
+                Feature06 = featuresToSet.ElementAtOrDefault(5);
+                Feature07 = featuresToSet.ElementAtOrDefault(6);
+                Feature08 = featuresToSet.ElementAtOrDefault(7);
+                Feature09 = featuresToSet.ElementAtOrDefault(8);
+                Feature10 = featuresToSet.ElementAtOrDefault(9);
+            }
+        }
+
         [StringLength(100)]
         public string Feature01 { get; set; }
 
@@ -59,54 +87,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models
                     Feature10,
                 }.Where(f => !string.IsNullOrWhiteSpace(f))
                 .ToArray();
-
-        public FeaturesModel FromCatalogueItem(CatalogueItem catalogueItem)
-        {
-            catalogueItem.ValidateNotNull(nameof(catalogueItem));
-
-            SolutionId = catalogueItem.Id;
-            SolutionName = catalogueItem.Name;
-
-            var featuresToSet = catalogueItem.Features() ?? Array.Empty<string>();
-            for (var i = 0; i < featuresToSet.Length; i++)
-            {
-                switch (i)
-                {
-                    case 0:
-                        Feature01 = featuresToSet[i];
-                        break;
-                    case 1:
-                        Feature02 = featuresToSet[i];
-                        break;
-                    case 2:
-                        Feature03 = featuresToSet[i];
-                        break;
-                    case 3:
-                        Feature04 = featuresToSet[i];
-                        break;
-                    case 4:
-                        Feature05 = featuresToSet[i];
-                        break;
-                    case 5:
-                        Feature06 = featuresToSet[i];
-                        break;
-                    case 6:
-                        Feature07 = featuresToSet[i];
-                        break;
-                    case 7:
-                        Feature08 = featuresToSet[i];
-                        break;
-                    case 8:
-                        Feature09 = featuresToSet[i];
-                        break;
-                    case 9:
-                        Feature10 = featuresToSet[i];
-                        break;
-                }
-            }
-
-            return this;
-        }
 
         public TaskProgress Status() =>
             AllFeatures.Any()

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/HostingTypeModels/BaseCloudModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/HostingTypeModels/BaseCloudModel.cs
@@ -9,8 +9,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.HostingTypeModels
     {
         protected BaseCloudModel()
         {
-            BackLink = "./";
-            BackLinkText = "Go back";
         }
 
         protected BaseCloudModel(CatalogueItem solution)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/HostingTypeModels/DeleteHostingTypeConfirmationModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/HostingTypeModels/DeleteHostingTypeConfirmationModel.cs
@@ -18,7 +18,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.HostingTypeModels
             SolutionId = solution.Id;
             SolutionName = solution.Name;
             HostingType = hostingType;
-            BackLinkText = "Go back";
         }
 
         public HostingType HostingType { get; init; }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/InteroperabilityModels/AddGpConnectIntegrationModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/InteroperabilityModels/AddGpConnectIntegrationModel.cs
@@ -9,8 +9,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.InteroperabilityMo
     {
         public AddGpConnectIntegrationModel()
         {
-            BackLinkText = "Go back";
-
             IntegrationTypes = new List<object>
             {
                 new { Text = "GP Connect - HTML View", Value = "HTML View" },

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/InteroperabilityModels/AddIm1IntegrationModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/InteroperabilityModels/AddIm1IntegrationModel.cs
@@ -9,8 +9,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.InteroperabilityMo
     {
         public AddIm1IntegrationModel()
         {
-            BackLinkText = "Go back";
-
             IntegrationTypes = new List<object>
             {
                 new { Text = "IM1 Bulk", Value = "Bulk" },

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/InteroperabilityModels/InteroperabilityModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/InteroperabilityModels/InteroperabilityModel.cs
@@ -51,7 +51,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.InteroperabilityMo
             Link = catalogueItem.Solution?.IntegrationsUrl;
             SolutionName = catalogueItem.Name;
             CatalogueItemId = catalogueItem.Id;
-            BackLinkText = "Go back";
             BackLink = $"/admin/catalogue-solutions/manage/{catalogueItem.Id}";
         }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ManageCatalogueSolutionModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ManageCatalogueSolutionModel.cs
@@ -32,9 +32,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models
                 LastUpdatedByName = $"{lastUpdatedBy.FirstName} {lastUpdatedBy.LastName}";
 
             DescriptionStatus = new DescriptionModel(solution).Status();
-            FeaturesStatus = new FeaturesModel().FromCatalogueItem(solution).Status();
+            FeaturesStatus = new FeaturesModel(solution).Status();
             ImplementationStatus = new ImplementationTimescaleModel(solution).Status();
-            RoadmapStatus = new RoadmapModel().FromCatalogueItem(solution).Status();
+            RoadmapStatus = new RoadmapModel(solution).Status();
             HostingTypeStatus = new HostingTypeSectionModel(solution).Status();
             ClientApplicationTypeStatus = new ClientApplicationTypeSectionModel(solution).Status();
             InteroperabilityStatus = new InteroperabilityModels.InteroperabilityModel(solution).Status();

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/MarketingBaseModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/MarketingBaseModel.cs
@@ -10,7 +10,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models
     {
         protected MarketingBaseModel(CatalogueItem catalogueItem)
         {
-            BackLinkText = "Go back";
             CatalogueItem = catalogueItem;
             ClientApplication = CatalogueItem?.Solution?.GetClientApplication();
             SolutionId = CatalogueItem?.Id;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/RoadmapModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/RoadmapModel.cs
@@ -3,11 +3,25 @@ using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Models;
 
 namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models
 {
-    public sealed class RoadmapModel
+    public sealed class RoadmapModel : NavBaseModel
     {
+        public RoadmapModel()
+        {
+        }
+
+        public RoadmapModel(CatalogueItem catalogueItem)
+        {
+            catalogueItem.ValidateNotNull(nameof(catalogueItem));
+
+            Link = catalogueItem.Solution?.RoadMap;
+            SolutionId = catalogueItem.Id;
+            SolutionName = catalogueItem.Name;
+        }
+
         [StringLength(1000)]
         [Url]
         public string Link { get; set; }
@@ -15,17 +29,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models
         public CatalogueItemId SolutionId { get; set; }
 
         public string SolutionName { get; set; }
-
-        public RoadmapModel FromCatalogueItem(CatalogueItem catalogueItem)
-        {
-            catalogueItem.ValidateNotNull(nameof(catalogueItem));
-
-            Link = catalogueItem.Solution?.RoadMap;
-            SolutionId = catalogueItem.Id;
-            SolutionName = catalogueItem.Name;
-
-            return this;
-        }
 
         public TaskProgress Status() =>
             string.IsNullOrWhiteSpace(Link)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ServiceLevelAgreements/AddEditServiceLevelModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ServiceLevelAgreements/AddEditServiceLevelModel.cs
@@ -12,7 +12,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ServiceLevelAgreem
     {
         public AddEditServiceLevelModel()
         {
-            BackLinkText = "Go back";
         }
 
         public AddEditServiceLevelModel(CatalogueItem solution)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ServiceLevelAgreements/AddSlaTypeModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ServiceLevelAgreements/AddSlaTypeModel.cs
@@ -11,7 +11,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ServiceLevelAgreem
     {
         public AddSlaTypeModel()
         {
-            BackLinkText = "Go back";
         }
 
         public AddSlaTypeModel(Solution solution)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ServiceLevelAgreements/DeleteServiceAvailabilityTimesModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ServiceLevelAgreements/DeleteServiceAvailabilityTimesModel.cs
@@ -8,7 +8,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ServiceLevelAgreem
     {
         public DeleteServiceAvailabilityTimesModel()
         {
-            BackLinkText = "Go back";
         }
 
         public DeleteServiceAvailabilityTimesModel(CatalogueItem solution, ServiceAvailabilityTimes serviceAvailabilityTimes)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ServiceLevelAgreements/DeleteServiceLevelModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ServiceLevelAgreements/DeleteServiceLevelModel.cs
@@ -8,7 +8,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ServiceLevelAgreem
     {
         public DeleteServiceLevelModel()
         {
-            BackLinkText = "Go back";
         }
 
         public DeleteServiceLevelModel(CatalogueItem solution, SlaServiceLevel serviceLevel)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ServiceLevelAgreements/EditServiceAvailabilityTimesModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ServiceLevelAgreements/EditServiceAvailabilityTimesModel.cs
@@ -11,7 +11,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ServiceLevelAgreem
     {
         public EditServiceAvailabilityTimesModel()
         {
-            BackLinkText = "Go back";
         }
 
         public EditServiceAvailabilityTimesModel(CatalogueItem solution)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ServiceLevelAgreements/EditServiceLevelAgreementModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ServiceLevelAgreements/EditServiceLevelAgreementModel.cs
@@ -10,7 +10,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ServiceLevelAgreem
     {
         public EditServiceLevelAgreementModel()
         {
-            BackLinkText = "Go back";
         }
 
         public EditServiceLevelAgreementModel(CatalogueItem solution)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/SolutionModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/SolutionModel.cs
@@ -13,7 +13,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models
         public SolutionModel()
         {
             BackLink = "/admin/catalogue-solutions";
-            BackLinkText = "Go back";
         }
 
         public SolutionModel(CatalogueItem solution)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/SupplierModels/EditSupplierAddressModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/SupplierModels/EditSupplierAddressModel.cs
@@ -9,7 +9,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.SupplierModels
     {
         public EditSupplierAddressModel()
         {
-            BackLinkText = "Go back";
         }
 
         public EditSupplierAddressModel(Supplier supplier)
@@ -27,7 +26,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.SupplierModels
             PostCode = supplier.Address?.Postcode;
             Country = supplier.Address?.Country;
 
-            BackLinkText = "Go back";
             SupplierName = supplier.Name;
         }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/AdditionalServices/EditAdditionalServiceDetails.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/AdditionalServices/EditAdditionalServiceDetails.cshtml
@@ -25,7 +25,7 @@
                           label-text="Additional Service description"
                           label-hint="Describe the extra functionality provided by your Additional Service."
                           number-of-rows="5" />
-            <nhs-submit-button text="Save and continue" />
+            <nhs-submit-button />
         </form>
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/AdditionalServices/EditListPrice.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/AdditionalServices/EditListPrice.cshtml
@@ -73,7 +73,7 @@
                               label-text="Unit definition (optional)"
                               label-hint="For example, if the unit is per day, between what hours?"
                               number-of-rows="5" />
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
             @if (Model.CataloguePriceId is not null)
             {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/AssociatedServices/AddAssociatedService.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/AssociatedServices/AddAssociatedService.cshtml
@@ -24,7 +24,7 @@
             <nhs-textarea asp-for="OrderGuidance"
                           label-text="Order guidance"
                           label-hint="Help buyers understand how they should order the Associated Services by providing typical order volumes and implementation timescales." />
-            <nhs-submit-button text="Save and continue" />
+            <nhs-submit-button />
         </form>
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/AssociatedServices/AssociatedServices.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/AssociatedServices/AssociatedServices.cshtml
@@ -73,7 +73,7 @@
                 </nhs-table>
             }
 
-            <nhs-submit-button text="Save and continue" />
+            <nhs-submit-button />
 
         </form>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/AssociatedServices/EditListPrice.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/AssociatedServices/EditListPrice.cshtml
@@ -73,7 +73,7 @@
                               label-text="Unit definition (optional)"
                               label-hint="For example, if the unit is per day, between what hours?"
                               number-of-rows="5" />
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
             @if (Model.CataloguePriceId is not null)
             {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/AddApplicationType.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/AddApplicationType.cshtml
@@ -29,7 +29,7 @@
                         <br />
                     }
 
-                    <nhs-submit-button text="Save and continue" />
+                    <nhs-submit-button />
                 </form>
             </div>
         </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/AddHostingType.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/AddHostingType.cshtml
@@ -26,7 +26,7 @@
                 </div>
                 <br />
             }
-            <nhs-submit-button text="Save and continue" />
+            <nhs-submit-button />
         </form>
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/AdditionalInformation.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/AdditionalInformation.cshtml
@@ -21,7 +21,7 @@
                 <nhs-textarea asp-for="AdditionalInformation"
                               label-text="Additional information (optional)"
                               label-hint="Provide additional information about your browser-based Catalogue Solution." />
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
         </div>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/ConnectivityAndResolution.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/ConnectivityAndResolution.cshtml
@@ -26,7 +26,7 @@
                             asp-items="@(new SelectList(Model.ScreenResolutions,"Value","Text"))"
                             label-text="Screen resolution and aspect ratio (optional)"
                             label-hint="Select the minimum recommended screen resolution and aspect ratio for your Catalogue Solution to function on desktop." />
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
         </div>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/Description.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/Description.cshtml
@@ -26,7 +26,7 @@
                        label-text="Link to more information (optional)"
                        label-hint="Provide a URL to a page that gives buyers further information about your Catalogue Solution." />
             <br/>
-            <nhs-submit-button text="Save and continue" />
+            <nhs-submit-button />
         </form>
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/Features.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/Features.cshtml
@@ -3,10 +3,7 @@
     ViewBag.Title = "Features";
 }
 
-<vc:nhs-backlink text="Go back"
-                 url="@Url.Action("ManageCatalogueSolution", "CatalogueSolutions", new { solutionId = @Model.SolutionId })">
-</vc:nhs-backlink>
-
+<partial name="Partials/_BackLink" model="Model" />
 <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
@@ -22,18 +19,18 @@
 
         <form method="post">
 
-            <nhs-input asp-for="Feature01" label-text="Feature 1 (optional)" maxlength="100"></nhs-input>
-            <nhs-input asp-for="Feature02" label-text="Feature 2 (optional)" maxlength="100"></nhs-input>
-            <nhs-input asp-for="Feature03" label-text="Feature 3 (optional)" maxlength="100"></nhs-input>
-            <nhs-input asp-for="Feature04" label-text="Feature 4 (optional)" maxlength="100"></nhs-input>
-            <nhs-input asp-for="Feature05" label-text="Feature 5 (optional)" maxlength="100"></nhs-input>
-            <nhs-input asp-for="Feature06" label-text="Feature 6 (optional)" maxlength="100"></nhs-input>
-            <nhs-input asp-for="Feature07" label-text="Feature 7 (optional)" maxlength="100"></nhs-input>
-            <nhs-input asp-for="Feature08" label-text="Feature 8 (optional)" maxlength="100"></nhs-input>
-            <nhs-input asp-for="Feature09" label-text="Feature 9 (optional)" maxlength="100"></nhs-input>
-            <nhs-input asp-for="Feature10" label-text="Feature 10 (optional)" maxlength="100"></nhs-input>
+            <nhs-input asp-for="Feature01" label-text="Feature 1 (optional)" />
+            <nhs-input asp-for="Feature02" label-text="Feature 2 (optional)" />
+            <nhs-input asp-for="Feature03" label-text="Feature 3 (optional)" />
+            <nhs-input asp-for="Feature04" label-text="Feature 4 (optional)" />
+            <nhs-input asp-for="Feature05" label-text="Feature 5 (optional)" />
+            <nhs-input asp-for="Feature06" label-text="Feature 6 (optional)" />
+            <nhs-input asp-for="Feature07" label-text="Feature 7 (optional)" />
+            <nhs-input asp-for="Feature08" label-text="Feature 8 (optional)" />
+            <nhs-input asp-for="Feature09" label-text="Feature 9 (optional)" />
+            <nhs-input asp-for="Feature10" label-text="Feature 10 (optional)" />
             <br/>
-            <nhs-submit-button text="Save and continue"/>
+            <nhs-submit-button />
 
         </form>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/HardwareRequirements.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/HardwareRequirements.cshtml
@@ -19,7 +19,7 @@
                 <nhs-textarea asp-for="Description"
                               label-text="Hardware requirements (optional)"
                               label-hint="Provide information on any hardware that is required for your browser-based Catalogue Solution to function." />
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
         </div>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/HostingType.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/HostingType.cshtml
@@ -40,7 +40,7 @@
                     }
                 </nhs-table>
             }
-            <nhs-submit-button text="Save and continue" />
+            <nhs-submit-button />
         </form>
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/Hybrid.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/Hybrid.cshtml
@@ -49,7 +49,7 @@
                     </nhs-checkbox-container>
                 </nhs-fieldset-form-label>
 
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
             @if (!Model.IsNewHostingType)
             {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/Implementation.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/Implementation.cshtml
@@ -42,7 +42,7 @@
                           label-hint="Include the average number of working days, situations that could affect these timescales and any responsibilities expected of a buyer."
                           number-of-rows="10" />
 
-            <nhs-submit-button text="Save and continue" />
+            <nhs-submit-button />
         </form>
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/ManageCatalogueSolution.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/ManageCatalogueSolution.cshtml
@@ -239,7 +239,7 @@
                                    display-name="Text" />
             </nhs-fieldset-form-label>
 
-            <nhs-submit-button text="Save and continue" />
+            <nhs-submit-button />
         </form>
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/OnPremise.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/OnPremise.cshtml
@@ -50,7 +50,7 @@
                     </nhs-checkbox-container>
                 </nhs-fieldset-form-label>
 
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
             @if (!Model.IsNewHostingType)
             {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/PlugInsOrExtensions.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/PlugInsOrExtensions.cshtml
@@ -26,7 +26,7 @@
                               label-text="Additional information (optional)"
                               label-hint="If your Catalogue Solution uses plug-ins or extensions, provide more information about them for buyers."
                               number-of-rows="5" />
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
         </div>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/PrivateCloud.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/PrivateCloud.cshtml
@@ -50,7 +50,7 @@
                     </nhs-checkbox-container>
                 </nhs-fieldset-form-label>
 
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
             @if (!Model.IsNewHostingType)
             {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/PublicCloud.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/PublicCloud.cshtml
@@ -44,7 +44,7 @@
                     </nhs-checkbox-container>
                 </nhs-fieldset-form-label>
 
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
 
             @if (!Model.IsNewHostingType)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/Roadmap.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/Roadmap.cshtml
@@ -3,10 +3,7 @@
     ViewBag.Title = "Development plans";
 }
 
-<vc:nhs-backlink text="Go back"
-    url="@Url.Action("ManageCatalogueSolution", "CatalogueSolutions", new { solutionId = @Model.SolutionId })">
-</vc:nhs-backlink>
-
+<partial name="Partials/_BackLink" model="Model" />
 <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
@@ -15,19 +12,18 @@
             advice="Let buyers know about any future development plans for your Catalogue Solution."/>
 
         <form method="post">
-
+            <input type="hidden" asp-for="BackLink" />
+            <input type="hidden" asp-for="SolutionName" />
+            <input type="hidden" asp-for="SolutionId" />
             <nhs-input asp-for="Link"
-                label-text="Link to roadmap (optional)"
-                label-hint="Provide a URL to a page that gives buyers further information about your roadmap."
-                character-count="true"></nhs-input>
+                       label-text="Link to roadmap (optional)"
+                       label-hint="Provide a URL to a page that gives buyers further information about your roadmap."/>
 
             <div class="nhsuk-inset-text">
                 <span class="nhsuk-u-visually-hidden">Information: </span>
                 <p>This information will be published on the Buying Catalogue and therefore available to anyone. You should not include anything you consider commercially sensitive.</p>
             </div>
-            <nhs-submit-button text="Save and continue"/>
-
+            <nhs-submit-button />
         </form>
-
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/SupportedBrowsers.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/SupportedBrowsers.cshtml
@@ -32,7 +32,7 @@
                                          label-hint="Does the design of your Catalogue Solution adapt for use on mobile or tablet devices?">
                     <nhs-yesno-radio-buttons asp-for="MobileResponsive" />
                 </nhs-fieldset-form-label>
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
         </div>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/DesktopBased/AdditionalInformation.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/DesktopBased/AdditionalInformation.cshtml
@@ -21,7 +21,7 @@
                 <nhs-textarea asp-for="AdditionalInformation"
                               label-text="Additional information (optional)"
                               label-hint="Provide additional information about your desktop Catalogue Solution." />
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
         </div>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/DesktopBased/Connectivity.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/DesktopBased/Connectivity.cshtml
@@ -23,7 +23,7 @@
                             asp-items="@(new SelectList(Model.ConnectionSpeeds,"Value","Text"))"
                             label-text="Connection speed"
                             label-hint="Select the minimum bandwidth required for your Catalogue Solution to function." />
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
         </div>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/DesktopBased/HardwareRequirements.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/DesktopBased/HardwareRequirements.cshtml
@@ -19,7 +19,7 @@
                 <nhs-textarea asp-for="Description"
                               label-text="Hardware requirements (optional)"
                               label-hint="Provide information on any additional hardware that is required for your desktop Catalogue Solution to function." />
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
         </div>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/DesktopBased/MemoryAndStorage.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/DesktopBased/MemoryAndStorage.cshtml
@@ -37,7 +37,7 @@
                             label-text="Screen resolution and aspect ratio (optional)"
                             label-hint="Select the minimum recommended screen resolution and aspect ratio for your Catalogue Solution to function on desktop." />
 
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
         </div>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/DesktopBased/OperatingSystems.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/DesktopBased/OperatingSystems.cshtml
@@ -23,7 +23,7 @@
                               label-text="Supported operating systems"
                               label-hint="Provide information on the operating systems supported by your Catalogue Solution." />
 
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
         </div>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/DesktopBased/ThirdPartyComponents.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/DesktopBased/ThirdPartyComponents.cshtml
@@ -27,7 +27,7 @@
                               label-text="Device capabilities (optional)"
                               label-hint="Provide information on any device capabilities required for your Catalogue Solution to function, for example a camera or a certain type of connection port." />
 
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
         </div>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Interoperability/AddGpConnectIntegration.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Interoperability/AddGpConnectIntegration.cshtml
@@ -28,7 +28,7 @@
                               label-text="Additional Information"
                               label-hint="Provide additional information about how your Catalogue Solution integrates with the other system." />
 
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
         </div>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Interoperability/AddIm1Integration.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Interoperability/AddIm1Integration.cshtml
@@ -31,7 +31,7 @@
                               label-text="Description"
                               label-hint="Describe how your Catalogue Solution integrates with the other system." />
 
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
         </div>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Interoperability/Interoperability.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Interoperability/Interoperability.cshtml
@@ -137,7 +137,7 @@
                     </p>
                 </nhs-inset-text>
                 <br/>
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
         </div>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ListPrice/EditListPrice.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ListPrice/EditListPrice.cshtml
@@ -70,7 +70,7 @@
                           label-text="Unit definition (optional)"
                           label-hint="For example, if the unit is per day, between what hours?"
                           number-of-rows="5" />
-            <nhs-submit-button text="Save and continue" />
+            <nhs-submit-button />
         </form>
         @if (Model.CataloguePriceId is not null)
         {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Organisations/AddAnOrganisation.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Organisations/AddAnOrganisation.cshtml
@@ -24,7 +24,7 @@
                                        value-name="@nameof(Organisation.Id)"
                                        display-name="@nameof(Organisation.Name)" />
                 </nhs-fieldset-form-label>
-                <nhs-submit-button text="Save and continue" />
+                <nhs-submit-button />
             </form>
         </div>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Organisations/AddUser.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Organisations/AddUser.cshtml
@@ -26,7 +26,7 @@
                     label-text="Email address"
                 />
                 <div data-test-id="add-user-button">
-                    <nhs-submit-button text="Save and continue" />
+                    <nhs-submit-button />
                 </div>
             </form>
         </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Organisations/Create.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Organisations/Create.cshtml
@@ -46,7 +46,7 @@
                     </nhs-checkbox-container>
                 </nhs-fieldset-form-label>
                 <div data-test-id="save-button">
-                    <nhs-submit-button text="Save and continue" />
+                    <nhs-submit-button />
                 </div>
             </form>
         </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ServiceLevelAgreements/AddEditServiceAvailabilityTimes.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ServiceLevelAgreements/AddEditServiceAvailabilityTimes.cshtml
@@ -39,7 +39,7 @@
                        label-text="Applicable days"
                        label-hint="The days this support type is available during the times entered." />
 
-            <nhs-submit-button text="Save and continue" />
+            <nhs-submit-button />
         </form>
         @if (Model.CanDelete)
         {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ServiceLevelAgreements/AddEditServiceLevel.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ServiceLevelAgreements/AddEditServiceLevel.cshtml
@@ -44,7 +44,7 @@
             </nhs-fieldset-form-label>
 
             <br />
-            <nhs-submit-button text="Save and continue" />
+            <nhs-submit-button />
         </form>
 
         @if (Model.CanDelete)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ServiceLevelAgreements/AddEditSlaType.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ServiceLevelAgreements/AddEditSlaType.cshtml
@@ -21,7 +21,7 @@
                                    display-name="Name" />
             </nhs-fieldset-form-label>
 
-            <nhs-submit-button text="Save and continue" />
+            <nhs-submit-button />
         </form>
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ServiceLevelAgreements/EditSLAContact.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ServiceLevelAgreements/EditSLAContact.cshtml
@@ -33,7 +33,7 @@
                                       asp-for-until="Until" />
             </nhs-fieldset-form-label>
             <br />
-            <nhs-submit-button text="Save and continue" />
+            <nhs-submit-button />
         </form>
 
         @if (Model.CanDelete)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/Details.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/Details.cshtml
@@ -61,7 +61,7 @@
                 <input type="hidden" asp-for="@Model.Frameworks[i].Name" />
             }
             <br>
-            <nhs-submit-button text="Save and continue" />
+            <nhs-submit-button />
         </form>
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/EditCapabilities.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/EditCapabilities.cshtml
@@ -52,7 +52,7 @@
                 </nhs-fieldset-form-container>
             }
 
-            <nhs-submit-button text="Save and continue" />
+            <nhs-submit-button />
         </form>
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Suppliers/EditSupplier.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Suppliers/EditSupplier.cshtml
@@ -74,7 +74,7 @@
                                    value-name="Value" />
             </nhs-fieldset-form-label>
 
-            <nhs-submit-button text="Save and continue" />
+            <nhs-submit-button />
         </form>
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Suppliers/EditSupplierAddress.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Suppliers/EditSupplierAddress.cshtml
@@ -41,7 +41,7 @@
             <input type="hidden" asp-for="BackLinkText" />
             <input type="hidden" asp-for="SupplierName" />
             <br />
-            <nhs-submit-button text="Save and continue" />
+            <nhs-submit-button />
         </form>
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Suppliers/EditSupplierContact.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Suppliers/EditSupplierContact.cshtml
@@ -31,7 +31,7 @@
             <input type="hidden" asp-for="BackLinkText" />
             <input type="hidden" asp-for="SupplierName" />
             <input type="hidden" asp-for="Title" />
-            <nhs-submit-button text="Save and continue" />
+            <nhs-submit-button />
         </form>
         @if (Model.ContactId > 0)
         {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Suppliers/EditSupplierDetails.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Suppliers/EditSupplierDetails.cshtml
@@ -29,7 +29,7 @@
             <input type="hidden" asp-for="BackLinkText" />
             <input type="hidden" asp-for="SupplierDisplayName" />
 
-            <nhs-submit-button text="Save and continue"/>
+            <nhs-submit-button />
         </form>
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AdditionalServiceRecipients/SelectAdditionalServiceRecipientsModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AdditionalServiceRecipients/SelectAdditionalServiceRecipientsModel.cs
@@ -21,7 +21,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.AdditionalServiceR
                  : $"/order/organisation/{odsCode}/order/{state.CallOffId}/additional-services/select/additional-service/price"
                 : $"/order/organisation/{odsCode}/order/{state.CallOffId}/additional-services/{state.CatalogueItemId}";
 
-            BackLinkText = "Go back";
             Title = $"Service Recipients for {state.CatalogueItemName} for {state.CallOffId}";
             OdsCode = odsCode;
             CallOffId = state.CallOffId;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AdditionalServiceRecipientsDate/SelectAdditionalServiceRecipientsDateModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AdditionalServiceRecipientsDate/SelectAdditionalServiceRecipientsDateModel.cs
@@ -17,7 +17,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.AdditionalServiceR
             DateTime? defaultDeliveryDate)
         {
             BackLink = $"/order/organisation/{odsCode}/order/{state.CallOffId}/additional-services/select/additional-service/price/recipients";
-            BackLinkText = "Go back";
             Title = $"Planned delivery date of {state.CatalogueItemName} for {state.CallOffId}";
 
             CommencementDate = state.CommencementDate;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AdditionalServices/AdditionalServiceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AdditionalServices/AdditionalServiceModel.cs
@@ -8,7 +8,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.AdditionalServices
         public AdditionalServiceModel(string odsCode, EntityFramework.Ordering.Models.Order order, List<OrderItem> orderItems)
         {
             BackLink = $"/order/organisation/{odsCode}/order/{order.CallOffId}";
-            BackLinkText = "Go back";
             Title = $"Additional Services for {order.CallOffId}";
             OdsCode = odsCode;
             OrderDescription = order.Description;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AdditionalServices/EditAdditionalServiceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AdditionalServices/EditAdditionalServiceModel.cs
@@ -26,7 +26,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.AdditionalServices
                     BackLink = $"/order/organisation/{odsCode}/order/{state.CallOffId}/additional-services/select/additional-service/price/recipients/date";
             }
 
-            BackLinkText = "Go back";
             Title = $"{state.CatalogueItemName} information for {state.CallOffId}";
             OdsCode = odsCode;
             OrderItem = state;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AdditionalServices/NoAdditionalServicesFoundModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AdditionalServices/NoAdditionalServicesFoundModel.cs
@@ -7,7 +7,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.AdditionalServices
         public NoAdditionalServicesFoundModel(string odsCode, CallOffId callOffId)
         {
             BackLink = $"/order/organisation/{odsCode}/order/{callOffId}";
-            BackLinkText = "Go back";
             Title = "No Additional Services found";
         }
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AdditionalServices/SelectAdditionalServiceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AdditionalServices/SelectAdditionalServiceModel.cs
@@ -18,7 +18,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.AdditionalServices
             CatalogueItemId? selectedAdditionalServiceId)
         {
             BackLink = $"/order/organisation/{odsCode}/order/{callOffId}/additional-services";
-            BackLinkText = "Go back";
             Title = $"Add Additional Service for {callOffId}";
             OdsCode = odsCode;
             Solutions = solutions;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AdditionalServices/SelectAdditionalServicePriceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AdditionalServices/SelectAdditionalServicePriceModel.cs
@@ -16,7 +16,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.AdditionalServices
         public SelectAdditionalServicePriceModel(string odsCode, CallOffId callOffId, string solutionName, List<CataloguePrice> prices)
         {
             BackLink = $"/order/organisation/{odsCode}/order/{callOffId}/additional-services/select/additional-service";
-            BackLinkText = "Go back";
             Title = $"List price for {solutionName}";
             OdsCode = odsCode;
             SetPrices(prices);

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AdditionalServices/SelectFlatDeclarativeQuantityModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AdditionalServices/SelectFlatDeclarativeQuantityModel.cs
@@ -12,7 +12,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.AdditionalServices
         public SelectFlatDeclarativeQuantityModel(string odsCode, CallOffId callOffId, string solutionName, int? quantity)
         {
             BackLink = $"/order/organisation/{odsCode}/order/{callOffId}/additional-services/select/additional-service/price/recipients/date";
-            BackLinkText = "Go back";
             Title = $"Quantity of {solutionName} for {callOffId}";
             Quantity = quantity.ToString();
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AdditionalServices/SelectFlatOnDemandQuantityModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AdditionalServices/SelectFlatOnDemandQuantityModel.cs
@@ -16,7 +16,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.AdditionalServices
         public SelectFlatOnDemandQuantityModel(string odsCode, CallOffId callOffId, string solutionName, int? quantity, TimeUnit? timeUnit)
         {
             BackLink = $"/order/organisation/{odsCode}/order/{callOffId}/additional-services/select/additional-service/price/recipients/date";
-            BackLinkText = "Go back";
             Title = $"Quantity of {solutionName} for {callOffId}";
             OdsCode = odsCode;
             CallOffId = callOffId;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AssociatedServices/AssociatedServiceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AssociatedServices/AssociatedServiceModel.cs
@@ -8,7 +8,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.AssociatedServices
         public AssociatedServiceModel(string odsCode, EntityFramework.Ordering.Models.Order order, List<OrderItem> orderItems)
         {
             BackLink = $"/order/organisation/{odsCode}/order/{order.CallOffId}";
-            BackLinkText = "Go back";
             Title = $"Associated Services for {order.CallOffId}";
             OdsCode = odsCode;
             OrderDescription = order.Description;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AssociatedServices/EditAssociatedServiceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AssociatedServices/EditAssociatedServiceModel.cs
@@ -18,7 +18,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.AssociatedServices
                 ? $"/order/organisation/{odsCode}/order/{state.CallOffId}/associated-services/select/associated-service{(!state.SkipPriceSelection ? "/price" : string.Empty)}"
                 : $"/order/organisation/{odsCode}/order/{state.CallOffId}/associated-services";
 
-            BackLinkText = "Go back";
             Title = $"{state.CatalogueItemName} associated service information for {state.CallOffId}";
             OdsCode = odsCode;
             OrderItem = state;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AssociatedServices/NoAssociatedServicesFoundModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AssociatedServices/NoAssociatedServicesFoundModel.cs
@@ -7,7 +7,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.AssociatedServices
         public NoAssociatedServicesFoundModel(string odsCode, CallOffId callOffId)
         {
             BackLink = $"/order/organisation/{odsCode}/order/{callOffId}";
-            BackLinkText = "Go back";
             Title = "No Associated Services found";
         }
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AssociatedServices/SelectAssociatedServiceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AssociatedServices/SelectAssociatedServiceModel.cs
@@ -14,7 +14,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.AssociatedServices
         public SelectAssociatedServiceModel(string odsCode, CallOffId callOffId, List<CatalogueItem> solutions, CatalogueItemId? selectedSolutionId)
         {
             BackLink = $"/order/organisation/{odsCode}/order/{callOffId}/associated-services";
-            BackLinkText = "Go back";
             Title = $"Add Associated Service for {callOffId}";
             OdsCode = odsCode;
             Solutions = solutions;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AssociatedServices/SelectAssociatedServicePriceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/AssociatedServices/SelectAssociatedServicePriceModel.cs
@@ -16,7 +16,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.AssociatedServices
         public SelectAssociatedServicePriceModel(string odsCode, CallOffId callOffId, string solutionName, List<CataloguePrice> prices)
         {
             BackLink = $"/order/organisation/{odsCode}/order/{callOffId}/associated-services/select/associated-service";
-            BackLinkText = "Go back";
             Title = $"List price for {solutionName}";
             OdsCode = odsCode;
             SetPrices(prices);

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/CatalogueSolutionRecipients/SelectSolutionServiceRecipientsModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/CatalogueSolutionRecipients/SelectSolutionServiceRecipientsModel.cs
@@ -21,7 +21,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.CatalogueSolutionR
                     : $"/order/organisation/{odsCode}/order/{state.CallOffId}/catalogue-solutions/select/solution/price"
                 : $"/order/organisation/{odsCode}/order/{state.CallOffId}/catalogue-solutions/{state.CatalogueItemId}";
 
-            BackLinkText = "Go back";
             Title = $"Service Recipients for {state.CatalogueItemName} for {state.CallOffId}";
             OdsCode = odsCode;
             CallOffId = state.CallOffId;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/CatalogueSolutionRecipientsDate/SelectSolutionServiceRecipientsDateModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/CatalogueSolutionRecipientsDate/SelectSolutionServiceRecipientsDateModel.cs
@@ -17,7 +17,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.CatalogueSolutionR
             DateTime? defaultDeliveryDate)
         {
             BackLink = $"/order/organisation/{odsCode}/order/{state.CallOffId}/catalogue-solutions/select/solution/price/recipients";
-            BackLinkText = "Go back";
             Title = $"Planned delivery date of {state.CatalogueItemName} for {state.CallOffId}";
 
             CommencementDate = state.CommencementDate;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/CatalogueSolutions/CatalogueSolutionsModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/CatalogueSolutions/CatalogueSolutionsModel.cs
@@ -8,7 +8,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.CatalogueSolutions
         public CatalogueSolutionsModel(string odsCode, EntityFramework.Ordering.Models.Order order, List<OrderItem> orderItems)
         {
             BackLink = $"/order/organisation/{odsCode}/order/{order.CallOffId}";
-            BackLinkText = "Go back";
             Title = $"Catalogue Solution for {order.CallOffId}";
             OdsCode = odsCode;
             OrderDescription = order.Description;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/CatalogueSolutions/EditSolutionModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/CatalogueSolutions/EditSolutionModel.cs
@@ -26,7 +26,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.CatalogueSolutions
                     BackLink = $"/order/organisation/{odsCode}/order/{state.CallOffId}/catalogue-solutions/select/solution/price/recipients/date";
             }
 
-            BackLinkText = "Go back";
             Title = $"{state.CatalogueItemName} information for {state.CallOffId}";
             OdsCode = odsCode;
             OrderItem = state;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/CatalogueSolutions/SelectFlatDeclarativeQuantityModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/CatalogueSolutions/SelectFlatDeclarativeQuantityModel.cs
@@ -12,7 +12,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.CatalogueSolutions
         public SelectFlatDeclarativeQuantityModel(string odsCode, CallOffId callOffId, string solutionName, int? quantity)
         {
             BackLink = $"/order/organisation/{odsCode}/order/{callOffId}/catalogue-solutions/select/solution/price/recipients/date";
-            BackLinkText = "Go back";
             Title = $"Quantity of {solutionName} for {callOffId}";
             Quantity = quantity.ToString();
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/CatalogueSolutions/SelectFlatOnDemandQuantityModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/CatalogueSolutions/SelectFlatOnDemandQuantityModel.cs
@@ -16,7 +16,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.CatalogueSolutions
         public SelectFlatOnDemandQuantityModel(string odsCode, CallOffId callOffId, string solutionName, int? quantity, TimeUnit? estimationPeriod)
         {
             BackLink = $"/order/organisation/{odsCode}/order/{callOffId}/catalogue-solutions/select/solution/price/recipients/date";
-            BackLinkText = "Go back";
             Title = $"Quantity of {solutionName} for {callOffId}";
             OdsCode = odsCode;
             CallOffId = callOffId;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/CatalogueSolutions/SelectSolutionModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/CatalogueSolutions/SelectSolutionModel.cs
@@ -14,7 +14,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.CatalogueSolutions
         public SelectSolutionModel(string odsCode, CallOffId callOffId, List<CatalogueItem> solutions, CatalogueItemId? selectedSolutionId)
         {
             BackLink = $"/order/organisation/{odsCode}/order/{callOffId}/catalogue-solutions";
-            BackLinkText = "Go back";
             Title = $"Add Catalogue Solution for {callOffId}";
             OdsCode = odsCode;
             Solutions = solutions;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/CatalogueSolutions/SelectSolutionPriceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/CatalogueSolutions/SelectSolutionPriceModel.cs
@@ -16,7 +16,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.CatalogueSolutions
         public SelectSolutionPriceModel(string odsCode, CallOffId callOffId, string solutionName, List<CataloguePrice> prices)
         {
             BackLink = $"/order/organisation/{odsCode}/order/{callOffId}/catalogue-solutions/select/solution";
-            BackLinkText = "Go back";
             Title = $"List price for {solutionName}";
             OdsCode = odsCode;
             SetPrices(prices);

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/CommencementDate/CommencementDateModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/CommencementDate/CommencementDateModel.cs
@@ -13,7 +13,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.CommencementDate
 
         public CommencementDateModel(string odsCode, CallOffId callOffId, DateTime? commencementDate)
         {
-            BackLinkText = "Go back";
             BackLink = $"/order/organisation/{odsCode}/order/{callOffId}";
             Title = $"Commencement date for {callOffId}";
             OdsCode = odsCode;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/Dashboard/SelectOrganisationModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/Dashboard/SelectOrganisationModel.cs
@@ -13,7 +13,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.Dashboard
 
         public SelectOrganisationModel(string currentOdsCode, List<Organisation> organisations)
         {
-            BackLinkText = "Go back";
             BackLink = $"/order/organisation/{currentOdsCode}";
             Title = "Which organisation are you looking for?";
             OdsCode = currentOdsCode;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/DeleteAdditionalService/DeleteAdditionalServiceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/DeleteAdditionalService/DeleteAdditionalServiceModel.cs
@@ -11,7 +11,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.DeleteAdditionalSe
         public DeleteAdditionalServiceModel(string odsCode, CallOffId callOffId, CatalogueItemId additionalServiceId, string solutionName, string orderDescription)
         {
             BackLink = $"/order/organisation/{odsCode}/order/{callOffId}/additional-services/{additionalServiceId}";
-            BackLinkText = "Go back";
             Title = $"Delete {solutionName} from {callOffId}?";
             OdsCode = odsCode;
             CallOffId = callOffId;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/DeleteAssociatedService/DeleteAssociatedServiceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/DeleteAssociatedService/DeleteAssociatedServiceModel.cs
@@ -11,7 +11,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.DeleteAssociatedSe
         public DeleteAssociatedServiceModel(string odsCode, CallOffId callOffId, CatalogueItemId catalogueItemId, string solutionName, string orderDescription)
         {
             BackLink = $"/order/organisation/{odsCode}/order/{callOffId}/associated-services/{catalogueItemId}";
-            BackLinkText = "Go back";
             Title = $"Delete {solutionName} from {callOffId}?";
             OdsCode = odsCode;
             CallOffId = callOffId;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/DeleteCatalogueSolution/DeleteSolutionModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/DeleteCatalogueSolution/DeleteSolutionModel.cs
@@ -11,7 +11,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.DeleteCatalogueSol
         public DeleteSolutionModel(string odsCode, CallOffId callOffId, CatalogueItemId solutionId, string solutionName, string orderDescription)
         {
             BackLink = $"/order/organisation/{odsCode}/order/{callOffId}/catalogue-solutions/{solutionId}";
-            BackLinkText = "Go back";
             Title = $"Delete {solutionName} from {callOffId}?";
             OdsCode = odsCode;
             CallOffId = callOffId;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/DeleteOrder/DeleteOrderModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/DeleteOrder/DeleteOrderModel.cs
@@ -10,7 +10,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.DeleteOrder
 
         public DeleteOrderModel(string odsCode, EntityFramework.Ordering.Models.Order order)
         {
-            BackLinkText = "Go back";
             BackLink = $"/order/organisation/{odsCode}/order/{order.CallOffId}";
             Title = $"Delete order {order.CallOffId}?";
             Description = order.Description;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/FundingSource/FundingSourceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/FundingSource/FundingSourceModel.cs
@@ -12,7 +12,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.FundingSource
 
         public FundingSourceModel(string odsCode, CallOffId callOffId, bool? fundingSourceOnlyGms)
         {
-            BackLinkText = "Go back";
             BackLink = $"/order/organisation/{odsCode}/order/{callOffId}";
             Title = $"Funding source for {callOffId}";
             FundingSourceOnlyGms = fundingSourceOnlyGms.ToYesNo();

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/Order/SummaryModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/Order/SummaryModel.cs
@@ -8,7 +8,6 @@
 
         public SummaryModel(string odsCode, EntityFramework.Ordering.Models.Order order)
         {
-            BackLinkText = "Go back";
             OdsCode = odsCode;
             Order = order;
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/OrderDescription/OrderDescriptionModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/OrderDescription/OrderDescriptionModel.cs
@@ -10,7 +10,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.OrderDescription
 
         public OrderDescriptionModel(string odsCode, EntityFramework.Ordering.Models.Order order)
         {
-            BackLinkText = "Go back";
             Title = "Order description";
             OdsCode = odsCode;
             Description = order?.Description;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/OrderingParty/OrderingPartyModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/OrderingParty/OrderingPartyModel.cs
@@ -12,7 +12,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.OrderingParty
 
         public OrderingPartyModel(string odsCode, EntityFramework.Ordering.Models.Order order, Organisation organisation)
         {
-            BackLinkText = "Go back";
             BackLink = $"/order/organisation/{odsCode}/order/{order.CallOffId}";
             Title = $"Call-off Ordering Party information for {order.CallOffId}";
             OdsCode = odsCode;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/Supplier/SupplierModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/Supplier/SupplierModel.cs
@@ -10,7 +10,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.Supplier
     {
         public SupplierModel(string odsCode, EntityFramework.Ordering.Models.Order order, ICollection<SupplierContact> supplierContacts)
         {
-            BackLinkText = "Go back";
             BackLink = $"/order/organisation/{odsCode}/order/{order.CallOffId}";
             Title = $"Supplier information for {order.CallOffId}";
             OdsCode = odsCode;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/Supplier/SupplierSearchModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/Supplier/SupplierSearchModel.cs
@@ -4,7 +4,6 @@
     {
         public SupplierSearchModel(string odsCode, EntityFramework.Ordering.Models.Order order)
         {
-            BackLinkText = "Go back";
             BackLink = $"/order/organisation/{odsCode}/order/{order.CallOffId}";
             Title = $"Find supplier information for {order.CallOffId}";
             OdsCode = odsCode;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/Supplier/SupplierSearchSelectModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/Supplier/SupplierSearchSelectModel.cs
@@ -8,7 +8,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.Supplier
     {
         public SupplierSearchSelectModel(string odsCode, CallOffId callOffId, List<EntityFramework.Catalogue.Models.Supplier> suppliers)
         {
-            BackLinkText = "Go back";
             BackLink = $"/order/organisation/{odsCode}/order/{callOffId}/supplier/search";
             Title = "Suppliers found";
             OdsCode = odsCode;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Controllers/SolutionsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Controllers/SolutionsController.cs
@@ -9,6 +9,7 @@ using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Caching;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Models;
 
 namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
 {
@@ -122,7 +123,16 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
             if (item.PublishedStatus == PublicationStatus.Suspended)
                 return RedirectToAction(nameof(Description), new { solutionId });
 
-            return View(new CapabilitiesViewModel(item));
+            var model = new CapabilitiesViewModel(item)
+            {
+                BackLinkText = NavBaseModel.BackLinkTextDefault,
+                BackLink = Url.Action(
+                    nameof(AdditionalServices),
+                    typeof(SolutionsController).ControllerName(),
+                    new { solutionId }),
+            };
+
+            return View(model);
         }
 
         [HttpGet("{solutionId}/additional-services/{additionalServiceId}/capabilities")]
@@ -156,9 +166,17 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
                 return RedirectToAction(nameof(Description), new { solutionId });
 
             var solutionCapability = item.CatalogueItemCapability(capabilityId);
-            var model = new SolutionCheckEpicsModel(solutionCapability);
 
-            return View(model.WithSolutionName(item.Name));
+            var model = new SolutionCheckEpicsModel(solutionCapability)
+            {
+                BackLink = Url.Action(
+                    nameof(Capabilities),
+                    typeof(SolutionsController).ControllerName(),
+                    new { solutionId }),
+                SolutionName = item.Name,
+            };
+
+            return View(model);
         }
 
         [HttpGet("{solutionId}/additional-services/{additionalServiceId}/capability/{capabilityId}")]
@@ -180,11 +198,18 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
                 return RedirectToAction(nameof(Description), new { solutionId });
 
             var solutionCapability = item.CatalogueItemCapability(capabilityId);
-            var model = new SolutionCheckEpicsModel(solutionCapability);
+            var model = new SolutionCheckEpicsModel(solutionCapability)
+            {
+                SolutionName = item.Name,
+                SolutionId = solutionId,
+                CatalogueItemIdAdditional = additionalServiceId,
+                BackLink = Url.Action(
+                    nameof(CapabilitiesAdditionalServices),
+                    typeof(SolutionsController).ControllerName(),
+                    new { solutionId, additionalServiceId }),
+            };
 
-            return View(
-                "CheckEpics",
-                model.WithItems(solutionId, additionalServiceId, item.Name));
+            return View("CheckEpics", model);
         }
 
         [HttpGet("{solutionId}/client-application-types")]

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/CapabilitiesViewModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/CapabilitiesViewModel.cs
@@ -25,6 +25,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
 
         public string Description { get; set; }
 
+        public string BackLinkText { get; set; }
+
+        public string BackLink { get; set; }
+
         public IList<RowViewModel> RowViewModels { get; } = new List<RowViewModel>();
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/SolutionCheckEpicsModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/SolutionCheckEpicsModel.cs
@@ -3,10 +3,11 @@ using System.Linq;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Models;
 
 namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
 {
-    public sealed class SolutionCheckEpicsModel : INoNavModel
+    public sealed class SolutionCheckEpicsModel : NavBaseModel, INoNavModel
     {
         public SolutionCheckEpicsModel()
         {
@@ -43,25 +44,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
         public bool HasNoEpics() => !HasNhsDefined() && !HasSupplierDefined();
 
         public bool HasSupplierDefined() => SupplierDefined != null && SupplierDefined.Length > 0;
-
-        public SolutionCheckEpicsModel WithItems(
-            CatalogueItemId catalogueItemId,
-            CatalogueItemId catalogueItemIdAdditional,
-            string solutionName)
-        {
-            SolutionId = catalogueItemId;
-            CatalogueItemIdAdditional = catalogueItemIdAdditional;
-
-            return WithSolutionName(solutionName);
-        }
-
-        public SolutionCheckEpicsModel WithSolutionName(string solutionName)
-        {
-            if (!string.IsNullOrWhiteSpace(solutionName))
-                SolutionName = solutionName;
-
-            return this;
-        }
 
         private static string[] GetEpics(Capability capability, bool supplierDefined) =>
             capability?

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/CapabilitiesAdditionalServices.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/CapabilitiesAdditionalServices.cshtml
@@ -5,9 +5,8 @@
 
 @section BackLink
 {
-    <vc:nhs-backlink text="Go back" url="@Url.Action("AdditionalServices", "Solutions", new { solutionId = Model.SolutionId })"></vc:nhs-backlink>
+    <vc:nhs-backlink text="@Model.BackLinkText" url="@Model.BackLink" />
 }
-
 
 <div class="nhsuk-width-container">
     <main id="maincontent" role="main">

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/CheckEpics.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/CheckEpics.cshtml
@@ -6,14 +6,7 @@
 
 @section BackLink
 {
-    @if (Model.CatalogueItemIdAdditional.ItemId != null)
-    {
-        <vc:nhs-backlink text="Go back" url="@Url.Action("CapabilitiesAdditionalServices", "Solutions", new { solutionId = Model.SolutionId, additionalServiceId = Model.CatalogueItemIdAdditional })"></vc:nhs-backlink>
-    }
-    else
-    {
-        <vc:nhs-backlink text="Go back" url="@Url.Action("Capabilities", "Solutions", new { solutionId = Model.SolutionId })"></vc:nhs-backlink>
-    }
+    <partial name="Partials/_BackLink" model="@Model" />
 }
 
 <p>@Model.Description</p>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/Index.cshtml
@@ -7,7 +7,6 @@
 @{
     Layout = "~/Views/Shared/Layouts/_AllBannersLayout.cshtml";
     ViewBag.Title = "Find Buying Catalogue Solutions";
-    var backLinkModel = new NavBaseModel { BackLink = "/", BackLinkText = "Go back" };
 
     string sortText = Model.Options.Sort switch
     {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Models/NavBaseModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Models/NavBaseModel.cs
@@ -5,8 +5,12 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Models
     [ExcludeFromCodeCoverage]
     public class NavBaseModel
     {
-        public string BackLink { get; set; } = "./";
+        public const string BackLinkDefault = "./";
 
-        public string BackLinkText { get; set; } = "Go back";
+        public const string BackLinkTextDefault = "Go back";
+
+        public string BackLink { get; set; } = BackLinkDefault;
+
+        public string BackLinkText { get; set; } = BackLinkTextDefault;
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/NominateOrganisation/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/NominateOrganisation/Index.cshtml
@@ -1,7 +1,7 @@
 ﻿@using NHSD.GPIT.BuyingCatalogue.WebApp.Models
 @{
     ViewBag.Title = "Nominate an organisation to create orders on your behalf";
-    var backLinkModel = new NavBaseModel{ BackLink = "/", BackLinkText = "Go back" };
+    var backLinkModel = new NavBaseModel{ BackLink = "/" };
 }
 
 <partial name="Partials/_BackLink" model="@backLinkModel" />

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Features.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Features.cs
@@ -61,7 +61,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution
 
             await using var context = GetEndToEndDbContext();
             var catalogueItem = await context.CatalogueItems.Include(c => c.Solution).SingleAsync(s => s.Id == SolutionId);
-            var featuresModel = new FeaturesModel().FromCatalogueItem(catalogueItem);
+            var featuresModel = new FeaturesModel(catalogueItem);
 
             featuresModel.AllFeatures.Should().BeEquivalentTo(features);
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/AdditionalServicesControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/AdditionalServicesControllerTests.cs
@@ -585,7 +585,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             manageListPricesModel.CataloguePrices.Should().BeEquivalentTo(additionalService.CataloguePrices);
             manageListPricesModel.CatalogueItemId.Should().Be(additionalService.Id);
             manageListPricesModel.CatalogueName.Should().Be(additionalService.Name);
-            manageListPricesModel.BackLinkText.Should().Be("Go back");
         }
 
         [Theory]
@@ -639,7 +638,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             var model = actual.As<ViewResult>().Model.As<EditListPriceModel>();
             model.ItemId.Should().Be(additionalService.Id);
             model.ItemName.Should().Be(additionalService.Name);
-            model.BackLinkText.Should().Be("Go back");
         }
 
         [Theory]
@@ -744,7 +742,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
 
             model.As<EditListPriceModel>().ItemName.Should().Be(catalogueItem.Name);
             model.As<EditListPriceModel>().CataloguePriceId.Should().Be(cataloguePriceId);
-            model.As<EditListPriceModel>().BackLinkText.Should().Be("Go back");
         }
 
         [Theory]

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/AssociatedServicesControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/AssociatedServicesControllerTests.cs
@@ -412,7 +412,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             manageListPricesModel.CataloguePrices.Should().BeEquivalentTo(associatedService.CataloguePrices);
             manageListPricesModel.CatalogueItemId.Should().Be(associatedService.Id);
             manageListPricesModel.CatalogueName.Should().Be(associatedService.Name);
-            manageListPricesModel.BackLinkText.Should().Be("Go back");
         }
 
         [Theory]
@@ -466,7 +465,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             var model = actual.As<ViewResult>().Model.As<EditListPriceModel>();
             model.ItemId.Should().Be(associatedService.Id);
             model.ItemName.Should().Be(associatedService.Name);
-            model.BackLinkText.Should().Be("Go back");
         }
 
         [Theory]
@@ -571,7 +569,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
 
             model.As<EditListPriceModel>().ItemName.Should().Be(catalogueItem.Name);
             model.As<EditListPriceModel>().CataloguePriceId.Should().Be(cataloguePriceId);
-            model.As<EditListPriceModel>().BackLinkText.Should().Be("Go back");
         }
 
         [Theory]

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/CatalogueSolutionsControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/CatalogueSolutionsControllerTests.cs
@@ -64,11 +64,16 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             mockService.Setup(s => s.GetSolution(catalogueItemId))
                 .ReturnsAsync(catalogueItem);
 
+            var expected = new FeaturesModel(catalogueItem)
+            {
+                BackLink = "testUrl",
+            };
+
             var actual = (await controller.Features(catalogueItemId)).As<ViewResult>();
 
             mockService.Verify(s => s.GetSolution(catalogueItemId));
             actual.ViewName.Should().BeNull();
-            actual.Model.Should().BeEquivalentTo(new FeaturesModel().FromCatalogueItem(catalogueItem));
+            actual.Model.Should().BeEquivalentTo(expected);
         }
 
         [Theory]
@@ -124,11 +129,16 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             mockService.Setup(s => s.GetSolution(catalogueItemId))
                 .ReturnsAsync(catalogueItem);
 
+            var expected = new FeaturesModel(catalogueItem)
+            {
+                BackLink = "testUrl",
+            };
+
             var actual = (await controller.Features(catalogueItemId)).As<ViewResult>();
 
             mockService.Verify(s => s.GetSolution(catalogueItemId));
             actual.ViewName.Should().BeNull();
-            actual.Model.Should().BeEquivalentTo(new FeaturesModel().FromCatalogueItem(catalogueItem));
+            actual.Model.Should().BeEquivalentTo(expected);
         }
 
         [Theory]
@@ -497,11 +507,16 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             mockService.Setup(s => s.GetSolution(catalogueItemId))
                 .ReturnsAsync(catalogueItem);
 
+            var expected = new RoadmapModel(catalogueItem)
+            {
+                BackLink = "testUrl",
+            };
+
             var actual = (await controller.Roadmap(catalogueItemId)).As<ViewResult>();
 
             mockService.Verify(s => s.GetSolution(catalogueItemId));
             actual.ViewName.Should().BeNull();
-            actual.Model.Should().BeEquivalentTo(new RoadmapModel().FromCatalogueItem(catalogueItem));
+            actual.Model.Should().BeEquivalentTo(expected);
         }
 
         [Theory]
@@ -557,11 +572,16 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             mockService.Setup(s => s.GetSolution(catalogueItemId))
                 .ReturnsAsync(catalogueItem);
 
+            var expected = new RoadmapModel(catalogueItem)
+            {
+                BackLink = "testUrl",
+            };
+
             var actual = (await controller.Roadmap(catalogueItemId)).As<ViewResult>();
 
             mockService.Verify(s => s.GetSolution(catalogueItemId));
             actual.ViewName.Should().BeNull();
-            actual.Model.Should().BeEquivalentTo(new RoadmapModel().FromCatalogueItem(catalogueItem));
+            actual.Model.Should().BeEquivalentTo(expected);
         }
 
         [Theory]
@@ -2040,7 +2060,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
                 HostingType = hostingType,
                 SolutionId = catalogueItem.Id,
                 SolutionName = catalogueItem.Name,
-                BackLinkText = "Go back",
             };
 
             solutionsService.Setup(s => s.GetSolution(catalogueItem.Id))

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/ListPriceControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/ListPriceControllerTests.cs
@@ -61,7 +61,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             manageListPricesModel.CataloguePrices.Should().BeEquivalentTo(catalogueItem.CataloguePrices);
             manageListPricesModel.CatalogueItemId.Should().Be(catalogueItem.Id);
             manageListPricesModel.CatalogueName.Should().Be(catalogueItem.Name);
-            manageListPricesModel.BackLinkText.Should().Be("Go back");
         }
 
         [Theory]
@@ -101,7 +100,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             var model = actual.As<ViewResult>().Model.As<EditListPriceModel>();
             model.ItemId.Should().Be(catalogueItem.Id);
             model.ItemName.Should().Be(catalogueItem.Name);
-            model.BackLinkText.Should().Be("Go back");
         }
 
         [Theory]
@@ -176,7 +174,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             var model = actual.As<ViewResult>().Model.As<EditListPriceModel>();
             model.ItemName.Should().Be(catalogueItem.Name);
             model.CataloguePriceId.Should().Be(cataloguePriceId);
-            model.BackLinkText.Should().Be("Go back");
         }
 
         [Theory]

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/SuppliersControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/SuppliersControllerTests.cs
@@ -73,7 +73,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             var expectedResult = new EditSupplierModel(supplier)
             {
                 BackLink = "testUrl",
-                BackLinkText = "Go back",
             };
 
             mockSuppliersService.Setup(s => s.GetSupplier(It.IsAny<int>())).ReturnsAsync(supplier);
@@ -95,7 +94,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             var expectedResult = new EditSupplierDetailsModel
             {
                 BackLink = "testUrl",
-                BackLinkText = "Go back",
             };
 
             var actual = controller.AddSupplierDetails().As<ViewResult>();
@@ -177,7 +175,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             var expectedResult = new EditSupplierDetailsModel(supplier)
             {
                 BackLink = "testUrl",
-                BackLinkText = "Go back",
             };
 
             var actual = (await controller.EditSupplierDetails(supplier.Id)).As<ViewResult>();
@@ -314,7 +311,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             var expectedResult = new ManageSupplierContactsModel(supplier)
             {
                 BackLink = "testUrl",
-                BackLinkText = "Go back",
             };
 
             var actual = (await controller.ManageSupplierContacts(supplier.Id)).As<ViewResult>();
@@ -336,7 +332,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             var expectedResult = new EditContactModel(supplier)
             {
                 BackLink = "testUrl",
-                BackLinkText = "Go back",
             };
 
             var actual = (await controller.AddSupplierContact(supplier.Id)).As<ViewResult>();
@@ -398,7 +393,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             var expectedResult = new EditContactModel(supplier.SupplierContacts.First(), supplier)
             {
                 BackLink = "testUrl",
-                BackLinkText = "Go back",
             };
 
             var actual = (await controller.EditSupplierContact(supplier.Id, supplier.SupplierContacts.First().Id)).As<ViewResult>();
@@ -460,7 +454,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             var expectedResult = new DeleteContactModel(supplier.SupplierContacts.First(), supplier.Name)
             {
                 BackLink = "testUrl",
-                BackLinkText = "Go back",
             };
 
             var actual = (await controller.DeleteSupplierContact(supplier.Id, supplier.SupplierContacts.First().Id)).As<ViewResult>();

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/AssociatedServices/AddAssociatedServiceModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/AssociatedServices/AddAssociatedServiceModelTests.cs
@@ -16,7 +16,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.Associat
             var actual = new AddAssociatedServiceModel(catalogueItem);
 
             actual.Solution.Should().Be(catalogueItem);
-            actual.BackLinkText.Should().Be("Go back");
             actual.BackLink.Should().Be($"/admin/catalogue-solutions/manage/{catalogueItem.Id}/associated-services");
         }
     }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/AssociatedServices/AssociatedServicesModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/AssociatedServices/AssociatedServicesModelTests.cs
@@ -31,7 +31,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.Associat
 
             actual.SelectableAssociatedServices.Should().BeEquivalentTo(expected);
             actual.Solution.Should().Be(catalogueItem);
-            actual.BackLinkText.Should().Be("Go back");
             actual.BackLink.Should().Be($"/admin/catalogue-solutions/manage/{catalogueItem.Id}");
         }
 
@@ -63,7 +62,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.Associat
 
             actual.SelectableAssociatedServices.Should().BeEquivalentTo(expected);
             actual.Solution.Should().Be(catalogueItem);
-            actual.BackLinkText.Should().Be("Go back");
             actual.BackLink.Should().Be($"/admin/catalogue-solutions/manage/{catalogueItem.Id}");
         }
     }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/AssociatedServices/DeleteAssociatedServiceModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/AssociatedServices/DeleteAssociatedServiceModelTests.cs
@@ -29,7 +29,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.Associat
             var actual = new DeleteAssociatedServiceModel(catalogueItemId, associatedService);
 
             actual.AssociatedService.Should().Be(associatedService);
-            actual.BackLinkText.Should().Be("Go back");
             actual.BackLink.Should().Be($"/admin/catalogue-solutions/manage/{catalogueItemId}/associated-services/{associatedService.Id}/edit-associated-service");
         }
     }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/AssociatedServices/EditAssociatedServiceModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/AssociatedServices/EditAssociatedServiceModelTests.cs
@@ -22,7 +22,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.Associat
             actual.AssociatedServiceName.Should().Be(associatedService.CatalogueItem.Name);
             actual.SelectedPublicationStatus.Should().Be(associatedService.CatalogueItem.PublishedStatus);
             actual.AssociatedServicePublicationStatus.Should().Be(associatedService.CatalogueItem.PublishedStatus);
-            actual.BackLinkText.Should().Be("Go back");
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/BrowserBasedModels/ConnectivityAndResolutionModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/BrowserBasedModels/ConnectivityAndResolutionModelTests.cs
@@ -22,8 +22,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.BrowserB
             actual.SelectedScreenResolution.Should().Be(solution.GetClientApplication().MinimumDesktopResolution);
             actual.ConnectionSpeeds.Should().BeEquivalentTo(SelectLists.ConnectionSpeeds);
             actual.ScreenResolutions.Should().BeEquivalentTo(SelectLists.ScreenResolutions);
-            actual.BackLink.Should().Be("./");
-            actual.BackLinkText.Should().Be("Go back");
         }
 
         [Fact]

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/BrowserBasedModels/SupportedBrowsersModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/BrowserBasedModels/SupportedBrowsersModelTests.cs
@@ -33,9 +33,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.BrowserB
                 .Excluding(m => m.Checked));
 
             actual.MobileResponsive.Should().Be(solution.GetClientApplication().MobileResponsive.ToYesNo());
-
-            actual.BackLink.Should().Be("./");
-            actual.BackLinkText.Should().Be("Go back");
         }
 
         [Fact]
@@ -44,15 +41,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.BrowserB
             var actual = Assert.Throws<ArgumentNullException>(() => new SupportedBrowsersModel(null));
 
             actual.ParamName.Should().Be("catalogueItem");
-        }
-
-        [Fact]
-        public static void DefaultConstructor_PropertiesCorrectlySet()
-        {
-            var model = new SupportedBrowsersModel();
-
-            model.BackLinkText.Should().Be("Go back");
-            model.BackLink.Should().Be("./");
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/DeleteApplicationTypeModels/DeleteApplicationTypeConfirmationModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/DeleteApplicationTypeModels/DeleteApplicationTypeConfirmationModelTests.cs
@@ -15,7 +15,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.DeleteAp
             CatalogueItem catalogueItem)
         {
             var actual = new DeleteApplicationTypeConfirmationModel(catalogueItem, ClientApplicationType.BrowserBased);
-            actual.BackLinkText.Should().Be("Go back");
             actual.BackLink.Should().Be($"/admin/catalogue-solutions/manage/{catalogueItem.Id}/client-application-type/browser-based");
             actual.ApplicationType.Should().Be("browser-based");
         }
@@ -26,7 +25,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.DeleteAp
             CatalogueItem catalogueItem)
         {
             var actual = new DeleteApplicationTypeConfirmationModel(catalogueItem, ClientApplicationType.Desktop);
-            actual.BackLinkText.Should().Be("Go back");
             actual.BackLink.Should().Be($"/admin/catalogue-solutions/manage/{catalogueItem.Id}/client-application-type/desktop");
             actual.ApplicationType.Should().Be("desktop");
         }
@@ -37,7 +35,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.DeleteAp
             CatalogueItem catalogueItem)
         {
             var actual = new DeleteApplicationTypeConfirmationModel(catalogueItem, ClientApplicationType.MobileTablet);
-            actual.BackLinkText.Should().Be("Go back");
             actual.BackLink.Should().Be($"/admin/catalogue-solutions/manage/{catalogueItem.Id}/client-application-type/mobiletablet");
             actual.ApplicationType.Should().Be("mobile or tablet");
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/FeaturesModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/FeaturesModelTests.cs
@@ -70,15 +70,19 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models
             expected.SolutionId = catalogueItem.Id;
             expected.SolutionName = catalogueItem.Name;
 
-            var actual = new FeaturesModel().FromCatalogueItem(catalogueItem);
+            var actual = new FeaturesModel(catalogueItem);
 
-            actual.Should().BeEquivalentTo(expected);
+            actual.Should().BeEquivalentTo(
+                expected,
+                options => options
+                    .Excluding(fm => fm.BackLink)
+                    .Excluding(fm => fm.BackLinkText));
         }
 
         [Fact]
         public static void FromCatalogueItem_NullCatalogueItem_ThrowsException()
         {
-            var actual = Assert.Throws<ArgumentNullException>(() => new FeaturesModel().FromCatalogueItem(null));
+            var actual = Assert.Throws<ArgumentNullException>(() => new FeaturesModel(null));
 
             actual.ParamName.Should().Be("catalogueItem");
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/InteroperabilityModels/InteroperabilityModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/InteroperabilityModels/InteroperabilityModelTests.cs
@@ -30,7 +30,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.Interope
 
             var actual = new InteroperabilityModel(catalogueItem);
 
-            actual.BackLinkText.Should().Be("Go back");
             actual.BackLink.Should().Be($"/admin/catalogue-solutions/manage/{catalogueItem.Id}");
             actual.CatalogueItemId.Should().Be(catalogueItem.Id);
             actual.SolutionName.Should().BeEquivalentTo(expected.SolutionName);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/ManageCatalogueSolutionModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/ManageCatalogueSolutionModelTests.cs
@@ -42,7 +42,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models
             List<AdditionalService> additionalServices,
             List<AssociatedService> associatedServices)
         {
-            var expected = new FeaturesModel().FromCatalogueItem(solution.CatalogueItem).Status();
+            var expected = new FeaturesModel(solution.CatalogueItem).Status();
             var model = new ManageCatalogueSolutionModel(
                 solution.CatalogueItem,
                 additionalServices.Select(a => a.CatalogueItem).ToList(),
@@ -96,7 +96,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models
             List<AdditionalService> additionalServices,
             List<AssociatedService> associatedServices)
         {
-            var expected = new RoadmapModel().FromCatalogueItem(solution.CatalogueItem).Status();
+            var expected = new RoadmapModel(solution.CatalogueItem).Status();
             var model = new ManageCatalogueSolutionModel(
                 solution.CatalogueItem,
                 additionalServices.Select(a => a.CatalogueItem).ToList(),

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/RoadmapModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/RoadmapModelTests.cs
@@ -40,15 +40,19 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models
             expected.SolutionId = catalogueItem.Id;
             expected.SolutionName = catalogueItem.Name;
 
-            var actual = new RoadmapModel().FromCatalogueItem(catalogueItem);
+            var actual = new RoadmapModel(catalogueItem);
 
-            actual.Should().BeEquivalentTo(expected);
+            actual.Should().BeEquivalentTo(
+                expected,
+                options => options
+                    .Excluding(rm => rm.BackLink)
+                    .Excluding(rm => rm.BackLinkText));
         }
 
         [Fact]
         public static void FromCatalogueItem_NullCatalogueItem_ThrowsException()
         {
-            var actual = Assert.Throws<ArgumentNullException>(() => new RoadmapModel().FromCatalogueItem(null));
+            var actual = Assert.Throws<ArgumentNullException>(() => new RoadmapModel(null));
 
             actual.ParamName.Should().Be("catalogueItem");
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/SupplierModels/EditSupplierAddressModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/SupplierModels/EditSupplierAddressModelTests.cs
@@ -17,15 +17,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.Supplier
             actual.ParamName.Should().Be("supplier");
         }
 
-        [Fact]
-        public static void ParameterlessConstructor_PropertiesSetAsExpected()
-        {
-            var actual = new EditSupplierAddressModel();
-
-            actual.BackLinkText.Should().Be("Go back");
-            actual.BackLink.Should().Be("./");
-        }
-
         [Theory]
         [CommonAutoData]
         public static void WithValidConstruction_PropertiesSetAsExpected(
@@ -43,8 +34,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.Supplier
             actual.PostCode.Should().Be(supplier.Address.Postcode);
             actual.Country.Should().Be(supplier.Address.Country);
 
-            actual.BackLinkText.Should().Be("Go back");
-            actual.BackLink.Should().Be("./");
             actual.SupplierName.Should().Be(supplier.Name);
         }
     }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AdditionalServiceRecipients/SelectAdditionalServiceRecipientsModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AdditionalServiceRecipients/SelectAdditionalServiceRecipientsModelTests.cs
@@ -21,7 +21,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Addition
             var model = new SelectAdditionalServiceRecipientsModel(odsCode, state, selectionMode);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{state.CallOffId}/additional-services/select/additional-service/price");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Service Recipients for {state.CatalogueItemName} for {state.CallOffId}");
             model.OdsCode.Should().Be(odsCode);
             model.CallOffId.Should().Be(state.CallOffId);
@@ -39,7 +38,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Addition
             var model = new SelectAdditionalServiceRecipientsModel(odsCode, state, selectionMode);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{state.CallOffId}/additional-services/{state.CatalogueItemId}");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Service Recipients for {state.CatalogueItemName} for {state.CallOffId}");
             model.OdsCode.Should().Be(odsCode);
             model.CallOffId.Should().Be(state.CallOffId);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AdditionalServiceRecipientsDate/SelectAdditionalServiceRecipientsDateModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AdditionalServiceRecipientsDate/SelectAdditionalServiceRecipientsDateModelTests.cs
@@ -21,7 +21,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Addition
             var model = new SelectAdditionalServiceRecipientsDateModel(odsCode, state, defaultDeliveryDate);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{state.CallOffId}/additional-services/select/additional-service/price/recipients");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Planned delivery date of {state.CatalogueItemName} for {state.CallOffId}");
             model.CommencementDate.Should().Be(state.CommencementDate);
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AdditionalServices/AdditionalServicesModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AdditionalServices/AdditionalServicesModelTests.cs
@@ -19,7 +19,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Addition
             var model = new AdditionalServiceModel(odsCode, order, orderItems);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{order.CallOffId}");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Additional Services for {order.CallOffId}");
             model.OdsCode.Should().Be(odsCode);
             model.OrderDescription.Should().Be(order.Description);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AdditionalServices/EditAdditionalServiceModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AdditionalServices/EditAdditionalServiceModelTests.cs
@@ -18,7 +18,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Addition
         {
             var model = new EditAdditionalServiceModel(odsCode, state);
 
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"{state.CatalogueItemName} information for {state.CallOffId}");
             model.OdsCode.Should().Be(odsCode);
             model.OrderItem.Should().Be(state);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AdditionalServices/NoAdditionalServicesFoundModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AdditionalServices/NoAdditionalServicesFoundModelTests.cs
@@ -17,7 +17,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Addition
             var model = new NoAdditionalServicesFoundModel(odsCode, callOffId);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{callOffId}");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be("No Additional Services found");
         }
     }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AdditionalServices/SelectAdditionalServiceModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AdditionalServices/SelectAdditionalServiceModelTests.cs
@@ -21,7 +21,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Addition
             var model = new SelectAdditionalServiceModel(odsCode, callOffId, solutions, selectedSolutionId);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{callOffId}/additional-services");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Add Additional Service for {callOffId}");
             model.OdsCode.Should().Be(odsCode);
             model.Solutions.Should().BeEquivalentTo(solutions);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AdditionalServices/SelectAdditionalServicePriceModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AdditionalServices/SelectAdditionalServicePriceModelTests.cs
@@ -24,7 +24,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Addition
             var model = new SelectAdditionalServicePriceModel(odsCode, callOffId, solutionName, prices);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{callOffId}/additional-services/select/additional-service");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"List price for {solutionName}");
             model.OdsCode.Should().Be(odsCode);
             model.Prices.Should().HaveCount(prices.Count);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AdditionalServices/SelectFlatDeclarativeQuantityModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AdditionalServices/SelectFlatDeclarativeQuantityModelTests.cs
@@ -19,7 +19,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Addition
             var model = new SelectFlatDeclarativeQuantityModel(odsCode, callOffId, solutionName, quantity);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{callOffId}/additional-services/select/additional-service/price/recipients/date");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Quantity of {solutionName} for {callOffId}");
             model.Quantity.Should().Be(quantity.ToString());
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AdditionalServices/SelectFlatOnDemandQuantityModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AdditionalServices/SelectFlatOnDemandQuantityModelTests.cs
@@ -21,7 +21,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Addition
             var model = new SelectFlatOnDemandQuantityModel(odsCode, callOffId, solutionName, quantity, estimationPeriod);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{callOffId}/additional-services/select/additional-service/price/recipients/date");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Quantity of {solutionName} for {callOffId}");
             model.OdsCode.Should().Be(odsCode);
             model.CallOffId.Should().Be(callOffId);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AssociatedServices/AssociatedServicesModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AssociatedServices/AssociatedServicesModelTests.cs
@@ -19,7 +19,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Associat
             var model = new AssociatedServiceModel(odsCode, order, orderItems);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{order.CallOffId}");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Associated Services for {order.CallOffId}");
             model.OdsCode.Should().Be(odsCode);
             model.OrderDescription.Should().Be(order.Description);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AssociatedServices/EditAssociatedServiceModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AssociatedServices/EditAssociatedServiceModelTests.cs
@@ -16,7 +16,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Associat
         {
             var model = new EditAssociatedServiceModel(odsCode, state);
 
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"{state.CatalogueItemName} associated service information for {state.CallOffId}");
             model.OdsCode.Should().Be(odsCode);
             model.OrderItem.Should().Be(state);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AssociatedServices/NoAssociatedServicesFoundModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AssociatedServices/NoAssociatedServicesFoundModelTests.cs
@@ -17,7 +17,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Associat
             var model = new NoAssociatedServicesFoundModel(odsCode, callOffId);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{callOffId}");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be("No Associated Services found");
         }
     }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AssociatedServices/SelectAssociatedServiceModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AssociatedServices/SelectAssociatedServiceModelTests.cs
@@ -21,7 +21,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Associat
             var model = new SelectAssociatedServiceModel(odsCode, callOffId, solutions, selectedSolutionId);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{callOffId}/associated-services");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Add Associated Service for {callOffId}");
             model.OdsCode.Should().Be(odsCode);
             model.Solutions.Should().BeEquivalentTo(solutions);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AssociatedServices/SelectAssociatedServicePriceModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/AssociatedServices/SelectAssociatedServicePriceModelTests.cs
@@ -24,7 +24,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Associat
             var model = new SelectAssociatedServicePriceModel(odsCode, callOffId, solutionName, prices);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{callOffId}/associated-services/select/associated-service");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"List price for {solutionName}");
             model.OdsCode.Should().Be(odsCode);
             model.Prices.Should().HaveCount(prices.Count);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/CatalogueSolutionRecipients/SelectSolutionServiceRecipientsModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/CatalogueSolutionRecipients/SelectSolutionServiceRecipientsModelTests.cs
@@ -21,7 +21,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Catalogu
             var model = new SelectSolutionServiceRecipientsModel(odsCode, state, selectionMode);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{state.CallOffId}/catalogue-solutions/select/solution/price");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Service Recipients for {state.CatalogueItemName} for {state.CallOffId}");
             model.OdsCode.Should().Be(odsCode);
             model.CallOffId.Should().Be(state.CallOffId);
@@ -39,7 +38,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Catalogu
             var model = new SelectSolutionServiceRecipientsModel(odsCode, state, selectionMode);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{state.CallOffId}/catalogue-solutions/{state.CatalogueItemId}");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Service Recipients for {state.CatalogueItemName} for {state.CallOffId}");
             model.OdsCode.Should().Be(odsCode);
             model.CallOffId.Should().Be(state.CallOffId);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/CatalogueSolutionRecipientsDate/SelectSolutionServiceRecipientsDateModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/CatalogueSolutionRecipientsDate/SelectSolutionServiceRecipientsDateModelTests.cs
@@ -21,7 +21,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Catalogu
             var model = new SelectSolutionServiceRecipientsDateModel(odsCode, state, defaultDeliveryDate);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{state.CallOffId}/catalogue-solutions/select/solution/price/recipients");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Planned delivery date of {state.CatalogueItemName} for {state.CallOffId}");
             model.CommencementDate.Should().Be(state.CommencementDate);
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/CatalogueSolutions/CatalogueSolutionsModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/CatalogueSolutions/CatalogueSolutionsModelTests.cs
@@ -19,7 +19,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Catalogu
             var model = new CatalogueSolutionsModel(odsCode, order, orderItems);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{order.CallOffId}");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Catalogue Solution for {order.CallOffId}");
             model.OdsCode.Should().Be(odsCode);
             model.OrderDescription.Should().Be(order.Description);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/CatalogueSolutions/EditSolutionModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/CatalogueSolutions/EditSolutionModelTests.cs
@@ -18,7 +18,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Catalogu
         {
             var model = new EditSolutionModel(odsCode, state);
 
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"{state.CatalogueItemName} information for {state.CallOffId}");
             model.OdsCode.Should().Be(odsCode);
             model.OrderItem.Should().Be(state);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/CatalogueSolutions/SelectFlatDeclarativeQuantityModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/CatalogueSolutions/SelectFlatDeclarativeQuantityModelTests.cs
@@ -19,7 +19,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Catalogu
             var model = new SelectFlatDeclarativeQuantityModel(odsCode, callOffId, solutionName, quantity);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{callOffId}/catalogue-solutions/select/solution/price/recipients/date");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Quantity of {solutionName} for {callOffId}");
             model.Quantity.Should().Be(quantity.ToString());
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/CatalogueSolutions/SelectFlatOnDemandQuantityModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/CatalogueSolutions/SelectFlatOnDemandQuantityModelTests.cs
@@ -21,7 +21,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Catalogu
             var model = new SelectFlatOnDemandQuantityModel(odsCode, callOffId, solutionName, quantity, estimationPeriod);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{callOffId}/catalogue-solutions/select/solution/price/recipients/date");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Quantity of {solutionName} for {callOffId}");
             model.OdsCode.Should().Be(odsCode);
             model.CallOffId.Should().Be(callOffId);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/CatalogueSolutions/SelectSolutionModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/CatalogueSolutions/SelectSolutionModelTests.cs
@@ -21,7 +21,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Catalogu
             var model = new SelectSolutionModel(odsCode, callOffId, solutions, selectedSolutionId);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{callOffId}/catalogue-solutions");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Add Catalogue Solution for {callOffId}");
             model.OdsCode.Should().Be(odsCode);
             model.Solutions.Should().BeEquivalentTo(solutions);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/CatalogueSolutions/SelectSolutionPriceModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/CatalogueSolutions/SelectSolutionPriceModelTests.cs
@@ -24,7 +24,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Catalogu
             var model = new SelectSolutionPriceModel(odsCode, callOffId, solutionName, prices);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{callOffId}/catalogue-solutions/select/solution");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"List price for {solutionName}");
             model.OdsCode.Should().Be(odsCode);
             model.Prices.Should().HaveCount(prices.Count);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/CommencementDate/CommencementDateModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/CommencementDate/CommencementDateModelTests.cs
@@ -20,7 +20,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Commence
             var model = new CommencementDateModel(odsCode, callOffId, commencementDate);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{callOffId}");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Commencement date for {callOffId}");
             model.OdsCode.Should().Be(odsCode);
             model.Day.Should().Be(commencementDate.Day.ToString("00"));

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/Dashboard/SelectOrganisationModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/Dashboard/SelectOrganisationModelTests.cs
@@ -20,7 +20,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Dashboar
             var model = new SelectOrganisationModel(currentOdsCode, organisations);
 
             model.BackLink.Should().Be($"/order/organisation/{currentOdsCode}");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be("Which organisation are you looking for?");
             model.AvailableOrganisations.Should().BeEquivalentTo(organisations);
             model.SelectedOrganisation.Should().Be(currentOdsCode);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/DeleteAdditionalService/DeleteAdditionalServiceModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/DeleteAdditionalService/DeleteAdditionalServiceModelTests.cs
@@ -20,7 +20,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.DeleteAd
             var model = new DeleteAdditionalServiceModel(odsCode, callOffId, catalogueItemId, solutionName, orderDescription);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{callOffId}/additional-services/{catalogueItemId}");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Delete {solutionName} from {callOffId}?");
             model.OdsCode.Should().Be(odsCode);
             model.CallOffId.Should().Be(callOffId);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/DeleteAssociatedService/DeleteAssociatedServiceModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/DeleteAssociatedService/DeleteAssociatedServiceModelTests.cs
@@ -20,7 +20,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.DeleteAs
             var model = new DeleteAssociatedServiceModel(odsCode, callOffId, catalogueItemId, solutionName, orderDescription);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{callOffId}/associated-services/{catalogueItemId}");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Delete {solutionName} from {callOffId}?");
             model.OdsCode.Should().Be(odsCode);
             model.CallOffId.Should().Be(callOffId);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/DeleteCatalogueSolution/DeleteSolutionModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/DeleteCatalogueSolution/DeleteSolutionModelTests.cs
@@ -20,7 +20,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.DeleteCa
             var model = new DeleteSolutionModel(odsCode, callOffId, catalogueItemId, solutionName, orderDescription);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{callOffId}/catalogue-solutions/{catalogueItemId}");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Delete {solutionName} from {callOffId}?");
             model.OdsCode.Should().Be(odsCode);
             model.CallOffId.Should().Be(callOffId);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/DeleteOrder/DeleteOrderModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/DeleteOrder/DeleteOrderModelTests.cs
@@ -16,7 +16,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.DeleteOr
             var model = new DeleteOrderModel(odsCode, order);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{order.CallOffId}");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Delete order {order.CallOffId}?");
             model.Description.Should().Be(order.Description);
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/FundingSource/FundingSourceModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/FundingSource/FundingSourceModelTests.cs
@@ -19,7 +19,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.FundingS
             var model = new FundingSourceModel(odsCode, callOffId, fundingSourceOnlyGms);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{callOffId}");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Funding source for {callOffId}");
             model.FundingSourceOnlyGms.Should().Be(fundingSourceOnlyGms.ToYesNo());
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/Order/SummaryModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/Order/SummaryModelTests.cs
@@ -15,8 +15,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Order
         {
             var model = new SummaryModel(odsCode, order);
 
-            model.BackLink.Should().Be("./");
-            model.BackLinkText.Should().Be("Go back");
             model.OdsCode.Should().Be(odsCode);
             model.Order.Should().BeEquivalentTo(order);
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/OrderDescription/OrderDescriptionModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/OrderDescription/OrderDescriptionModelTests.cs
@@ -15,8 +15,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.OrderDes
         {
             var model = new OrderDescriptionModel(odsCode, order);
 
-            model.BackLink.Should().Be("./");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be("Order description");
             model.Description.Should().Be(order.Description);
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/OrderingParty/OrderingPartyModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/OrderingParty/OrderingPartyModelTests.cs
@@ -18,7 +18,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Ordering
             var model = new OrderingPartyModel(odsCode, order, organisation);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{order.CallOffId}");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Call-off Ordering Party information for {order.CallOffId}");
             model.OdsCode.Should().Be(odsCode);
             model.OrganisationName.Should().Be(organisation.Name);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/Supplier/SupplierModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/Supplier/SupplierModelTests.cs
@@ -20,7 +20,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Supplier
             var model = new SupplierModel(odsCode, order, supplierContacts);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{order.CallOffId}");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Supplier information for {order.CallOffId}");
             model.OdsCode.Should().Be(odsCode);
             model.Id.Should().Be(order.Supplier.Id);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/Supplier/SupplierSearchModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/Supplier/SupplierSearchModelTests.cs
@@ -16,7 +16,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Supplier
             var model = new SupplierSearchModel(odsCode, order);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{order.CallOffId}");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be($"Find supplier information for {order.CallOffId}");
             model.OdsCode.Should().Be(odsCode);
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/Supplier/SupplierSearchSelectModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/Supplier/SupplierSearchSelectModelTests.cs
@@ -19,7 +19,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Supplier
             var model = new SupplierSearchSelectModel(odsCode, callOffId, suppliers);
 
             model.BackLink.Should().Be($"/order/organisation/{odsCode}/order/{callOffId}/supplier/search");
-            model.BackLinkText.Should().Be("Go back");
             model.Title.Should().Be("Suppliers found");
             model.OdsCode.Should().Be(odsCode);
             model.Suppliers.Should().BeEquivalentTo(suppliers);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Solutions/Controllers/SolutionsControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Solutions/Controllers/SolutionsControllerTests.cs
@@ -238,7 +238,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Controllers
 
             actual.Should().NotBeNull();
             actual.ViewName.Should().BeNullOrEmpty();
-            actual.Model.Should().BeEquivalentTo(capabilitiesViewModel);
+            actual.Model.Should().BeEquivalentTo(capabilitiesViewModel, opt => opt.Excluding(cvm => cvm.BackLink).Excluding(cvm => cvm.BackLinkText));
         }
 
         [Theory]
@@ -372,7 +372,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Controllers
             var capability = solution.CatalogueItemCapability(capabilityId);
 
             var expectedModel = new SolutionCheckEpicsModel(capability)
-                .WithSolutionName(solution.Name);
+            {
+                SolutionName = solution.Name,
+            };
 
             mockSolutionsService
                 .Setup(s => s.GetSolutionCapability(catalogueItemId, capabilityId))
@@ -382,7 +384,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Controllers
 
             actual.Should().NotBeNull();
             actual.ViewName.Should().BeNullOrEmpty();
-            actual.Model.Should().BeEquivalentTo(expectedModel);
+            actual.Model.Should().BeEquivalentTo(expectedModel, opt => opt.Excluding(em => em.BackLinkText).Excluding(em => em.BackLink));
         }
 
         [Theory]
@@ -427,7 +429,11 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Controllers
             var capability = additionalSolution.CatalogueItemCapability(capabilityId);
 
             var expectedModel = new SolutionCheckEpicsModel(capability)
-                .WithItems(catalogueItemId, catalogueItemIdAdditional, additionalSolution.Name);
+            {
+                SolutionName = additionalSolution.Name,
+                SolutionId = catalogueItemId,
+                CatalogueItemIdAdditional = catalogueItemIdAdditional,
+            };
 
             mockSolutionsService
                 .Setup(s => s.GetAdditionalServiceCapability(catalogueItemIdAdditional, capabilityId))
@@ -441,7 +447,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Controllers
 
             actual.Should().NotBeNull();
             actual.ViewName.Should().Be("CheckEpics");
-            actual.Model.Should().BeEquivalentTo(expectedModel);
+            actual.Model.Should().BeEquivalentTo(expectedModel, opt => opt.Excluding(em => em.BackLink).Excluding(em => em.BackLinkText));
         }
 
         [Theory]

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Solutions/Models/SolutionCheckEpicsModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Solutions/Models/SolutionCheckEpicsModelTests.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.Linq;
 using AutoFixture;
-using AutoFixture.Xunit2;
 using FluentAssertions;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
-using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations;
-using NHSD.GPIT.BuyingCatalogue.Test.Framework.TestData;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models;
 using Xunit;
@@ -119,44 +116,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Models
             model.HasSupplierDefined().Should().BeTrue();
             model.HasNhsDefined().Should().BeFalse();
             model.HasNoEpics().Should().BeFalse();
-        }
-
-        [Theory]
-        [CommonAutoData]
-        public static void WithItems_SetsCatalogueItemIdAdditional(
-            CatalogueItemId catalogueItemId,
-            CatalogueItemId catalogueItemIdAdditional,
-            string solutionName)
-        {
-            var model = new SolutionCheckEpicsModel();
-
-            var actual = model.WithItems(catalogueItemId, catalogueItemIdAdditional, solutionName);
-
-            actual.CatalogueItemIdAdditional.Should().Be(catalogueItemIdAdditional);
-        }
-
-        [Theory]
-        [AutoData]
-        public static void WithSolutionName_InputValid_SetsSolutionName(string solutionName)
-        {
-            var model = new SolutionCheckEpicsModel();
-
-            var actual = model.WithSolutionName(solutionName);
-
-            actual.SolutionName.Should().Be(solutionName);
-            actual.Should().BeEquivalentTo(new SolutionCheckEpicsModel { SolutionName = solutionName });
-        }
-
-        [Theory]
-        [MemberData(nameof(InvalidStringData.TestData), MemberType = typeof(InvalidStringData))]
-        public static void WithSolutionName_InputNotValid_SolutionNameNotChanged(string invalid)
-        {
-            const string expected = "some-solution-name";
-            var model = new SolutionCheckEpicsModel { SolutionName = expected };
-
-            model.WithSolutionName(invalid);
-
-            model.SolutionName.Should().Be(expected);
         }
     }
 }


### PR DESCRIPTION
Remove all unneeded setting of "Go back" LinkText

Remove all unneeded setting of "Save and Continue" Submit Button text.

Remove testing for "Go back" and "./" from unit tests that don't need them

Update RoadMapModel.cs, RoadMap.cshtml and controllers to set the go back url using Url.Action

Update RoadMapModel.cs to use constructors to set values instead of random functions.

Update FeaturesModel.cs, Features.cshtml and controllers to set the go back url using Url.Action.

Update FeatuesModel.cs to use constructor instead of random functions to set values

Update SolutionCheckEpicsModel.cs, Capabilities.cshtml, AdditionalCapabilities.cshtml and controllers to set go back url using Url.Action

Update tests for FeaturesModel.cs and RoadMapModel.cs to take into account the use of constructors.