### PR TITLE
Kirsty Requests - Round 2

### DIFF
--- a/database/NHSD.GPITBuyingCatalogue.Database/Catalogue/Tables/CatalogueItems.sql
+++ b/database/NHSD.GPITBuyingCatalogue.Database/Catalogue/Tables/CatalogueItems.sql
@@ -15,6 +15,5 @@
     CONSTRAINT FK_CatalogueItems_CatalogueItemType FOREIGN KEY (CatalogueItemTypeId) REFERENCES catalogue.CatalogueItemTypes(Id),
     CONSTRAINT FK_CatalogueItems_Supplier FOREIGN KEY (SupplierId) REFERENCES catalogue.Suppliers(Id),
     CONSTRAINT FK_CatalogueItems_PublicationStatus FOREIGN KEY (PublishedStatusId) REFERENCES catalogue.PublicationStatus(Id),
-    CONSTRAINT AK_CatalogueItems_Supplier_Name UNIQUE (SupplierId, [Name]),
     CONSTRAINT FK_CatalogueItems_LastUpdatedBy FOREIGN KEY (LastUpdatedBy) REFERENCES users.AspNetUsers(Id),
 ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = catalogue.CatalogueItems_History));

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/AdditionalServices/IAdditionalServicesService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/AdditionalServices/IAdditionalServicesService.cs
@@ -14,6 +14,11 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.AdditionalServices
 
         Task<List<CatalogueItem>> GetAdditionalServicesBySolutionIds(IEnumerable<CatalogueItemId> solutionIds);
 
+        Task<bool> AdditionalServiceExistsWithNameForSolution(
+            string additionalServiceName,
+            CatalogueItemId solutionId,
+            CatalogueItemId currentCatalogueItemId = default);
+
         Task<CatalogueItemId> AddAdditionalService(CatalogueItem solution, AdditionalServicesDetailsModel model);
 
         Task EditAdditionalService(CatalogueItemId catalogueItemId, CatalogueItemId additionalServiceId, AdditionalServicesDetailsModel model);

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/AssociatedServices/IAssociatedServicesService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/AssociatedServices/IAssociatedServicesService.cs
@@ -12,6 +12,11 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.AssociatedServices
 
         Task<CatalogueItem> GetAssociatedService(CatalogueItemId associatedServiceId);
 
+        Task<bool> AssociatedServiceExistsWithNameForSupplier(
+            string additionalServiceName,
+            int supplierId,
+            CatalogueItemId currentCatalogueItemId = default);
+
         Task RelateAssociatedServicesToSolution(CatalogueItemId solutionId, IEnumerable<CatalogueItemId> associatedServices);
 
         Task EditDetails(CatalogueItemId associatedServiceId, AssociatedServicesDetailsModel model);

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Solutions/ISolutionsService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Solutions/ISolutionsService.cs
@@ -14,6 +14,8 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions
 
         Task<CatalogueItem> GetSolutionByName(string solutionName);
 
+        Task<bool> CatalogueSolutionExistsWithName(string solutionName, CatalogueItemId currentCatalogueItemId = default);
+
         Task<CatalogueItem> GetSolutionCapability(CatalogueItemId catalogueItemId, int capabilityId);
 
         Task<IList<Standard>> GetSolutionStandardsForMarketing(CatalogueItemId catalogueItemId);

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/AdditionalServices/AdditionalServicesService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/AdditionalServices/AdditionalServicesService.cs
@@ -83,6 +83,19 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.AdditionalServices
                 .ToListAsync();
         }
 
+        // checks to see if this additional services' name is unique for this solution
+        public Task<bool> AdditionalServiceExistsWithNameForSolution(
+            string additionalServiceName,
+            CatalogueItemId solutionId,
+            CatalogueItemId currentCatalogueItemId = default) =>
+            dbContext
+                .AdditionalServices
+                .AnyAsync(add =>
+                    add.CatalogueItem.CatalogueItemType == CatalogueItemType.AdditionalService
+                    && add.SolutionId == solutionId
+                    && add.CatalogueItem.Name == additionalServiceName
+                    && add.CatalogueItemId != currentCatalogueItemId);
+
         public async Task SavePublicationStatus(
             CatalogueItemId catalogueItemId,
             CatalogueItemId additionalServiceId,

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/AssociatedServices/AssociatedServicesService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/AssociatedServices/AssociatedServicesService.cs
@@ -44,6 +44,19 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.AssociatedServices
                 .FirstOrDefaultAsync();
         }
 
