### PR TITLE
development plans and standards marketing pages

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Catalogue/Models/CatalogueItem.partial.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Catalogue/Models/CatalogueItem.partial.cs
@@ -41,8 +41,6 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models
 
         public virtual bool HasClientApplication() => !string.IsNullOrWhiteSpace(Solution?.ClientApplication);
 
-        public virtual bool HasDevelopmentPlans() => !string.IsNullOrWhiteSpace(Solution?.RoadMap);
-
         public virtual bool HasFeatures() => !string.IsNullOrWhiteSpace(Solution?.Features);
 
         public virtual bool HasHosting() => Solution?.Hosting is not null;

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Solutions/ISolutionsService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Solutions/ISolutionsService.cs
@@ -67,5 +67,7 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions
         Task SavePublicationStatus(CatalogueItemId solutionId, PublicationStatus publicationStatus);
 
         Task SaveContacts(CatalogueItemId solutionId, IList<SupplierContact> supplierContacts);
+
+        Task<List<WorkOffPlan>> GetWorkOffPlans(CatalogueItemId solutionId);
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Solutions/SolutionsService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Solutions/SolutionsService.cs
@@ -83,6 +83,8 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Solutions
         {
             var requiredStandardsQuery = dbContext.Standards.Where(s => s.StandardType == StandardType.Overarching);
 
+            var capabilityStandards = dbContext.WorkOffPlans.Where(wp => wp.SolutionId == catalogueItemId).Select(wp => wp.Standard).Distinct();
+
             return await dbContext.CatalogueItems
                .Where(ci => ci.Id == catalogueItemId)
                .SelectMany(ci => ci.CatalogueItemCapabilities)
@@ -91,9 +93,8 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Solutions
                .Select(sc => sc.Standard)
                .Distinct()
                .Union(requiredStandardsQuery)
+               .Union(capabilityStandards)
                .ToListAsync();
-
-            // TODO : Add in Capability Standards when workoff plans is done.
         }
 
         public async Task<IList<Standard>> GetSolutionStandardsForEditing(CatalogueItemId catalogueItemId)
@@ -462,6 +463,11 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Solutions
 
             await dbContext.SaveChangesAsync();
         }
+
+        public async Task<List<WorkOffPlan>> GetWorkOffPlans(CatalogueItemId solutionId) =>
+            await dbContext.WorkOffPlans
+                .Include(wp => wp.Standard)
+                .Where(wp => wp.SolutionId == solutionId).ToListAsync();
 
         internal static ClientApplication RemoveClientApplicationType(ClientApplication clientApplication, ClientApplicationType clientApplicationType)
         {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/DevelopmentPlansController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/DevelopmentPlansController.cs
@@ -57,7 +57,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
 
             await developmentPlansService.SaveDevelopmentPlans(solutionId, model.Link);
 
-            return RedirectToAction(nameof(CatalogueSolutionsController.ManageCatalogueSolution), new { solutionId });
+            return RedirectToAction(
+                nameof(CatalogueSolutionsController.ManageCatalogueSolution),
+                typeof(CatalogueSolutionsController).ControllerName(),
+                new { solutionId });
         }
 
         [HttpGet("add-work-off-plan")]

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Controllers/SolutionsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Controllers/SolutionsController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
@@ -348,7 +349,21 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
 
             var standards = await solutionsService.GetSolutionStandardsForMarketing(solutionId);
 
-            return View(new SolutionStandardsModel(item, standards));
+            var standardsWithWorkOffPlans = (await solutionsService.GetWorkOffPlans(solutionId)).Select(wp => wp.StandardId);
+
+            return View(new SolutionStandardsModel(item, standards, standardsWithWorkOffPlans));
+        }
+
+        [HttpGet("{solutionId}/development-plans")]
+        public async Task<IActionResult> DevelopmentPlans(CatalogueItemId solutionId)
+        {
+            var item = await solutionsService.GetSolutionOverview(solutionId);
+            if (item is null)
+                return BadRequest($"No Catalogue Item found for Id: {solutionId}");
+
+            var workOffPlans = await solutionsService.GetWorkOffPlans(solutionId);
+
+            return View(new DevelopmentPlansModel(item, workOffPlans));
         }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/DevelopmentPlansModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/DevelopmentPlansModel.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
