### PR TITLE
Fix Check Epics Capability link

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Controllers/SolutionsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Controllers/SolutionsController.cs
@@ -172,13 +172,12 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
 
             var solutionCapability = item.CatalogueItemCapability(capabilityId);
 
-            var model = new SolutionCheckEpicsModel(solutionCapability)
+            var model = new SolutionCheckEpicsModel(solutionCapability, item)
             {
                 BackLink = Url.Action(
                     nameof(Capabilities),
                     typeof(SolutionsController).ControllerName(),
                     new { solutionId }),
-                SolutionName = item.Name,
             };
 
             return View(model);
@@ -203,11 +202,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
                 return RedirectToAction(nameof(Description), new { solutionId });
 
             var solutionCapability = item.CatalogueItemCapability(capabilityId);
-            var model = new SolutionCheckEpicsModel(solutionCapability)
+            var model = new SolutionCheckEpicsModel(solutionCapability, item, additionalServiceId)
             {
-                SolutionName = item.Name,
-                SolutionId = solutionId,
-                CatalogueItemIdAdditional = additionalServiceId,
                 BackLink = Url.Action(
                     nameof(CapabilitiesAdditionalServices),
                     typeof(SolutionsController).ControllerName(),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/SolutionCheckEpicsModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/SolutionCheckEpicsModel.cs
@@ -13,7 +13,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
         {
         }
 
-        public SolutionCheckEpicsModel(CatalogueItemCapability solutionCapability)
+        public SolutionCheckEpicsModel(CatalogueItemCapability solutionCapability, CatalogueItem catalogueItem)
         {
             Description = solutionCapability.Capability?.Description;
             Name = solutionCapability.Capability?.Name;
@@ -21,23 +21,37 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
             NhsDefined = GetEpics(solutionCapability.Capability, false);
             SupplierDefined = GetEpics(solutionCapability.Capability, true);
             LastReviewed = solutionCapability.LastUpdated;
+            SolutionName = catalogueItem.Name;
+            SolutionId = catalogueItem.Id;
+            Url = solutionCapability.Capability.SourceUrl;
         }
 
-        public CatalogueItemId CatalogueItemIdAdditional { get; set; }
+        public SolutionCheckEpicsModel(
+            CatalogueItemCapability solutionCapability,
+            CatalogueItem catalogueItem,
+            CatalogueItemId additionalServiceId)
+            : this(solutionCapability, catalogueItem)
+        {
+            CatalogueItemIdAdditional = additionalServiceId;
+        }
 
-        public string Description { get; set; }
+        public CatalogueItemId CatalogueItemIdAdditional { get; init; }
+
+        public string Description { get; init; }
 
         public DateTime LastReviewed { get; set; }
 
         public string Name { get; set; }
 
-        public string[] NhsDefined { get; set; }
+        public string Url { get; init; }
+
+        public string[] NhsDefined { get; init; }
 
         public CatalogueItemId SolutionId { get; set; }
 
         public string SolutionName { get; set; }
 
-        public string[] SupplierDefined { get; set; }
+        public string[] SupplierDefined { get; init; }
 
         public bool HasNhsDefined() => NhsDefined != null && NhsDefined.Length > 0;
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/CheckEpics.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/CheckEpics.cshtml
@@ -26,7 +26,7 @@ else
         <h2>NHS defined Epics</h2>
 
         <p>
-            <a target="_blank" href="https://gpitbjss.atlassian.net/wiki/spaces/GPITF/pages/1391134029/Appointments+Management+-+GP">
+            <a target="_blank" href="@Model.Url">
                 View more details including acceptance criteria for Epics defined by the NHS</a>
             (opens in a new tab)
         </p>

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Solutions/Controllers/SolutionsControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Solutions/Controllers/SolutionsControllerTests.cs
@@ -373,10 +373,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Controllers
             var capabilityId = capabilityItem.Capability.Id;
             var capability = solution.CatalogueItemCapability(capabilityId);
 
-            var expectedModel = new SolutionCheckEpicsModel(capability)
-            {
-                SolutionName = solution.Name,
-            };
+            var expectedModel = new SolutionCheckEpicsModel(capability, solution);
 
             mockSolutionsService
                 .Setup(s => s.GetSolutionCapability(catalogueItemId, capabilityId))
@@ -430,12 +427,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Controllers
             var capabilityId = capabilityItem.Capability.Id;
             var capability = additionalSolution.CatalogueItemCapability(capabilityId);
 
-            var expectedModel = new SolutionCheckEpicsModel(capability)
-            {
-                SolutionName = additionalSolution.Name,
-                SolutionId = catalogueItemId,
-                CatalogueItemIdAdditional = catalogueItemIdAdditional,
-            };
+            var expectedModel = new SolutionCheckEpicsModel(capability, additionalSolution, catalogueItemIdAdditional);
 
             mockSolutionsService
                 .Setup(s => s.GetAdditionalServiceCapability(catalogueItemIdAdditional, capabilityId))

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Solutions/Models/SolutionCheckEpicsModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Solutions/Models/SolutionCheckEpicsModelTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using AutoFixture;
+using AutoFixture.Xunit2;
 using FluentAssertions;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations;
@@ -73,11 +74,12 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Models
         [Theory]
         [CommonAutoData]
         public static void HasNoEpics_NoNhsOrSupplierDefinedEpics_ReturnsTrue(
-            CatalogueItemCapability solutionCapability)
+            CatalogueItemCapability solutionCapability,
+            [Frozen] CatalogueItem catalogueItem)
         {
             solutionCapability.Capability.Epics = Array.Empty<Epic>();
 
-            var model = new SolutionCheckEpicsModel(solutionCapability);
+            var model = new SolutionCheckEpicsModel(solutionCapability, catalogueItem);
 
             model.HasNoEpics().Should().BeTrue();
         }
@@ -85,7 +87,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Models
         [Theory]
         [CommonAutoData]
         public static void HasNoEpics_HasNhsDefinedEpicsOnly_ReturnsFalse(
-            CatalogueItemCapability solutionCapability)
+            CatalogueItemCapability solutionCapability,
+            [Frozen] CatalogueItem catalogueItem)
         {
             var epics = new Fixture()
                 .Build<Epic>()
@@ -94,7 +97,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Models
                 .CreateMany();
 
             solutionCapability.Capability.Epics = epics.ToList();
-            var model = new SolutionCheckEpicsModel(solutionCapability);
+            var model = new SolutionCheckEpicsModel(solutionCapability, catalogueItem);
 
             model.HasSupplierDefined().Should().BeFalse();
             model.HasNhsDefined().Should().BeTrue();
@@ -104,7 +107,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Models
         [Theory]
         [CommonAutoData]
         public static void HasNoEpics_HasSupplierDefinedEpicsOnly_ReturnsFalse(
-            CatalogueItemCapability solutionCapability)
+            CatalogueItemCapability solutionCapability,
+            [Frozen] CatalogueItem catalogueItem)
         {
             var epics = new Fixture()
                 .Build<Epic>()
@@ -113,7 +117,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Models
                 .CreateMany();
 
             solutionCapability.Capability.Epics = epics.ToList();
-            var model = new SolutionCheckEpicsModel(solutionCapability);
+            var model = new SolutionCheckEpicsModel(solutionCapability, catalogueItem);
 
             model.HasSupplierDefined().Should().BeTrue();
             model.HasNhsDefined().Should().BeFalse();


### PR DESCRIPTION
Fix the CheckEpics.cshtml to use the sourceUrl from the capability and not a hard coded link -_-

update the model to take in the source URL and to set the values correctly.

Update tests to reflect the model changes.