+        // checks to see if this associated services' name is unique for the supplier
+        public Task<bool> AssociatedServiceExistsWithNameForSupplier(
+            string additionalServiceName,
+            int supplierId,
+            CatalogueItemId currentCatalogueItemId = default) =>
+            dbContext
+                .AssociatedServices
+                .AnyAsync(asoc =>
+                    asoc.CatalogueItem.CatalogueItemType == CatalogueItemType.AssociatedService
+                    && asoc.CatalogueItem.SupplierId == supplierId
+                    && asoc.CatalogueItem.Name == additionalServiceName
+                    && asoc.CatalogueItemId != currentCatalogueItemId);
+
         public async Task RelateAssociatedServicesToSolution(
             CatalogueItemId solutionId,
             IEnumerable<CatalogueItemId> associatedServices)
@@ -56,10 +69,10 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.AssociatedServices
             solution.SupplierServiceAssociations.Clear();
 
             solution.SupplierServiceAssociations = associatedServices.Select(a => new SupplierServiceAssociation
-                {
-                    CatalogueItemId = solutionId,
-                    AssociatedServiceId = a,
-                }).ToList();
+            {
+                CatalogueItemId = solutionId,
+                AssociatedServiceId = a,
+            }).ToList();
 
             await dbContext.SaveChangesAsync();
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Solutions/SolutionsService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Solutions/SolutionsService.cs
@@ -70,6 +70,15 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Solutions
                 .FirstOrDefaultAsync();
         }
 
+        // checks to see if this catalogue solutions' name is globally unique
+        public Task<bool> CatalogueSolutionExistsWithName(string solutionName, CatalogueItemId currentCatalogueItemId = default) =>
+            dbContext
+                .CatalogueItems
+                .AnyAsync(ci =>
+                ci.CatalogueItemType == CatalogueItemType.Solution
+                && ci.Name == solutionName
+                && ci.Id != currentCatalogueItemId);
+
         public async Task<CatalogueItem> GetSolutionCapability(CatalogueItemId catalogueItemId, int capabilityId)
         {
             return await dbContext.CatalogueItems

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AddCatalogueSolutionController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AddCatalogueSolutionController.cs
@@ -41,7 +41,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
         [HttpPost]
         public async Task<IActionResult> Index(SolutionModel model)
         {
-            if (await solutionsService.GetSolutionByName(model.SolutionName) is not null)
+            if (await solutionsService.CatalogueSolutionExistsWithName(model.SolutionName))
                 ModelState.AddModelError(nameof(SolutionModel.SolutionName), "A solution with this name already exists");
 
             if (!ModelState.IsValid)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AssociatedServicesController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AssociatedServicesController.cs
@@ -78,8 +78,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
         [HttpPost("add-associated-service")]
         public async Task<IActionResult> AddAssociatedService(CatalogueItemId solutionId, AddAssociatedServiceModel model)
         {
-            if ((await suppliersService.GetAllSolutionsForSupplier(solutionId.SupplierId))
-                .Any(ci => ci.Name.Equals(model.Name, StringComparison.CurrentCultureIgnoreCase)))
+            if (await associatedServicesService.AssociatedServiceExistsWithNameForSupplier(model.Name, solutionId.SupplierId))
                 ModelState.AddModelError(nameof(AddAssociatedServiceModel.Name), "Associated Service name already exists. Enter a different name");
 
             var solution = await solutionsService.GetSolution(solutionId);
@@ -152,8 +151,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             if (associatedService is null)
                 return BadRequest($"No Associated Service found for Id: {associatedServiceId}");
 
-            if ((await suppliersService.GetAllSolutionsForSupplier(associatedServiceId.SupplierId))
-                .Any(ci => ci.Id != associatedServiceId && ci.Name.Equals(model.Name, StringComparison.CurrentCultureIgnoreCase)))
+            if (await associatedServicesService.AssociatedServiceExistsWithNameForSupplier(model.Name, solutionId.SupplierId, associatedServiceId))
                 ModelState.AddModelError(nameof(AddAssociatedServiceModel.Name), "Associated Service name already exists. Enter a different name");
 
             if (!ModelState.IsValid)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/CatalogueSolutionsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/CatalogueSolutionsController.cs
@@ -168,9 +168,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
         [HttpPost("manage/{solutionId}/details")]
         public async Task<IActionResult> Details(CatalogueItemId solutionId, SolutionModel model)
         {
-            var existingSolution = await solutionsService.GetSolutionByName(model.SolutionName);
-
-            if (existingSolution is not null && existingSolution.Id != solutionId)
+            if (await solutionsService.CatalogueSolutionExistsWithName(model.SolutionName, solutionId))
                 ModelState.AddModelError(nameof(SolutionModel.SolutionName), "A solution with this name already exists");
 
             if (!ModelState.IsValid)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/CapabilityModels/EditCapabilitiesModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/CapabilityModels/EditCapabilitiesModel.cs
@@ -40,8 +40,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.CapabilityModels
                         Selected = catalogueItem.CatalogueItemEpics
                             .Where(itemEpic => itemEpic.CapabilityId == c.Id)
                             .Any(itemEpic => string.Equals(itemEpic.EpicId, epic.Id, StringComparison.CurrentCultureIgnoreCase)),
-                    }).OrderBy(e => e.Name).ToList(),
-                }).OrderBy(c => c.Name).ToList(),
+                    }).OrderBy(e => e.Id).ToList(),
+                }).OrderBy(c => c.Id).ToList(),
             }).OrderBy(cc => cc.Name).ToList();
         }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ServiceLevelAgreements/AddEditServiceLevelModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ServiceLevelAgreements/AddEditServiceLevelModel.cs
