### PR TITLE
Update List Price Behaviour 

### DIFF
--- a/database/NHSD.GPITBuyingCatalogue.Database/Catalogue/Tables/CataloguePrices.sql
+++ b/database/NHSD.GPITBuyingCatalogue.Database/Catalogue/Tables/CataloguePrices.sql
@@ -7,6 +7,8 @@
     PricingUnitId smallint NOT NULL,
     TimeUnitId int NULL,
     CurrencyCode nvarchar(3) NOT NULL,
+    PublishedStatusId INT CONSTRAINT DF_CataloguePrice_PublishedStatus DEFAULT 1 NOT NULL,
+    IsLocked BIT CONSTRAINT DF_CataloguePrices_IsLocked DEFAULT 0 NOT NULL,
     LastUpdated datetime2(7) DEFAULT GETUTCDATE() NOT NULL,
     LastUpdatedBy int NULL,
     Price decimal(18, 4) NULL,
@@ -20,4 +22,5 @@
     CONSTRAINT FK_CataloguePrices_PricingUnit_PricingUnitId FOREIGN KEY (PricingUnitId) REFERENCES catalogue.PricingUnits(Id),
     CONSTRAINT FK_CataloguePrices_TimeUnit_TimeUnitId FOREIGN KEY (TimeUnitId) REFERENCES catalogue.TimeUnits(Id),
     CONSTRAINT FK_CataloguePrices_LastUpdatedBy FOREIGN KEY (LastUpdatedBy) REFERENCES users.AspNetUsers(Id),
+    CONSTRAINT FK_CataloguePrices_PublicationStatus FOREIGN KEY (PublishedStatusId) REFERENCES catalogue.PublicationStatus(Id),
 ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = catalogue.CataloguePrices_History));

--- a/database/NHSD.GPITBuyingCatalogue.Database/Catalogue/TemporalTables/CataloguePrices_History.sql
+++ b/database/NHSD.GPITBuyingCatalogue.Database/Catalogue/TemporalTables/CataloguePrices_History.sql
@@ -7,6 +7,8 @@
     PricingUnitId smallint NOT NULL,
     TimeUnitId int NULL,
     CurrencyCode nvarchar(3) NOT NULL,
+    PublishedStatusId INT NOT NULL,
+    IsLocked BIT NOT NULL,
     LastUpdated datetime2(7) NOT NULL,
     LastUpdatedBy int NULL,
     Price decimal(18, 4) NULL,

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Catalogue/Configuration/CataloguePriceEntityTypeConfiguration.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Catalogue/Configuration/CataloguePriceEntityTypeConfiguration.cs
@@ -45,6 +45,16 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Configuration
                 .HasForeignKey(p => p.PricingUnitId)
                 .OnDelete(DeleteBehavior.ClientSetNull);
 
+            builder.Property(i => i.PublishedStatus)
+                .HasConversion<int>()
+                .HasColumnName("PublishedStatusId")
+                .HasDefaultValue(PublicationStatus.Draft);
+
+            builder.Property(i => i.IsLocked)
+                .HasConversion<bool>()
+                .HasColumnName("IsLocked")
+                .HasDefaultValue(false);
+
             builder.HasOne(p => p.LastUpdatedByUser)
                 .WithMany()
                 .HasForeignKey(p => p.LastUpdatedBy)

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Catalogue/Models/CataloguePrice.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Catalogue/Models/CataloguePrice.cs
@@ -29,6 +29,10 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models
 
         public decimal? Price { get; set; }
 