+{
+    public sealed class DevelopmentPlansModel : SolutionDisplayBaseModel
+    {
+        public DevelopmentPlansModel(CatalogueItem catalogueItem, IList<WorkOffPlan> workoffPlans)
+                : base(catalogueItem)
+        {
+            WorkOffPlans = workoffPlans;
+            RoadmapLink = catalogueItem.Solution.RoadMap;
+        }
+
+        public DevelopmentPlansModel()
+        {
+        }
+
+        public override int Index => 12;
+
+        public string RoadmapLink { get; init; }
+
+        public IList<WorkOffPlan> WorkOffPlans { get; init; }
+    }
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/SolutionDisplayBaseModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/SolutionDisplayBaseModel.cs
@@ -177,10 +177,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
                 },
                 new()
                 {
-                    Action = nameof(SolutionsController.Description),
+                    Action = nameof(SolutionsController.DevelopmentPlans),
                     Controller = ControllerName,
                     Name = "Development plans",
-                    Show = catalogueItem.HasDevelopmentPlans(),
+                    Show = true,
                 },
                 new()
                 {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/SolutionStandardsModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/SolutionStandardsModel.cs
@@ -5,10 +5,11 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
 {
     public sealed class SolutionStandardsModel : SolutionDisplayBaseModel
     {
-        public SolutionStandardsModel(CatalogueItem catalogueItem, IList<Standard> standards)
+        public SolutionStandardsModel(CatalogueItem catalogueItem, IList<Standard> standards, IEnumerable<string> standardsWithWorkOffPlans)
             : base(catalogueItem)
         {
             Standards = standards;
+            StandardsWithWorkOffPlans = standardsWithWorkOffPlans;
         }
 
         public SolutionStandardsModel()
@@ -18,5 +19,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
         public override int Index => 3;
 
         public IList<Standard> Standards { get; init; }
+
+        public IEnumerable<string> StandardsWithWorkOffPlans { get; init; }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/DevelopmentPlans.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/DevelopmentPlans.cshtml
@@ -1,0 +1,49 @@
+﻿@using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models
+@using System.Linq;
+@model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models.DevelopmentPlansModel;
+@{ 
+    var roadmapTitle = string.IsNullOrWhiteSpace(Model.RoadmapLink) ? "Roadmap" : "Roadmaps";
+
+    var standardsInOrder = Model.WorkOffPlans.Select(wp => wp.Standard).Distinct().OrderBy(s => s.Name);
+}
+
+<b>These are the development plans for this Catalogue Solution:</b>
+<br/>
+<br/>
+<h2>@roadmapTitle</h2>
+@if (!string.IsNullOrWhiteSpace(Model.RoadmapLink))
+{
+    <p>The supplier has provided a roadmap detailing the development plans for this Catalogue Solution.</p>
+    <p><a href="@Model.RoadmapLink" target="_blank">View supplier’s roadmap for this Catalogue Solution</a>(opens in a new tab)</p>
+}
+<p>The GP IT Futures Capabilities and Standards roadmap outlines future changes to the Capabilities and Standards model.</p>
+<p><a href="https://gpitbjss.atlassian.net/wiki/spaces/GPITF/pages/1391133519/Roadmap" target="_blank">View GP IT Futures Capabilities and Standards roadmap</a>(opens in a new tab)</p>
+
+@if (Model.WorkOffPlans.Any()) 
+{ 
+    <h2>Work-off Plans</h2>
+    <p>This Catalogue Solution is subject to a Compliance Work-off Plan. It means the supplier has agreed to complete any outstanding work to meet a Standard within an agreed timeframe.</p>
+    <p><a href="https://gpitbjss.atlassian.net/wiki/spaces/GPITF/pages/1391134310/Introduction+to+Capabilities+and+Standards" target="_blank">More information about these requirements</a></p>
+    <hr/>
+
+    @foreach(var standard in standardsInOrder)
+    {
+        <h3 id="@standard.Id">@standard.Name</h3>
+        <p><b>Description: </b>@standard.Description</p>
+        <p><a href="@standard.Url" target="_blank">More information about this Standard</a>(opens in a new tab)</p>
+        <p>The supplier is working towards full compliance with this Standard and has the following Work-off Plan items:</p>
+
+        <nhs-table>
+            <nhs-table-column>Details</nhs-table-column>
+            <nhs-table-column>Agreed&nbsp;completion&nbsp;date</nhs-table-column>
+            @foreach(var workOffPlan in Model.WorkOffPlans.Where(wp => wp.StandardId == standard.Id).OrderBy(wp => wp.CompletionDate).ThenBy(wp => wp.Details))
+            {
+                <nhs-table-row-container>
+                    <nhs-table-cell>@workOffPlan.Details</nhs-table-cell>
+                    <nhs-table-cell>@workOffPlan.CompletionDate.ToShortDateString()</nhs-table-cell>
+                </nhs-table-row-container>
+            }
+        </nhs-table>
+        <br/>
+    }
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/Standards.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/Standards.cshtml
@@ -1,4 +1,6 @@
 ﻿@using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models
+@using NHSD.GPIT.BuyingCatalogue.Framework.Extensions 
+@using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers 
 @model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models.SolutionStandardsModel
 
 <p><b>Standards describe the technical specifications or operating conditions required for a Catalogue Solution to be published on the Buying Catalogue. This is how @Model.SolutionName has performed against the relevant Standards:</b></p>
@@ -22,8 +24,21 @@
         <nhs-table-row-container>
             <nhs-table-cell>@standard.Name</nhs-table-cell>
             <nhs-table-cell>@standard.Description <a href="@standard.Url">More information about this Standard</a></nhs-table-cell>
-            <nhs-table-cell><nhs-tag colour="Green" text="Fully&nbsp;met" /></nhs-table-cell>
-            <nhs-table-cell></nhs-table-cell>
+            @if (Model.StandardsWithWorkOffPlans.Any(swp => swp == standard.Id))
+            {
+                <nhs-table-cell><nhs-tag colour="Yellow" text="In&nbsp;Progress" /></nhs-table-cell>
+                <nhs-table-cell>
+                    <a asp-action="@nameof(SolutionsController.DevelopmentPlans)"
+                       asp-controller="@typeof(SolutionsController).ControllerName()"
+                       asp-route-solutionId="@Model.SolutionId"
+                       asp-fragment="@standard.Id">View&nbsp;details</a>
+                </nhs-table-cell>
+            }
+            else
+            {
+                <nhs-table-cell><nhs-tag colour="Green" text="Fully&nbsp;met" /></nhs-table-cell>
+                <nhs-table-cell></nhs-table-cell>
+            }
         </nhs-table-row-container>
     }
 </nhs-table>
@@ -49,8 +64,21 @@
             <nhs-table-row-container>
                 <nhs-table-cell>@standard.Name</nhs-table-cell>
                 <nhs-table-cell>@standard.Description <a href="@standard.Url">More information about this Standard</a></nhs-table-cell>
-                <nhs-table-cell><nhs-tag colour="Green" text="Fully&nbsp;met" /></nhs-table-cell>
-                <nhs-table-cell></nhs-table-cell>
+                @if (Model.StandardsWithWorkOffPlans.Any(swp => swp == standard.Id))
+                {
+                    <nhs-table-cell><nhs-tag colour="Yellow" text="In&nbsp;Progress" /></nhs-table-cell>
+                    <nhs-table-cell>
+                        <a asp-action="@nameof(SolutionsController.DevelopmentPlans)"
+                           asp-controller="@typeof(SolutionsController).ControllerName()"
+                           asp-route-solutionId="@Model.SolutionId"
+                           asp-fragment="@standard.Id">View&nbsp;details</a>
+                    </nhs-table-cell>
+                }
+                else
+                {
+                    <nhs-table-cell><nhs-tag colour="Green" text="Fully&nbsp;met" /></nhs-table-cell>
+                    <nhs-table-cell></nhs-table-cell>
+                }
             </nhs-table-row-container>
         }
     </nhs-table>
@@ -77,8 +105,19 @@
             <nhs-table-row-container>
                 <nhs-table-cell>@standard.Name</nhs-table-cell>
                 <nhs-table-cell>@standard.Description <a href="@standard.Url">More information about this Standard</a></nhs-table-cell>
-                <nhs-table-cell><nhs-tag colour="Green" text="Fully&nbsp;met" /></nhs-table-cell>
-                <nhs-table-cell></nhs-table-cell>
+                @if (Model.StandardsWithWorkOffPlans.Any(swp => swp == standard.Id))
+                {
+                    <nhs-table-cell><nhs-tag colour="Yellow" text="In&nbsp;Progress" /></nhs-table-cell>
+                    <nhs-table-cell><a asp-action="@nameof(SolutionsController.DevelopmentPlans)"
+                                       asp-controller="@typeof(SolutionsController).ControllerName()"
+                                       asp-route-solutionId="@Model.SolutionId"
+                                       asp-fragment="@standard.Id">View&nbsp;details</a></nhs-table-cell>
+                }
+                else
+                {
+                    <nhs-table-cell><nhs-tag colour="Green" text="Fully&nbsp;met" /></nhs-table-cell>
+                    <nhs-table-cell></nhs-table-cell>
+                }
             </nhs-table-row-container>
         }
     </nhs-table>

--- a/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/Models/BuyingCatalogue/CatalogueItemTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/Models/BuyingCatalogue/CatalogueItemTests.cs
@@ -414,38 +414,6 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests.Models.BuyingCatal
 
         [Theory]
         [CommonAutoData]
-        public static void HasDevelopmentPlans_SolutionHasDevelopmentPlans_ReturnsTrue(Solution solution)
-        {
-            solution.RoadMap.Should().NotBeNullOrWhiteSpace();
-
-            var actual = solution.CatalogueItem.HasDevelopmentPlans();
-
-            actual.Should().BeTrue();
-        }
-
-        [Theory]
-        [MemberData(nameof(InvalidStringData.TestData), MemberType = typeof(InvalidStringData))]
-        public static void HasDevelopmentPlans_SolutionHasInvalidDevelopmentPlans_ReturnsFalse(string invalid)
-        {
-            var catalogueItem = new CatalogueItem { Solution = new Solution { RoadMap = invalid } };
-
-            var actual = catalogueItem.HasDevelopmentPlans();
-
-            actual.Should().BeFalse();
-        }
-
-        [Fact]
-        public static void HasDevelopmentPlans_SolutionHasIsNull_ReturnsFalse()
-        {
-            var catalogueItem = new CatalogueItem { Solution = null };
-
-            var actual = catalogueItem.HasDevelopmentPlans();
-
-            actual.Should().BeFalse();
-        }
-
-        [Theory]
-        [CommonAutoData]
         public static void HasFeatures_SolutionHasFeatures_ReturnsTrue(Solution solution)
         {
             solution.Features.Should().NotBeNullOrWhiteSpace();

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/DevelopmentPlansControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/DevelopmentPlansControllerTests.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 using Moq;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.DevelopmentPlans;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions;
 using NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations;
@@ -90,7 +91,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             var actual = (await controller.DevelopmentPlans(catalogueItemId, model)).As<RedirectToActionResult>();
 
             actual.ActionName.Should().Be(nameof(CatalogueSolutionsController.ManageCatalogueSolution));
-            actual.ControllerName.Should().BeNull();
+            actual.ControllerName.Should().Be(typeof(CatalogueSolutionsController).ControllerName());
             actual.RouteValues["solutionId"].Should().Be(catalogueItemId);
         }
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Solutions/Controllers/SolutionsControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Solutions/Controllers/SolutionsControllerTests.cs
@@ -289,13 +289,15 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Controllers
         {
             solution.CatalogueItem.PublishedStatus = PublicationStatus.Published;
 
-            var solutionStandardsModel = new SolutionStandardsModel(solution.CatalogueItem, standards);
+            var solutionStandardsModel = new SolutionStandardsModel(solution.CatalogueItem, standards, new List<string>());
 
             mockService.Setup(s => s.GetSolutionOverview(solution.CatalogueItemId))
                 .ReturnsAsync(solution.CatalogueItem);
 
             mockService.Setup(s => s.GetSolutionStandardsForMarketing(solution.CatalogueItemId))
                 .ReturnsAsync(standards);
+
+            mockService.Setup(s => s.GetWorkOffPlans(solution.CatalogueItemId)).ReturnsAsync(new List<WorkOffPlan>());
 
             var actual = (await controller.Standards(solution.CatalogueItemId)).As<ViewResult>();
 


### PR DESCRIPTION
Update Standards Marketing Page to link to the Development Plans Page if a work-off plan exists

Add service endpoint to get work-off plans

fix development plans to always show in marketing page

Update standardsformarketing endpoint to include the standards referenced by the work-off plans.

fix tests