@@ -37,6 +37,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ServiceLevelAgreem
 
         public int? ServiceLevelId { get; init; }
 
+        [StringLength(100)]
         public string ServiceType { get; init; }
 
         [StringLength(1000)]

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Validators/EditAdditionalServiceDetailsModelValidator.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Validators/EditAdditionalServiceDetailsModelValidator.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using FluentValidation;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.AdditionalServices;
@@ -34,12 +32,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Validators
 
         private async Task<bool> NotBeADuplicateService(EditAdditionalServiceDetailsModel model, CancellationToken cancellationToken)
         {
-            var allSolutions = await additionalServicesService.GetAdditionalServicesBySolutionId(model.CatalogueItemId);
-
-            if (model.Id is not null)
-                allSolutions = allSolutions.Where(s => s.Id != model.Id).ToList();
-
-            return !allSolutions.Any(s => string.Equals(s.Name, model.Name, StringComparison.CurrentCultureIgnoreCase));
+            return !await additionalServicesService.AdditionalServiceExistsWithNameForSolution(model.Name, model.CatalogueItemId);
         }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Validators/EditListPriceModelValidator.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Validators/EditListPriceModelValidator.cs
@@ -23,7 +23,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Validators
                 .Cascade(CascadeMode.Stop)
                 .NotNull()
                 .WithMessage("Enter a price")
-                .GreaterThan(0)
+                .GreaterThanOrEqualTo(0)
                 .WithMessage("Price cannot be negative")
                 .Must(p => Regex.IsMatch(p.ToString(), @"^\d+.?\d{0,4}$"))
                 .WithMessage("Price must be to a maximum of 4 decimal places");

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ServiceLevelAgreements/AddEditServiceLevel.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ServiceLevelAgreements/AddEditServiceLevel.cshtml
@@ -21,17 +21,16 @@
             <input type="hidden" asp-for="BackLink" />
             <nhs-input asp-for="ServiceType"
                        label-text="Type of service"
-                       label-hint="For example, permitted downtime, incident response or escalation and complaints management." />
+                       label-hint="For example, permitted downtime, incident response or escalation and complaints management."
+                       character-count="true"/>
 
             <nhs-textarea asp-for="ServiceLevel"
                           label-text="Service level"
-                          label-hint="For example, how quickly you’ll respond to incidents or how much downtime is permitted."
-                          character-count="false" />
+                          label-hint="For example, how quickly you’ll respond to incidents or how much downtime is permitted." />
 
             <nhs-textarea asp-for="HowMeasured"
                           label-text="How the service levels are measured"
-                          label-hint="For example, how you show that the service levels have or have not been met."
-                          character-count="false" />
+                          label-hint="For example, how you show that the service levels have or have not been met." />
 
             <nhs-fieldset-form-label asp-for="@Model"
                                      label-text="Are service credits applied?"

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AssociatedServices/EditAssociatedServiceDetails.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AssociatedServices/EditAssociatedServiceDetails.cs
@@ -19,6 +19,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.Associat
 
         private static readonly CatalogueItemId AssociatedServiceId = new(99999, "S-999");
 