+        public bool IsLocked { get; set; }
+
+        public PublicationStatus PublishedStatus { get; set; }
+
         public CatalogueItem CatalogueItem { get; set; }
 
         public CataloguePriceType CataloguePriceType { get; set; }

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/ListPrices/IListPricesService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/ListPrices/IListPricesService.cs
@@ -7,9 +7,11 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.ListPrices
 {
     public interface IListPricesService
     {
-        Task SaveListPrice(CatalogueItemId itemId, SaveListPriceModel model);
+        Task<int> SaveListPrice(CatalogueItemId itemId, SaveListPriceModel model);
 
         Task UpdateListPrice(CatalogueItemId itemId, SaveListPriceModel model);
+
+        Task UpdateListPriceStatus(CatalogueItemId itemId, SaveListPriceModel model);
 
         Task DeleteListPrice(CatalogueItemId itemId, int cataloguePriceId);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Models/SaveListPriceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Models/SaveListPriceModel.cs
@@ -13,5 +13,7 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models
         public TimeUnit? TimeUnit { get; init; }
 
         public PricingUnit PricingUnit { get; init; }
+
+        public PublicationStatus Status { get; init; }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/ListPriceController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/ListPriceController.cs
@@ -7,7 +7,6 @@ using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.ListPrices;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models;
-using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ListPriceModels;
 
 namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
@@ -17,26 +16,20 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
     [Route("admin/catalogue-solutions/manage/{solutionId}/list-prices")]
     public sealed class ListPriceController : Controller
     {
-        private readonly ISolutionsService solutionsService;
         private readonly IListPricesService listPricesService;
 
-        public ListPriceController(
-            ISolutionsService solutionsService,
-            IListPricesService listPricesService)
-        {
-            this.solutionsService = solutionsService ?? throw new ArgumentNullException(nameof(solutionsService));
+        public ListPriceController(IListPricesService listPricesService) =>
             this.listPricesService = listPricesService ?? throw new ArgumentNullException(nameof(listPricesService));
-        }
 
         [HttpGet]
         public async Task<IActionResult> ManageListPrices(CatalogueItemId solutionId)
         {
-            var solution = await solutionsService.GetSolution(solutionId);
+            var solution = await listPricesService.GetCatalogueItemWithPrices(solutionId);
 
             if (solution is null)
                 return BadRequest($"No Solution found for Id: {solutionId}");
 
-            var model = new ManageListPricesModel(solution)
+            var model = new ManageListPricesModel(solution, solutionId)
             {
                 BackLink = Url.Action(
                     nameof(CatalogueSolutionsController.ManageCatalogueSolution),
@@ -46,6 +39,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                     nameof(AddListPrice),
                     typeof(ListPriceController).ControllerName(),
                     new { solutionId }),
+                EditPriceStatusActionName = nameof(EditListPriceStatus),
+                EditPriceActionName = nameof(EditListPrice),
+                ControllerName = typeof(ListPriceController).ControllerName(),
             };
 
             return View(model);
@@ -54,7 +50,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
         [HttpGet("add-list-price")]
         public async Task<IActionResult> AddListPrice(CatalogueItemId solutionId)
         {
-            var solution = await solutionsService.GetSolution(solutionId);
+            var solution = await listPricesService.GetCatalogueItemWithPrices(solutionId);
 
             if (solution is null)
                 return BadRequest($"No Solution found for Id: {solutionId}");
@@ -82,18 +78,21 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                 TimeUnit = model.GetTimeUnit(provisioningType),
             };
 
-            await listPricesService.SaveListPrice(solutionId, saveSolutionListPriceModel);
+            var listPriceId = await listPricesService.SaveListPrice(solutionId, saveSolutionListPriceModel);
 
-            return RedirectToAction(nameof(ManageListPrices), new { solutionId });
+            return RedirectToAction(nameof(PublishListPrice), new { solutionId, listPriceId });
         }
 
         [HttpGet("{listPriceId}")]
         public async Task<IActionResult> EditListPrice(CatalogueItemId solutionId, int listPriceId)
         {
-            var solution = await solutionsService.GetSolution(solutionId);
+            var solution = await listPricesService.GetCatalogueItemWithPrices(solutionId);
             var cataloguePrice = solution.CataloguePrices.FirstOrDefault(cp => cp.CataloguePriceId == listPriceId);
             if (cataloguePrice is null)
                 return RedirectToAction(nameof(ManageListPrices), new { solutionId });
+
+            if (cataloguePrice.IsLocked)
+                return RedirectToAction(nameof(EditListPriceStatus), new { solutionId, listPriceId });
 
             var editListPriceModel = new EditListPriceModel(solution, cataloguePrice)
             {
@@ -110,6 +109,14 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             if (!ModelState.IsValid)
                 return View("EditListPrice", model);
 
+            var solution = await listPricesService.GetCatalogueItemWithPrices(solutionId);
+            var cataloguePrice = solution.CataloguePrices.FirstOrDefault(cp => cp.CataloguePriceId == listPriceId);
+            if (cataloguePrice is null)
+                return RedirectToAction(nameof(ManageListPrices), new { solutionId });
+
+            if (cataloguePrice.IsLocked)
+                throw new ArgumentException($"List price {listPriceId} cannot be edited due to being locked");
+
             var provisioningType = model.SelectedProvisioningType!.Value;
             var saveSolutionListPriceModel = new SaveListPriceModel
             {
@@ -122,13 +129,99 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
 
             await listPricesService.UpdateListPrice(solutionId, saveSolutionListPriceModel);
 
+            return RedirectToAction(nameof(PublishListPrice), new { solutionId, listPriceId });
+        }
+
+        [HttpGet("{listPriceId}/publish-list-price")]
+        public async Task<IActionResult> PublishListPrice(CatalogueItemId solutionId, int listPriceId)
+        {
+            var solution = await listPricesService.GetCatalogueItemWithPrices(solutionId);
+            var cataloguePrice = solution.CataloguePrices.FirstOrDefault(cp => cp.CataloguePriceId == listPriceId);
+            if (cataloguePrice is null)
+                return RedirectToAction(nameof(ManageListPrices), new { solutionId });
+
+            var editListPriceModel = new EditListPriceStatus(solution, cataloguePrice)
+            {
+                BackLink = Url.Action(nameof(EditListPrice), new { solutionId, listPriceId }),
+                Title = "Publish list price",
+                Advice = "Are you sure you want to publish this list price? Once you do, you'll no longer be able to edit or delete it.",
+            };
+
+            return View("EditListPriceStatus", editListPriceModel);
+        }
+
+        [HttpPost("{listPriceId}/publish-list-price")]
+        public async Task<IActionResult> PublishListPrice(CatalogueItemId solutionId, int listPriceId, EditListPriceStatus model)
+        {
+            if (!ModelState.IsValid)
+                return View("EditListPriceStatus", model);
+
+            var solution = await listPricesService.GetCatalogueItemWithPrices(solutionId);
+            var cataloguePrice = solution.CataloguePrices.FirstOrDefault(cp => cp.CataloguePriceId == listPriceId);
+            if (cataloguePrice is null)
+                return RedirectToAction(nameof(ManageListPrices), new { solutionId });
+
+            if (cataloguePrice.IsLocked)
+                return RedirectToAction(nameof(EditListPriceStatus), new { solutionId, listPriceId });
+
+            var saveSolutionListPriceModel = new SaveListPriceModel
+            {
+                Status = model.Status,
+                CataloguePriceId = listPriceId,
+            };
+
+            await listPricesService.UpdateListPriceStatus(solutionId, saveSolutionListPriceModel);
+
+            return RedirectToAction(nameof(ManageListPrices), new { solutionId });
+        }
+
+        [HttpGet("{listPriceId}/edit-status")]
+        public async Task<IActionResult> EditListPriceStatus(CatalogueItemId solutionId, int listPriceId)
+        {
+            var solution = await listPricesService.GetCatalogueItemWithPrices(solutionId);
+            var cataloguePrice = solution.CataloguePrices.FirstOrDefault(cp => cp.CataloguePriceId == listPriceId);
+            if (cataloguePrice is null)
+                return RedirectToAction(nameof(ManageListPrices), new { solutionId });
+
+            var editListPriceModel = new EditListPriceStatus(solution, cataloguePrice)
+            {
+                BackLink = Url.Action(nameof(ManageListPrices), new { solutionId }),
+                Title = "Edit list price",
+                Advice = "Change the publication status for this list price.",
+            };
+
+            return View("EditListPriceStatus", editListPriceModel);
+        }
+
+        [HttpPost("{listPriceId}/edit-status")]
+        public async Task<IActionResult> EditListPriceStatus(CatalogueItemId solutionId, int listPriceId, EditListPriceStatus model)
+        {
+            if (!ModelState.IsValid)
+                return View("EditListPriceStatus", model);
+
+            var solution = await listPricesService.GetCatalogueItemWithPrices(solutionId);
+            var cataloguePrice = solution.CataloguePrices.FirstOrDefault(cp => cp.CataloguePriceId == listPriceId);
+            if (cataloguePrice is null)
+                return RedirectToAction(nameof(ManageListPrices), new { solutionId });
+
+            if (!cataloguePrice.IsLocked)
+                return RedirectToAction(nameof(EditListPriceStatus), new { solutionId, listPriceId });
+
+            var saveSolutionListPriceModel = new SaveListPriceModel
+            {
+                Status = model.Status,
+                CataloguePriceId = listPriceId,
+            };
+
+            await listPricesService.UpdateListPriceStatus(solutionId, saveSolutionListPriceModel);
+
             return RedirectToAction(nameof(ManageListPrices), new { solutionId });
         }
 
         [HttpGet("{listPriceId}/delete")]
         public async Task<IActionResult> DeleteListPrice(CatalogueItemId solutionId, int listPriceId)
         {
-            var solution = await solutionsService.GetSolution(solutionId);
+            var solution = await listPricesService.GetCatalogueItemWithPrices(solutionId);
 
             var model = new DeleteListPriceModel(solution)
             {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AdditionalServices/EditAdditionalServiceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AdditionalServices/EditAdditionalServiceModel.cs
@@ -34,9 +34,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.AdditionalServices
                 ? TaskProgress.Completed
                 : TaskProgress.NotStarted;
 
-            ListPriceStatus = additionalService.CataloguePrices.Any()
-                ? TaskProgress.Completed
-                : TaskProgress.NotStarted;
+            ListPriceStatus = new ListPriceModels.ManageListPricesModel(additionalService).Status();
         }
 
         public CatalogueItemId SolutionId { get; init; }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AssociatedServices/EditAssociatedServiceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/AssociatedServices/EditAssociatedServiceModel.cs
@@ -32,9 +32,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.AssociatedServices
                 ? TaskProgress.Completed
                 : TaskProgress.NotStarted;
 
-            ListPriceStatus = associatedService.CataloguePrices.Any()
-                ? TaskProgress.Completed
-                : TaskProgress.NotStarted;
+            ListPriceStatus = new ListPriceModels.ManageListPricesModel(associatedService).Status();
         }
 
         public CatalogueItemId SolutionId { get; init; }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ListPriceModels/EditListPriceStatus.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ListPriceModels/EditListPriceStatus.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Models;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ListPriceModels
+{
+    public sealed class EditListPriceStatus : NavBaseModel
+    {
+        public EditListPriceStatus()
+        {
+        }
+
+        public EditListPriceStatus(CatalogueItem catalogueItem)
+        {
+            CatalogueItemId = catalogueItem.Id;
+            SolutionName = catalogueItem.Name;
+        }
+
+        public EditListPriceStatus(CatalogueItem catalogueItem, CataloguePrice cataloguePrice)
+            : this(catalogueItem)
+        {
+            CataloguePriceId = cataloguePrice.CataloguePriceId;
+            AvailableStatuses = cataloguePrice.IsLocked ? LockedItemStatues : UnlockedItemStatuses;
+            Status = cataloguePrice.PublishedStatus;
+        }
+
+        public EditListPriceStatus(CatalogueItem catalogueItem, CataloguePrice cataloguePrice, CatalogueItemId relatedCatalogueItemId)
+            : this(catalogueItem, cataloguePrice)
+        {
+            RelatedCatalogueItemId = relatedCatalogueItemId;
+        }
+
+        public static IEnumerable<PublicationStatus> UnlockedItemStatuses => new PublicationStatus[]
+        {
+            PublicationStatus.Published,
+            PublicationStatus.Draft,
+        };
+
+        public static IEnumerable<PublicationStatus> LockedItemStatues => new PublicationStatus[]
+        {
+            PublicationStatus.Published,
+            PublicationStatus.Unpublished,
+        };
+
+        public string Title { get; init; }
+
+        public CatalogueItemId CatalogueItemId { get; init; }
+
+        public CatalogueItemId RelatedCatalogueItemId { get; }
+
+        public int CataloguePriceId { get; init; }
+
+        public IEnumerable<PublicationStatus> AvailableStatuses { get; init; }
+
+        public string SolutionName { get; init; }
+
+        public string Advice { get; init; }
+
+        public PublicationStatus Status { get; init; }
+    }
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ListPriceModels/ManageListPricesModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ListPriceModels/ManageListPricesModel.cs
@@ -66,7 +66,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ListPriceModels
 
         public TaskProgress Status()
         {
-            if (CataloguePrices is null)
+            if (CataloguePrices is null || !CataloguePrices.Any())
                 return TaskProgress.NotStarted;
 
             if (CataloguePrices.Any(cp => cp.PublishedStatus == PublicationStatus.Published))

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/EditListPriceStatus.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/EditListPriceStatus.cshtml
@@ -1,0 +1,32 @@
+﻿@using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ListPriceModels
+@model EditListPriceStatus
+
+@{
+    ViewBag.Title = Model.Title;
+}
+
+<partial name="Partials/_BackLink" model="Model" />
+<div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+        <nhs-validation-summary />
+        <nhs-page-title title="@ViewBag.Title"
+                        caption="@Model.SolutionName"
+                        advice="@Model.Advice" />
+        <form method="post">
+            <input type="hidden" asp-for="CataloguePriceId" />
+            <input type="hidden" asp-for="SolutionName" />
+            <input type="hidden" asp-for="BackLinkText" />
+            <input type="hidden" asp-for="BackLink" />
+            <input type="hidden" asp-for="Title" />
+            <input type="hidden" asp-for="CatalogueItemId" />
+            <input type="hidden" asp-for="Advice" />
+            <nhs-fieldset-form-label asp-for="@Model">
+                <nhs-radio-buttons asp-for="Status"
+                                   values="Model.AvailableStatuses.Cast<object>()"
+                                   value-name="EnumMemberName"
+                                   display-name="Description" />
+            </nhs-fieldset-form-label>
+            <nhs-submit-button />
+        </form>
+    </div>
+</div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/ManageListPrices.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/ManageListPrices.cshtml
@@ -1,10 +1,16 @@
-﻿@using NHSD.GPIT.BuyingCatalogue.EntityFramework.Extensions
-@using NHSD.GPIT.BuyingCatalogue.Framework.Constants
+﻿@using NHSD.GPIT.BuyingCatalogue.EntityFramework.Extensions;
+@using NHSD.GPIT.BuyingCatalogue.Framework.Constants;
+@using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 
 @model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ListPriceModels.ManageListPricesModel
 
 @{
     ViewBag.Title = "List price";
+    ViewBag.Advice = $"Provide details of how much your {Model.SolutionType} costs. You must publish at least one price type.";
+}
+
+@section Scripts{
+    <script type="text/javascript" src="@Url.Content("~/js/ListPriceManagement.min.js")" asp-append-version="true"></script>
 }
 
 <partial name="Partials/_BackLink" model="Model" />
@@ -13,24 +19,36 @@
         <nhs-validation-summary />
         <nhs-page-title title="@ViewBag.Title"
                         caption="@Model.CatalogueName"
-                        advice="Provide details of how much your Catalogue Solution costs. You must add at least one price type." />
+                        advice="@ViewBag.Advice" />
 
         <vc:nhs-action-link text="Add a list price" url="@Model.AddLink" />
+
+        <nhs-checkbox-container Id="unpublished-price-checkbox" style="display:none;">
+            <nhs-checkbox asp-for="ShowUnpublishedPrices"
+                          label-text="Show unpublished list prices" />
+        </nhs-checkbox-container>
 
         <nhs-table data-test-id="solution-list-prices">
             <nhs-table-column>Provisioning type</nhs-table-column>
             <nhs-table-column>Price</nhs-table-column>
             <nhs-table-column>Unit</nhs-table-column>
+            <nhs-table-column>Status</nhs-table-column>
             <nhs-table-column></nhs-table-column>
 
             @foreach (var cataloguePrice in Model.CataloguePrices)
             {
-                <nhs-table-row-container>
+                <nhs-table-row-container class="@(cataloguePrice.PublishedStatus == PublicationStatus.Unpublished ? "unpublished" : null)">
                     <nhs-table-cell>@cataloguePrice.ProvisioningType.Name()</nhs-table-cell>
                     <nhs-table-cell>@CurrencyCodeSigns.Code[cataloguePrice.CurrencyCode]@cataloguePrice.Price</nhs-table-cell>
                     <nhs-table-cell>@cataloguePrice.PricingUnit.Description</nhs-table-cell>
+                    <nhs-table-cell><nhs-tag status-enum="@cataloguePrice.PublishedStatus" /></nhs-table-cell>
                     <nhs-table-cell>
-                        <a asp-action="EditListPrice" asp-controller="ListPrice" asp-route-solutionId="@Model.CatalogueItemId" asp-route-listPriceId="@cataloguePrice.CataloguePriceId">Edit</a>
+                    <a asp-action="@(cataloguePrice.IsLocked ? Model.EditPriceStatusActionName : Model.EditPriceActionName)"
+                       asp-controller="@Model.ControllerName"
+                       asp-route-solutionId="@Model.SolutionId"
+                       asp-route-additionalServiceId="@Model.AdditionalServiceId"
+                       asp-route-associatedServiceId="@Model.AssociatedServiceId"
+                       asp-route-listPriceId="@cataloguePrice.CataloguePriceId">Edit</a>
                     </nhs-table-cell>
                 </nhs-table-row-container>
             }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/AdditionalServicesController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/AdditionalServicesController.cs
@@ -116,7 +116,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
 
             orderSessionService.SetOrderStateToSession(state);
 
-            var prices = solution.CataloguePrices.Where(p => p.CataloguePriceType == CataloguePriceType.Flat).ToList();
+            var prices = solution.CataloguePrices.Where(p =>
+            p.CataloguePriceType == CataloguePriceType.Flat
+            && p.PublishedStatus == PublicationStatus.Published).ToList();
 
             if (!prices.Any())
                 throw new InvalidOperationException($"Additional Service {state.CatalogueItemId.GetValueOrDefault()} does not have any Flat prices associated");
@@ -147,7 +149,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
 
             var solution = await solutionsService.GetSolutionListPrices(state.CatalogueItemId.GetValueOrDefault());
 
-            var prices = solution.CataloguePrices.Where(p => p.CataloguePriceType == CataloguePriceType.Flat).ToList();
+            var prices = solution.CataloguePrices.Where(p =>
+            p.CataloguePriceType == CataloguePriceType.Flat
+            && p.PublishedStatus == PublicationStatus.Published).ToList();
 
             var model = new SelectAdditionalServicePriceModel(odsCode, callOffId, state.CatalogueItemName, prices)
             {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/AssociatedServicesController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/AssociatedServicesController.cs
@@ -122,7 +122,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
 
             orderSessionService.SetOrderStateToSession(state);
 
-            var prices = solution.CataloguePrices.Where(p => p.CataloguePriceType == CataloguePriceType.Flat).ToList();
+            var prices = solution.CataloguePrices.Where(p =>
+            p.CataloguePriceType == CataloguePriceType.Flat
+            && p.PublishedStatus == PublicationStatus.Published).ToList();
 
             if (!prices.Any())
                 throw new InvalidOperationException($"Associated Service {state.CatalogueItemId.GetValueOrDefault()} does not have any Flat prices associated");
@@ -153,7 +155,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
 
             var solution = await solutionsService.GetSolutionListPrices(state.CatalogueItemId.Value);
 
-            var prices = solution.CataloguePrices.Where(p => p.CataloguePriceType == CataloguePriceType.Flat).ToList();
+            var prices = solution.CataloguePrices.Where(p =>
+            p.CataloguePriceType == CataloguePriceType.Flat
+            && p.PublishedStatus == PublicationStatus.Published).ToList();
 
             var model = new SelectAssociatedServicePriceModel(odsCode, state.CatalogueItemName, prices)
             {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/CatalogueSolutionsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/CatalogueSolutionsController.cs
@@ -100,7 +100,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
             state.CatalogueItemName = solution.Name;
             orderSessionService.SetOrderStateToSession(state);
 
-            var prices = solution.CataloguePrices.Where(p => p.CataloguePriceType == CataloguePriceType.Flat).ToList();
+            var prices = solution.CataloguePrices.Where(p =>
+            p.CataloguePriceType == CataloguePriceType.Flat
+            && p.PublishedStatus == PublicationStatus.Published).ToList();
 
             if (!prices.Any())
                 throw new InvalidOperationException($"Catalogue Solution {state.CatalogueItemId.GetValueOrDefault()} does not have any Flat prices associated");
@@ -131,7 +133,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
 
             var solution = await solutionsService.GetSolutionListPrices(state.CatalogueItemId.GetValueOrDefault());
 
-            var prices = solution.CataloguePrices.Where(p => p.CataloguePriceType == CataloguePriceType.Flat).ToList();
+            var prices = solution.CataloguePrices.Where(p =>
+            p.CataloguePriceType == CataloguePriceType.Flat
+            && p.PublishedStatus == PublicationStatus.Published).ToList();
 
             var model = new SelectSolutionPriceModel(odsCode, state.CatalogueItemName, prices)
             {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/ListPriceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/ListPriceModel.cs
@@ -14,7 +14,11 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
         public ListPriceModel(CatalogueItem item)
             : base(item)
         {
-            FlatListPrices = item.CataloguePrices.Select(cp => new PriceViewModel(cp)).ToList();
+            FlatListPrices = item.CataloguePrices
+                .Where(cp =>
+                    cp.CataloguePriceType == CataloguePriceType.Flat
+                    && cp.PublishedStatus == PublicationStatus.Published)
+                .Select(cp => new PriceViewModel(cp)).ToList();
         }
 
         public override int Index => 4;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/bundleconfig.json
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/bundleconfig.json
@@ -16,5 +16,11 @@
     "inputFiles": [
       "wwwroot/js/SupplierManagement.js"
     ]
+  },
+  {
+    "outputFileName": "wwwroot/js/ListPriceManagement.min.js",
+    "inputFiles": [
+      "wwwroot/js/ListPriceManagement.js"
+    ]
   }
 ]

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/wwwroot/ts/ListPriceManagement.ts
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/wwwroot/ts/ListPriceManagement.ts
@@ -1,0 +1,28 @@
+﻿window.onload = function () {
+    const unpublishedPriceCheckboxContainer = "unpublished-price-checkbox";
+    const unpublishedPriceCheckbox = "ShowUnpublishedPrices";
+
+    // only run if there are actually unpublished items to hide
+    if (document.getElementsByClassName("unpublished").length > 0) {
+
+        document.getElementById(unpublishedPriceCheckboxContainer).style.display = 'block';
+
+        ChangePriceDisplayStyle('none');
+
+        const checkbox = document.getElementById(unpublishedPriceCheckbox);
+
+        checkbox.addEventListener("click", ChangePriceDisplay)
+    }
+}
+
+function ChangePriceDisplay() {
+    this.checked ? ChangePriceDisplayStyle('table-row') : ChangePriceDisplayStyle('none');
+}
+
+function ChangePriceDisplayStyle(style) {
+    const unpublishedPrice = document.getElementsByClassName("unpublished");
+    for (let i = 0; i < unpublishedPrice.length; i++) {
+        const input = unpublishedPrice.item(i) as HTMLInputElement;
+        input.style.display = style;
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AdditionalServices/ListPrices/AddListPrice.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AdditionalServices/ListPrices/AddListPrice.cs
@@ -211,7 +211,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.Addition
             CommonActions
                 .PageLoadedCorrectGetIndex(
                     typeof(AdditionalServicesController),
-                    nameof(AdditionalServicesController.ManageListPrices))
+                    nameof(AdditionalServicesController.PublishListPrice))
                 .Should()
                 .BeTrue();
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AdditionalServices/ListPrices/DeleteListPrice.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AdditionalServices/ListPrices/DeleteListPrice.cs
@@ -14,7 +14,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.Addition
 {
     public sealed class DeleteListPrice : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
     {
-        private const int ListPriceId = 6;
+        private const int ListPriceId = 16;
         private static readonly CatalogueItemId SolutionId = new(99998, "001");
         private static readonly CatalogueItemId AdditionalServiceId = new(99998, "001A99");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AdditionalServices/ListPrices/EditListPrice.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AdditionalServices/ListPrices/EditListPrice.cs
@@ -15,7 +15,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.Addition
 {
     public sealed class EditListPrice : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
     {
-        private const int ListPriceId = 6;
+        private const int ListPriceId = 16;
         private static readonly CatalogueItemId SolutionId = new(99998, "001");
         private static readonly CatalogueItemId AdditionalServiceId = new(99998, "001A99");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AssociatedServices/ListPrices/AddListPrice.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AssociatedServices/ListPrices/AddListPrice.cs
@@ -212,7 +212,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.Associat
             CommonActions
                 .PageLoadedCorrectGetIndex(
                     typeof(AssociatedServicesController),
-                    nameof(AssociatedServicesController.ManageListPrices))
+                    nameof(AssociatedServicesController.PublishListPrice))
                 .Should()
                 .BeTrue();
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AssociatedServices/ListPrices/DeleteListPrice.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AssociatedServices/ListPrices/DeleteListPrice.cs
@@ -14,7 +14,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.Associat
 {
     public sealed class DeleteListPrice : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
     {
-        private const int ListPriceId = 10;
+        private const int ListPriceId = 17;
         private static readonly CatalogueItemId SolutionId = new(99998, "001");
 
         private static readonly CatalogueItemId AssociatedServiceId = new(99998, "S-997");

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AssociatedServices/ListPrices/EditListPrice.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AssociatedServices/ListPrices/EditListPrice.cs
@@ -15,7 +15,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.Associat
 {
     public sealed class EditListPrice : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
     {
-        private const int ListPriceId = 10;
+        private const int ListPriceId = 17;
         private static readonly CatalogueItemId SolutionId = new(99998, "001");
 
         private static readonly CatalogueItemId AssociatedServiceId = new(99998, "S-997");

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/AddListPrice.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/AddListPrice.cs
@@ -209,7 +209,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices
             CommonActions
                 .PageLoadedCorrectGetIndex(
                     typeof(ListPriceController),
-                    nameof(ListPriceController.ManageListPrices))
+                    nameof(ListPriceController.PublishListPrice))
                 .Should()
                 .BeTrue();
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/DeleteListPrice.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/DeleteListPrice.cs
@@ -14,7 +14,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices
 {
     public sealed class DeleteListPrice : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
     {
-        private const int ListPriceId = -1;
+        private const int ListPriceId = 18;
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 
         private static readonly Dictionary<string, string> Parameters = new()
@@ -76,6 +76,10 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices
         [Fact]
         public async Task DeleteListPrice_ClickDelete_ListPriceDeleted()
         {
+            await using var context = GetEndToEndDbContext();
+
+            var originalCount = context.CataloguePrices.Count(cp => cp.CatalogueItemId == SolutionId);
+
             CommonActions.ClickSave();
 
             CommonActions.PageLoadedCorrectGetIndex(
@@ -84,9 +88,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices
                 .Should()
                 .BeTrue();
 
-            await using var context = GetEndToEndDbContext();
-
-            context.CataloguePrices.Count(cp => cp.CatalogueItemId == SolutionId).Should().Be(0);
+            context.CataloguePrices.Count(cp => cp.CatalogueItemId == SolutionId).Should().Be(originalCount - 1);
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/ListPriceDetails.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/ListPriceDetails.cs
@@ -43,7 +43,9 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
             var prices = PublicBrowsePages.SolutionAction.GetPrices();
 
             await using var context = GetEndToEndDbContext();
-            var dbPrices = await context.CataloguePrices.Where(s => s.CatalogueItemId == new CatalogueItemId(99999, "001")).ToListAsync();
+            var dbPrices = await context.CataloguePrices.Where(s =>
+            s.CatalogueItemId == new CatalogueItemId(99999, "001")
+            && s.PublishedStatus == PublicationStatus.Published).ToListAsync();
 
             prices.Should().Contain(dbPrices.Select(s => s.Price.ToString()));
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/AdditionalServicesSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/AdditionalServicesSeedData.cs
@@ -220,6 +220,25 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             Price = 999.9999M,
                             LastUpdated = DateTime.UtcNow,
                         },
+                        new()
+                        {
+                            CataloguePriceId = 16,
+                            CatalogueItemId = new CatalogueItemId(99998, "001A99"),
+                            ProvisioningType = ProvisioningType.Patient,
+                            CataloguePriceType = CataloguePriceType.Flat,
+                            PublishedStatus = PublicationStatus.Draft,
+                            IsLocked = false,
+                            PricingUnit = new PricingUnit
+                            {
+                                Id = 16,
+                                TierName = "Test Tier",
+                                Description = "per test declarative",
+                            },
+                            TimeUnit = TimeUnit.PerYear,
+                            CurrencyCode = "GBP",
+                            Price = 999.9999M,
+                            LastUpdated = DateTime.UtcNow,
+                        },
                     },
                 },
                 new()

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/AdditionalServicesSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/AdditionalServicesSeedData.cs
@@ -169,6 +169,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             CatalogueItemId = new CatalogueItemId(99998, "001A99"),
                             ProvisioningType = ProvisioningType.Patient,
                             CataloguePriceType = CataloguePriceType.Flat,
+                            PublishedStatus = PublicationStatus.Published,
+                            IsLocked = true,
                             PricingUnit = new PricingUnit
                             {
                                 Id = 6,
@@ -186,6 +188,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             CatalogueItemId = new CatalogueItemId(99998, "001A99"),
                             ProvisioningType = ProvisioningType.OnDemand,
                             CataloguePriceType = CataloguePriceType.Flat,
+                            PublishedStatus = PublicationStatus.Published,
+                            IsLocked = true,
                             PricingUnit = new PricingUnit
                             {
                                 Id = 7,
@@ -203,6 +207,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             CatalogueItemId = new CatalogueItemId(99998, "001A99"),
                             ProvisioningType = ProvisioningType.Declarative,
                             CataloguePriceType = CataloguePriceType.Flat,
+                            PublishedStatus = PublicationStatus.Published,
+                            IsLocked = true,
                             PricingUnit = new PricingUnit
                             {
                                 Id = 8,
@@ -273,6 +279,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             CatalogueItemId = new CatalogueItemId(99998, "002A999"),
                             ProvisioningType = ProvisioningType.Patient,
                             CataloguePriceType = CataloguePriceType.Flat,
+                            PublishedStatus = PublicationStatus.Published,
+                            IsLocked = true,
                             PricingUnit = new PricingUnit
                             {
                                 Id = 9,

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/AssociatedServicesSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/AssociatedServicesSeedData.cs
@@ -63,6 +63,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             CatalogueItemId = new CatalogueItemId(99998, "S-997"),
                             ProvisioningType = ProvisioningType.Patient,
                             CataloguePriceType = CataloguePriceType.Flat,
+                            PublishedStatus = PublicationStatus.Published,
+                            IsLocked = true,
                             PricingUnit = new PricingUnit
                             {
                                 Id = 10,
@@ -80,6 +82,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             CatalogueItemId = new CatalogueItemId(99998, "S-997"),
                             ProvisioningType = ProvisioningType.OnDemand,
                             CataloguePriceType = CataloguePriceType.Flat,
+                            PublishedStatus = PublicationStatus.Published,
+                            IsLocked = true,
                             PricingUnit = new PricingUnit
                             {
                                 Id = 11,
@@ -97,6 +101,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             CatalogueItemId = new CatalogueItemId(99998, "S-997"),
                             ProvisioningType = ProvisioningType.Declarative,
                             CataloguePriceType = CataloguePriceType.Flat,
+                            PublishedStatus = PublicationStatus.Published,
+                            IsLocked = true,
                             PricingUnit = new PricingUnit
                             {
                                 Id = 12,
@@ -132,6 +138,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             CatalogueItemId = new CatalogueItemId(99998, "S-998"),
                             ProvisioningType = ProvisioningType.Patient,
                             CataloguePriceType = CataloguePriceType.Flat,
+                            PublishedStatus = PublicationStatus.Published,
+                            IsLocked = true,
                             PricingUnit = new PricingUnit
                             {
                                 Id = 13,
@@ -167,6 +175,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             CatalogueItemId = new CatalogueItemId(99998, "S-999"),
                             ProvisioningType = ProvisioningType.Patient,
                             CataloguePriceType = CataloguePriceType.Flat,
+                            PublishedStatus = PublicationStatus.Published,
+                            IsLocked = true,
                             PricingUnit = new PricingUnit
                             {
                                 Id = 14,

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/AssociatedServicesSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/AssociatedServicesSeedData.cs
@@ -114,6 +114,25 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             Price = 999.9999M,
                             LastUpdated = DateTime.UtcNow,
                         },
+                        new()
+                        {
+                            CataloguePriceId = 17,
+                            CatalogueItemId = new CatalogueItemId(99998, "S-997"),
+                            ProvisioningType = ProvisioningType.Patient,
+                            CataloguePriceType = CataloguePriceType.Flat,
+                            PublishedStatus = PublicationStatus.Draft,
+                            IsLocked = false,
+                            PricingUnit = new PricingUnit
+                            {
+                                Id = 17,
+                                TierName = "Test Tier",
+                                Description = "per test declarative",
+                            },
+                            TimeUnit = TimeUnit.PerYear,
+                            CurrencyCode = "GBP",
+                            Price = 999.9999M,
+                            LastUpdated = DateTime.UtcNow,
+                        },
                     },
                 },
                 new()

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
@@ -250,6 +250,28 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                         new() { CapabilityId = 43, EpicId = "E00099", StatusId = 1 },
                     },
                     PublishedStatus = PublicationStatus.Published,
+                    CataloguePrices = new List<CataloguePrice>
+                    {
+                        new()
+                        {
+                            CataloguePriceId = 15,
+                            CatalogueItemId = new CatalogueItemId(99999, "001"),
+                            ProvisioningType = ProvisioningType.Patient,
+                            CataloguePriceType = CataloguePriceType.Flat,
+                            PublishedStatus = PublicationStatus.Published,
+                            IsLocked = true,
+                            PricingUnit = new PricingUnit
+                            {
+                                Id = 15,
+                                TierName = "Test Tier",
+                                Description = "per test patient",
+                            },
+                            TimeUnit = TimeUnit.PerYear,
+                            CurrencyCode = "GBP",
+                            Price = 999.9999M,
+                            LastUpdated = DateTime.UtcNow,
+                        },
+                    },
                 },
                 new CatalogueItem
                 {
@@ -609,6 +631,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             CatalogueItemId = new CatalogueItemId(99997, "001"),
                             ProvisioningType = ProvisioningType.Patient,
                             CataloguePriceType = CataloguePriceType.Flat,
+                            PublishedStatus = PublicationStatus.Published,
+                            IsLocked = true,
                             PricingUnit = new PricingUnit
                             {
                                 Id = 5,
@@ -800,6 +824,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             CatalogueItemId = new CatalogueItemId(99998, "001"),
                             ProvisioningType = ProvisioningType.Patient,
                             CataloguePriceType = CataloguePriceType.Flat,
+                            PublishedStatus = PublicationStatus.Published,
+                            IsLocked = true,
                             PricingUnit = new PricingUnit
                             {
                                 Id = 1,
@@ -817,6 +843,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             CatalogueItemId = new CatalogueItemId(99998, "001"),
                             ProvisioningType = ProvisioningType.OnDemand,
                             CataloguePriceType = CataloguePriceType.Flat,
+                            PublishedStatus = PublicationStatus.Published,
+                            IsLocked = true,
                             PricingUnit = new PricingUnit
                             {
                                 Id = 2,
@@ -834,6 +862,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             CatalogueItemId = new CatalogueItemId(99998, "001"),
                             ProvisioningType = ProvisioningType.Declarative,
                             CataloguePriceType = CataloguePriceType.Flat,
+                            PublishedStatus = PublicationStatus.Published,
+                            IsLocked = true,
                             PricingUnit = new PricingUnit
                             {
                                 Id = 3,
@@ -1026,6 +1056,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             CatalogueItemId = new CatalogueItemId(99998, "002"),
                             ProvisioningType = ProvisioningType.Declarative,
                             CataloguePriceType = CataloguePriceType.Flat,
+                            PublishedStatus = PublicationStatus.Published,
+                            IsLocked = true,
                             PricingUnit = new PricingUnit
                             {
                                 Id = 4,

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
@@ -271,6 +271,25 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             Price = 999.9999M,
                             LastUpdated = DateTime.UtcNow,
                         },
+                        new()
+                        {
+                            CataloguePriceId = 18,
+                            CatalogueItemId = new CatalogueItemId(99999, "001"),
+                            ProvisioningType = ProvisioningType.Patient,
+                            CataloguePriceType = CataloguePriceType.Flat,
+                            PublishedStatus = PublicationStatus.Draft,
+                            IsLocked = false,
+                            PricingUnit = new PricingUnit
+                            {
+                                Id = 18,
+                                TierName = "Test Tier",
+                                Description = "per test patient",
+                            },
+                            TimeUnit = TimeUnit.PerYear,
+                            CurrencyCode = "GBP",
+                            Price = 999.9999M,
+                            LastUpdated = DateTime.UtcNow,
+                        },
                     },
                 },
                 new CatalogueItem

--- a/tests/NHSD.GPIT.BuyingCatalogue.Test.Framework/AutoFixtureCustomisations/CatalogueItemCustomization.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Test.Framework/AutoFixtureCustomisations/CatalogueItemCustomization.cs
@@ -24,7 +24,8 @@ namespace NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations
                 .Without(i => i.Solution)
                 .Without(i => i.Supplier)
                 .Without(i => i.SupplierId)
-                .Without(i => i.SupplierServiceAssociations);
+                .Without(i => i.SupplierServiceAssociations)
+                .Without(i => i.PublishedStatus);
 
             fixture.Customize<CatalogueItem>(ComposerTransformation);
         }
@@ -37,7 +38,11 @@ namespace NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations
                     return new NoSpecimen();
 
                 var id = context.Create<CatalogueItemId>();
-                var item = new CatalogueItem { Id = id };
+                var item = new CatalogueItem
+                {
+                    Id = id,
+                    PublishedStatus = PublicationStatus.Published,
+                };
 
                 AddCapabilities(item, context);
                 AddPrices(item, context);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/AdditionalServicesControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/AdditionalServicesControllerTests.cs
@@ -689,7 +689,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
 
         [Theory]
         [CommonAutoData]
-        public static async Task Post_AddListPrice_ModelStateValid_RedirectsToManageListPrices(
+        public static async Task Post_AddListPrice_ModelStateValid_RedirectsToPublishListPrice(
             CatalogueItemId catalogueItemId,
             CatalogueItemId additionalServiceId,
             [Frozen] Mock<IAdditionalServicesService> mockAdditionalServicesService,
@@ -719,7 +719,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             actual.Should().NotBeNull();
             actual.Should().BeOfType<RedirectToActionResult>();
             actual.As<RedirectToActionResult>().ControllerName.Should().BeNull();
-            actual.As<RedirectToActionResult>().ActionName.Should().Be(nameof(AdditionalServicesController.ManageListPrices));
+            actual.As<RedirectToActionResult>().ActionName.Should().Be(nameof(AdditionalServicesController.PublishListPrice));
         }
 
         [Theory]
@@ -735,6 +735,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
                 .CataloguePrices
                 .First()
                 .CataloguePriceId;
+
+            catalogueItem.CataloguePrices.First().IsLocked = false;
 
             mockListPricesService
                 .Setup(s => s.GetCatalogueItemWithPrices(additionalServiceId))
@@ -777,7 +779,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
 
         [Theory]
         [CommonAutoData]
-        public static async Task Post_EditListPrice_ModelStateValid_RedirectsToManageListPrices(
+        public static async Task Post_EditListPrice_ModelStateValid_RedirectsToPublishListPrice(
             CatalogueItemId catalogueItemId,
             CatalogueItem catalogueItem,
             [Frozen] Mock<IListPricesService> mockListPricesService,
@@ -789,6 +791,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
                 .First()
                 .CataloguePriceId;
 
+            catalogueItem.CataloguePrices.First().IsLocked = false;
+
             var editListPriceModel = new EditListPriceModel(catalogueItem)
             {
                 CataloguePriceId = cataloguePriceId,
@@ -797,14 +801,17 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
                 Unit = "per patient",
             };
 
+            mockListPricesService.Setup(lps => lps.GetCatalogueItemWithPrices(catalogueItem.Id))
+                .ReturnsAsync(catalogueItem);
+
             var actual = await controller.EditListPrice(catalogueItemId, catalogueItem.Id, cataloguePriceId, editListPriceModel);
 
-            mockListPricesService.Verify(s => s.UpdateListPrice(catalogueItem.Id, It.IsAny<ServiceContracts.Models.SaveListPriceModel>()));
+            mockListPricesService.Verify(s => s.UpdateListPrice(catalogueItem.Id, It.IsAny<SaveListPriceModel>()));
 
             actual.Should().NotBeNull();
             actual.Should().BeOfType<RedirectToActionResult>();
             actual.As<RedirectToActionResult>().ControllerName.Should().BeNull();
-            actual.As<RedirectToActionResult>().ActionName.Should().Be(nameof(AdditionalServicesController.ManageListPrices));
+            actual.As<RedirectToActionResult>().ActionName.Should().Be(nameof(AdditionalServicesController.PublishListPrice));
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/AssociatedServicesControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/AssociatedServicesControllerTests.cs
@@ -473,7 +473,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
 
         [Theory]
         [CommonAutoData]
-        public static async Task Post_AddListPrice_ModelStateValid_RedirectsToManageListPrices(
+        public static async Task Post_AddListPrice_ModelStateValid_RedirectsPublishListPrice(
             CatalogueItemId catalogueItemId,
             CatalogueItemId associatedServiceId,
             [Frozen] Mock<IAssociatedServicesService> mockAssociatedServicesService,
@@ -503,7 +503,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             actual.Should().NotBeNull();
             actual.Should().BeOfType<RedirectToActionResult>();
             actual.As<RedirectToActionResult>().ControllerName.Should().BeNull();
-            actual.As<RedirectToActionResult>().ActionName.Should().Be(nameof(AssociatedServicesController.ManageListPrices));
+            actual.As<RedirectToActionResult>().ActionName.Should().Be(nameof(AssociatedServicesController.PublishListPrice));
         }
 
         [Theory]
@@ -519,6 +519,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
                 .CataloguePrices
                 .First()
                 .CataloguePriceId;
+
+            catalogueItem.CataloguePrices.First().IsLocked = false;
 
             mockListPricesService
                 .Setup(s => s.GetCatalogueItemWithPrices(associatedServiceId))
@@ -561,7 +563,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
 
         [Theory]
         [CommonAutoData]
-        public static async Task Post_EditListPrice_ModelStateValid_RedirectsToManageListPrices(
+        public static async Task Post_EditListPrice_ModelStateValid_RedirectsToPublishListPrice(
             CatalogueItemId catalogueItemId,
             CatalogueItem catalogueItem,
             [Frozen] Mock<IListPricesService> mockListPricesService,
@@ -572,6 +574,11 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
                 .CataloguePrices
                 .First()
                 .CataloguePriceId;
+
+            catalogueItem.CataloguePrices.First().IsLocked = false;
+
+            mockListPricesService.Setup(lps => lps.GetCatalogueItemWithPrices(catalogueItem.Id))
+                 .ReturnsAsync(catalogueItem);
 
             var editListPriceModel = new EditListPriceModel(catalogueItem)
             {
@@ -588,7 +595,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             actual.Should().NotBeNull();
             actual.Should().BeOfType<RedirectToActionResult>();
             actual.As<RedirectToActionResult>().ControllerName.Should().BeNull();
-            actual.As<RedirectToActionResult>().ActionName.Should().Be(nameof(AssociatedServicesController.ManageListPrices));
+            actual.As<RedirectToActionResult>().ActionName.Should().Be(nameof(AssociatedServicesController.PublishListPrice));
         }
 
         [Theory]

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/AdditionalServicesControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/AdditionalServicesControllerTests.cs
@@ -138,7 +138,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
                 catalogueItemCataloguePrice.CurrencyCode = "GBP";
             }
 
-            var prices = catalogueItem.CataloguePrices.Where(p => p.CataloguePriceType == CataloguePriceType.Flat).ToList();
+            var prices = catalogueItem.CataloguePrices.Where(p =>
+            p.CataloguePriceType == CataloguePriceType.Flat
+            && p.PublishedStatus == PublicationStatus.Published).ToList();
 
             var expectedViewData = new SelectAdditionalServicePriceModel(odsCode, state.CallOffId, state.CatalogueItemName, prices);
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/AssociatedServicesControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/AssociatedServicesControllerTests.cs
@@ -147,7 +147,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
                 catalogueItemCataloguePrice.CurrencyCode = "GBP";
             }
 
-            var prices = catalogueItem.CataloguePrices.Where(p => p.CataloguePriceType == CataloguePriceType.Flat).ToList();
+            var prices = catalogueItem.CataloguePrices.Where(p =>
+            p.CataloguePriceType == CataloguePriceType.Flat
+            && p.PublishedStatus == PublicationStatus.Published).ToList();
 
             var expectedViewData = new SelectAssociatedServicePriceModel(odsCode, state.CatalogueItemName, prices);
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/CatalogueSolutionsControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/CatalogueSolutionsControllerTests.cs
@@ -108,6 +108,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
             {
                 catalogueItemCataloguePrice.CataloguePriceType = CataloguePriceType.Flat;
                 catalogueItemCataloguePrice.CurrencyCode = "GBP";
+                catalogueItemCataloguePrice.PublishedStatus = PublicationStatus.Published;
             }
 
             var prices = catalogueItem.CataloguePrices.Where(p => p.CataloguePriceType == CataloguePriceType.Flat).ToList();

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Solutions/Controllers/SolutionsControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Solutions/Controllers/SolutionsControllerTests.cs
@@ -168,7 +168,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Controllers
         [CommonAutoData]
         public static async Task Get_AssociatedServices_ValidSolutionForId_ReturnsExpectedViewResult(
             [Frozen] Mock<ISolutionsService> solutionsServiceMock,
-            CatalogueItemId id,
             ClientApplication clientApplication,
             Solution solution,
             SolutionsController controller)
@@ -177,10 +176,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Solutions.Controllers
             solution.ClientApplication = JsonSerializer.Serialize(clientApplication);
             var associatedServicesModel = new AssociatedServicesModel(catalogueItem);
 
-            solutionsServiceMock.Setup(s => s.GetSolutionWithAllAssociatedServices(id))
+            solutionsServiceMock.Setup(s => s.GetSolutionWithAllAssociatedServices(catalogueItem.Id))
                 .ReturnsAsync(catalogueItem);
 
-            var actual = (await controller.AssociatedServices(id)).As<ViewResult>();
+            var actual = (await controller.AssociatedServices(catalogueItem.Id)).As<ViewResult>();
 
             actual.Should().NotBeNull();
             actual.ViewName.Should().BeNullOrEmpty();


### PR DESCRIPTION
Update list prices to now have a Status and Locking Functionality.

Add PublishStatusId and IsLocked to tables to handle the above functionality

Update List Price admin loading logic to handle the new statuses

update order form to only load published prices

updated market page to only show published prices.

fix the ManageListPrice view not showing the correct edit link paths for the different places that the price could be being edited from.

update status logic to show prices in progress when they're created but none are published.

update ManageListPrice view to hide the now unpublished prices.

fix failing automated tests due the the change in how list prices work