### PR TITLE
Add Minimum Browser Version to Supported Browsers

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Solutions/ClientApplication.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Solutions/ClientApplication.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Serialization;
 using EnumsNET;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions.Serialization;
 
 namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions
 {
@@ -10,7 +12,8 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions
     {
         public HashSet<string> ClientApplicationTypes { get; set; } = new();
 
-        public HashSet<string> BrowsersSupported { get; set; } = new();
+        [JsonConverter(typeof(SupportedBrowsersJsonConverter))]
+        public HashSet<SupportedBrowser> BrowsersSupported { get; set; } = new();
 
         public bool? MobileResponsive { get; set; }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Solutions/Serialization/SupportedBrowsersJsonConverter.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Solutions/Serialization/SupportedBrowsersJsonConverter.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions.Serialization
+{
+    public sealed class SupportedBrowsersJsonConverter : JsonConverter<HashSet<SupportedBrowser>>
+    {
+        public override HashSet<SupportedBrowser> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var output = new HashSet<SupportedBrowser>();
+
+            if (reader.TokenType == JsonTokenType.StartArray)
+            {
+                while (reader.TokenType != JsonTokenType.EndArray)
+                {
+                    if (reader.TokenType == JsonTokenType.StartObject)
+                    {
+                        var supportedBrowser = new SupportedBrowser();
+                        Type supportedBrowserType = typeof(SupportedBrowser);
+                        reader.Read(); // move to first property name token
+                        while (reader.TokenType != JsonTokenType.EndObject)
+                        {
+                            var propertyName = reader.GetString();
+                            reader.Read(); // move from propertyName token to value token
+                            var propertyValue = reader.GetString();
+
+                            var property = supportedBrowserType.GetProperty(propertyName);
+                            property.SetValue(supportedBrowser, propertyValue);
+
+                            reader.Read(); // move to next property in object
+                        }
+
+                        output.Add(supportedBrowser);
+                    }
+
+                    if (reader.TokenType == JsonTokenType.String)
+                    {
+                        var supportedBrowser = new SupportedBrowser
+                        {
+                            BrowserName = reader.GetString(),
+                        };
+                        output.Add(supportedBrowser);
+                    }
+
+                    reader.Read(); // move to next item in array
+                }
+            }
+
+            return output;
+        }
+
+        public override void Write(Utf8JsonWriter writer, HashSet<SupportedBrowser> value, JsonSerializerOptions options)
+        {
+            JsonSerializer.Serialize(writer, value, options);
+        }
+    }
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Solutions/SupportedBrowser.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Solutions/SupportedBrowser.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+
+namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions
+{
+    [ExcludeFromCodeCoverage]
+    public sealed class SupportedBrowser
+    {
+        public string BrowserName { get; set; }
+
+        [MaxLength(50)]
+        public string MinimumBrowserVersion { get; set; }
+    }
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/FieldSet/FieldSetTagHelperBuilders.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/FieldSet/FieldSetTagHelperBuilders.cs
@@ -9,10 +9,10 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.FieldS
 
         public const string NhsFieldset = "nhsuk-fieldset";
         public const string NhsFieldsetLegend = "nhsuk-fieldset__legend";
-        public const string NhsFieldsetLegendExtraLarge = "nhsuk-label--xl";
-        public const string NhsFieldsetLegendLarge = "nhsuk-label--l";
-        public const string NhsFieldsetLegendMedium = "nhsuk-label--m";
-        public const string NhsFieldsetLegendSmall = "nhsuk-label--s";
+        public const string NhsFieldsetLegendExtraLarge = "nhsuk-fieldset__legend--xl";
+        public const string NhsFieldsetLegendLarge = "nhsuk-fieldset__legend--l";
+        public const string NhsFieldsetLegendMedium = "nhsuk-fieldset__legend--m";
+        public const string NhsFieldsetLegendSmall = "nhsuk-fieldset__legend--s";
         public const string NhsFieldSetLegendHeading = "nhsuk-fieldset__heading";
 
         public enum FieldSetSize

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/CatalogueSolutionsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/CatalogueSolutionsController.cs
@@ -537,8 +537,13 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
 
             clientApplication.BrowsersSupported.Clear();
             clientApplication.BrowsersSupported = model.Browsers is null
-                ? new HashSet<string>()
-                : model.Browsers.Where(b => b.Checked).Select(b => b.BrowserName).ToHashSet();
+                ? new HashSet<SupportedBrowser>()
+                : model.Browsers.Where(b => b.Checked).Select(b =>
+                new SupportedBrowser
+                {
+                    BrowserName = b.BrowserName,
+                    MinimumBrowserVersion = b.MinimumBrowserVersion,
+                }).ToHashSet();
 
             clientApplication.MobileResponsive = string.IsNullOrWhiteSpace(model.MobileResponsive)
                 ? null

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/BrowserBasedModels/SupportedBrowserModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/BrowserBasedModels/SupportedBrowserModel.cs
@@ -4,6 +4,8 @@
     {
         public string BrowserName { get; set; }
 
+        public string MinimumBrowserVersion { get; set; }
+
         public bool Checked { get; set; }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/BrowserBasedModels/SupportedBrowsersModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/BrowserBasedModels/SupportedBrowsersModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions;
@@ -49,7 +50,13 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.BrowserBasedModels
             foreach (var browser in Browsers)
             {
                 browser.Checked = ClientApplication.BrowsersSupported is not null &&
-                    ClientApplication.BrowsersSupported.Contains(browser.BrowserName);
+                    ClientApplication.BrowsersSupported.Any(bs => bs.BrowserName.Contains(browser.BrowserName));
+
+                if (ClientApplication.BrowsersSupported.Any(bs => bs.BrowserName.Contains(browser.BrowserName)))
+                {
+                    browser.MinimumBrowserVersion = ClientApplication.BrowsersSupported
+                        .FirstOrDefault(bs => bs.BrowserName.Contains(browser.BrowserName)).MinimumBrowserVersion;
+                }
             }
         }
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/SupportedBrowsers.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/SupportedBrowsers.cshtml
@@ -19,11 +19,17 @@
                 <input type="hidden" asp-for="@Model.SolutionName" />
                 <nhs-fieldset-form-label asp-for="@Model"
                                          label-text="Supported browser types"
-                                         label-hint="Select all the types of browser that are supported by your Catalogue Solution.">
+                                         label-hint="Select all the types of browser and minimum version that are supported by your Catalogue Solution.">
                     <nhs-checkbox-container>
                         @for (var i = 0; i < Model.Browsers.Length; i++)
                         {
-                            <nhs-checkbox asp-for="@Model.Browsers[i].Checked" label-text="@Model.Browsers[i].BrowserName" hidden-input="@Model.Browsers[i].BrowserName" />
+                            <nhs-checkbox asp-for="@Model.Browsers[i].Checked" label-text="@Model.Browsers[i].BrowserName" hidden-input="@Model.Browsers[i].BrowserName" >
+                                <nhs-input
+                                    asp-for="@Model.Browsers[i].MinimumBrowserVersion"
+                                    label-text="Browser version (optional)"
+                                    label-hint="e.g 96 and above, 96.0.1441.110"
+                                    class="nhsuk-u-width-one-third"/>
+                            </nhs-checkbox>
                         }
                     </nhs-checkbox-container>
                 </nhs-fieldset-form-label>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/ClientApplicationTypeModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/ClientApplicationTypeModel.cs
@@ -43,7 +43,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
 
         public string DataTestTag { get; set; }
 
-        public HashSet<string> BrowsersSupported { get; set; } = new();
+        public HashSet<SupportedBrowser> BrowsersSupported { get; set; } = new();
 
         public bool? MobileResponsive { get; set; }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/ClientApplicationTypesModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/ClientApplicationTypesModel.cs
@@ -63,7 +63,15 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
             {
                 items.Add(
                     "Supported browser types",
-                    new ListViewModel { List = ClientApplication.BrowsersSupported.ToArray(), });
+                    new ListViewModel
+                    {
+                        List = ClientApplication
+                        .BrowsersSupported
+                        .Select(bs =>
+                        !string.IsNullOrWhiteSpace(bs.MinimumBrowserVersion)
+                        ? $"{bs.BrowserName} (Version {bs.MinimumBrowserVersion})"
+                        : bs.BrowserName).ToArray(),
+                    });
             }
 
             if (ClientApplication.MobileResponsive is not null)

--- a/tests/NHSD.GPIT.BuyingCatalogue.ServiceContracts.UnitTests/Solutions/ClientApplicationTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.ServiceContracts.UnitTests/Solutions/ClientApplicationTests.cs
@@ -294,7 +294,7 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.UnitTests.Solutions
         public static void SupportedBrowsersStatus_BrowsersSupportedIsEmpty_ReturnsNotStarted(
             ClientApplication clientApplication)
         {
-            clientApplication.BrowsersSupported = new HashSet<string>();
+            clientApplication.BrowsersSupported = new HashSet<SupportedBrowser>();
             clientApplication.MobileResponsive.HasValue.Should().BeTrue();
 
             clientApplication.SupportedBrowsersStatus().Should().Be(TaskProgress.NotStarted);

--- a/tests/NHSD.GPIT.BuyingCatalogue.ServiceContracts.UnitTests/Solutions/Serialization/SupportedBrowsersJsonConverterTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.ServiceContracts.UnitTests/Solutions/Serialization/SupportedBrowsersJsonConverterTests.cs
@@ -1,0 +1,118 @@
+﻿using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions.Serialization;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.UnitTests.Solutions.Serialization
+{
+    public sealed class SupportedBrowsersJsonConverterTests
+    {
+        private readonly HashSet<string> jsonStringArray = new() { "Google Chrome", "Microsoft Edge", "Mozilla Firefox" };
+
+        private readonly HashSet<SupportedBrowser> jsonObjectArray = new()
+        {
+            new SupportedBrowser { BrowserName = "Google Chrome", MinimumBrowserVersion = "96.0.4664.110" },
+            new SupportedBrowser { BrowserName = "Microsoft Edge" },
+            new SupportedBrowser { BrowserName = "Mozilla Firefox" },
+        };
+
+        [Fact]
+        public static void SupportedBrowsersJsonConverter_Read_EmptyHashSetArray_ReturnsNewHashSet()
+        {
+            var expected = new HashSet<SupportedBrowser>();
+
+            var reader = new Utf8JsonReader(new System.Buffers.ReadOnlySequence<byte>(JsonSerializer.SerializeToUtf8Bytes(expected)));
+
+            var jsonConverter = new SupportedBrowsersJsonConverter();
+
+            reader.Read(); // needed to force it to look at the first token
+
+            var result = jsonConverter.Read(ref reader, expected.GetType(), new JsonSerializerOptions());
+
+            result.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public static void SupportedBrowsersJsonConverter_Read_EmptystringArray_ReturnsNewHashSet()
+        {
+            var expected = new HashSet<SupportedBrowser>();
+
+            var input = new HashSet<string>();
+
+            var reader = new Utf8JsonReader(new System.Buffers.ReadOnlySequence<byte>(JsonSerializer.SerializeToUtf8Bytes(input)));
+
+            var jsonConverter = new SupportedBrowsersJsonConverter();
+
+            reader.Read(); // needed to force it to look at the first token
+
+            var result = jsonConverter.Read(ref reader, expected.GetType(), new JsonSerializerOptions());
+
+            result.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void SupportedBrowsersJsonConverter_Read_StringArrayInput_ReturnsHashSet()
+        {
+            var expected = new HashSet<SupportedBrowser>
+            {
+                new SupportedBrowser { BrowserName = "Google Chrome" },
+                new SupportedBrowser { BrowserName = "Microsoft Edge" },
+                new SupportedBrowser { BrowserName = "Mozilla Firefox" },
+            };
+
+            var reader = new Utf8JsonReader(new System.Buffers.ReadOnlySequence<byte>(JsonSerializer.SerializeToUtf8Bytes(jsonStringArray)));
+
+            var jsonConverter = new SupportedBrowsersJsonConverter();
+
+            reader.Read(); // needed to force it to look at the first token
+
+            var result = jsonConverter.Read(ref reader, expected.GetType(), new JsonSerializerOptions());
+
+            result.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void SupportedBrowsersJsonConverter_Read_ObjectArrayInput_ReturnsHashSet()
+        {
+            var expected = new HashSet<SupportedBrowser>
+            {
+                new SupportedBrowser { BrowserName = "Google Chrome", MinimumBrowserVersion = "96.0.4664.110" },
+                new SupportedBrowser { BrowserName = "Microsoft Edge" },
+                new SupportedBrowser { BrowserName = "Mozilla Firefox" },
+            };
+
+            var reader = new Utf8JsonReader(new System.Buffers.ReadOnlySequence<byte>(JsonSerializer.SerializeToUtf8Bytes(jsonObjectArray)));
+
+            var jsonConverter = new SupportedBrowsersJsonConverter();
+
+            reader.Read(); // needed to force it to look at the first token
+
+            var result = jsonConverter.Read(ref reader, expected.GetType(), new JsonSerializerOptions());
+
+            result.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void SupportedBrowsersJsonConverter_Write_ConvertsToObjectJson()
+        {
+            var expected = JsonSerializer.Serialize(jsonObjectArray);
+
+            var stream = new System.IO.MemoryStream();
+
+            var writer = new Utf8JsonWriter(stream);
+
+            var jsonConverter = new SupportedBrowsersJsonConverter();
+
+            jsonConverter.Write(writer, jsonObjectArray, new JsonSerializerOptions());
+
+            var output = Encoding.UTF8.GetString(stream.ToArray());
+
+            stream.Dispose();
+
+            output.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.Test.Framework/AutoFixtureCustomisations/ClientApplicationCustomization.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Test.Framework/AutoFixtureCustomisations/ClientApplicationCustomization.cs
@@ -11,13 +11,13 @@ namespace NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations
     {
         public void Customize(IFixture fixture)
         {
-            var browsersSupported = new HashSet<string>
+            var browsersSupported = new HashSet<SupportedBrowser>
             {
-                "Internet Explorer 11",
-                "Google Chrome",
-                "OPERA",
-                "safari",
-                "mozilla firefox",
+                new SupportedBrowser { BrowserName = "Internet Explorer 11" },
+                new SupportedBrowser { BrowserName = "Google Chrome" },
+                new SupportedBrowser { BrowserName = "OPERA" },
+                new SupportedBrowser { BrowserName = "safari" },
+                new SupportedBrowser { BrowserName = "mozilla firefox" },
             };
 
             ISpecimenBuilder ComposerTransformation(ICustomizationComposer<ClientApplication> composer) => composer


### PR DESCRIPTION
Add new Conditional Minimum Browser Version box to selected supported browsers.

Update the JSON for supported browsers to use an objected called supported browsers instead of string array.

Add SupportedBrowsersJsonConverter so that we can read from the old string array and new object array into a single field, and save everything down in the new object format.

Update Models to include the new MinimumBroswerVersion field if required.

Update FieldSetTagHelperBuilders to apply the correct classes to a fieldsetlabel, since it was using the incorrect ones.

Add Tests for JsonConverter
Add Tests for new conditional Fields.