+        private static readonly CatalogueItemId ExistingAssociatedServiceId = new(99999, "S-998");
+
         private static readonly Dictionary<string, string> Parameters = new()
         {
             { nameof(SolutionId), SolutionId.ToString() },
@@ -85,14 +87,12 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.Associat
         public async Task EditAssociatedServiceDetails_DuplicateNameOfService()
         {
             await using var context = GetEndToEndDbContext();
-            var catalogueItems = await context.CatalogueItems
-                .Where(ci => ci.SupplierId == AssociatedServiceId.SupplierId
-                && ci.Id != AssociatedServiceId)
-                .ToListAsync();
 
-            var name = catalogueItems.OrderBy(_ => Guid.NewGuid()).First().Name;
+            var existingAssociatedService = await context
+                .CatalogueItems
+                .SingleOrDefaultAsync(ci => ci.Id == ExistingAssociatedServiceId);
 
-            CommonActions.ClearInputElement(CommonSelectors.Name);
+            var name = existingAssociatedService.Name;
 
             CommonActions.ElementAddValue(CommonSelectors.Name, name);
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/AddCatalogueSolutionControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/AddCatalogueSolutionControllerTests.cs
@@ -100,8 +100,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
 
             model.Frameworks = frameworks;
 
-            mockService.Setup(s => s.GetSolutionByName(It.IsAny<string>()))
-                .ReturnsAsync(existingSolution);
+            mockService.Setup(s => s.CatalogueSolutionExistsWithName(It.IsAny<string>(), default))
+                .ReturnsAsync(true);
 
             mockSuppliersService.Setup(s => s.GetAllActiveSuppliers())
                 .ReturnsAsync(suppliers);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/AssociatedServicesControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/AssociatedServicesControllerTests.cs
@@ -353,7 +353,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
         [Theory]
         [CommonAutoData]
         public static async Task Post_EditAssociatedServiceDetails_MatchingName_ReturnsModelError(
-            [Frozen] Mock<ISuppliersService> mockSupplierService,
             [Frozen] Mock<ISolutionsService> mockSolutionService,
             [Frozen] Mock<IAssociatedServicesService> mockAssociatedServicesService,
             AssociatedServicesController controller,
@@ -367,15 +366,18 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
                     .ReturnsAsync(solution);
 
             var catalogueItem = associatedService.CatalogueItem;
+
             mockAssociatedServicesService.Setup(s => s.GetAssociatedService(associatedServiceId))
                 .ReturnsAsync(catalogueItem);
+
+            mockAssociatedServicesService.Setup(s =>
+                s.AssociatedServiceExistsWithNameForSupplier(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CatalogueItemId>()))
+                .ReturnsAsync(true);
 
             var model = new EditAssociatedServiceDetailsModel(solution, catalogueItem);
 
             item.Id = solutionId;
             item.Name = model.Name;
-
-            mockSupplierService.Setup(s => s.GetAllSolutionsForSupplier(associatedServiceId.SupplierId)).ReturnsAsync(new List<CatalogueItem> { item });
 
             var actual = await controller.EditAssociatedServiceDetails(solutionId, associatedServiceId, model);
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Validators/EditAdditionalServiceDetailsModelValidatorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Validators/EditAdditionalServiceDetailsModelValidatorTests.cs
@@ -4,6 +4,7 @@ using AutoFixture.Xunit2;
 using FluentValidation.TestHelper;
 using Moq;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.AdditionalServices;
 using NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.AdditionalServices;
@@ -68,8 +69,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Validators
         {
             var additionalService = solution.AdditionalServices.First();
             var additionalServiceCatalogueItem = additionalService.CatalogueItem;
-            additionalServicesService.Setup(s => s.GetAdditionalServicesBySolutionId(solution.CatalogueItemId))
-                .ReturnsAsync(solution.AdditionalServices.Select(a => a.CatalogueItem).ToList());
+
+            additionalServicesService.Setup(s =>
+                s.AdditionalServiceExistsWithNameForSolution(It.IsAny<string>(), It.IsAny<CatalogueItemId>(), It.IsAny<CatalogueItemId>()))
+                    .ReturnsAsync(true);
 
             var model = new EditAdditionalServiceDetailsModel(solution.CatalogueItem, additionalServiceCatalogueItem)
             {


### PR DESCRIPTION
Change Capabilities in Edit Capabilities section to be ordered by their key (same with epics but its a dual data issue) - Change is made to EditCapabilitiesModel.cs

Fix SLA Service Levels to show the Character Counter and Restrict the type input box to 100 characters. Changes made to AddEditServiceLevel.cshtml

Change how name restrictions work in catalogue Items.
Catalogue Solution names should be globally unique.
Additional Services names should be unique within their parent solution
Associated Services names should be unique within their supplier.

To accomplish this, i had to remove the DB constraint tying catalogue item names to suppliers (since this is not the correct case)

I've then updated all the Cat/Add/Asoc solution Adding/Editing to follow the above rules.

Fix Unit/E2E tests for duplicate Cat/Add/Asoc Solutions.