### PR TITLE
Fix Selected Contact on Solution Marketing Page Being Incorrect

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Solutions/SolutionsService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Solutions/SolutionsService.cs
@@ -75,7 +75,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Solutions
         public async Task<CatalogueItem> GetSolutionWithSupplierDetails(CatalogueItemId solutionId) =>
             await dbContext.CatalogueItems.AsNoTracking()
                 .Include(ci => ci.Solution)
-                    .ThenInclude(s => s.MarketingContacts)
                 .Include(ci => ci.Supplier)
                     .ThenInclude(s => s.SupplierContacts)
                 .Include(ci => ci.CatalogueItemContacts)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/SolutionSupplierDetailsModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/SolutionSupplierDetailsModel.cs
@@ -15,8 +15,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
             Url = catalogueItem.Supplier?.SupplierUrl;
 
             Contacts = catalogueItem
-                .Solution
-                .MarketingContacts
+                .CatalogueItemContacts
                 .Select(mc => new SupplierContactViewModel(mc))
                 .ToList();
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/SupplierContactViewModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/SupplierContactViewModel.cs
@@ -5,7 +5,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
 {
     public sealed class SupplierContactViewModel
     {
-        public SupplierContactViewModel(MarketingContact contact)
+        public SupplierContactViewModel(SupplierContact contact)
         {
             FullName = string.Join(" ", new[] { contact.FirstName, contact.LastName }.Where(str => !string.IsNullOrWhiteSpace(str)));
             PhoneNumber = contact.PhoneNumber;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
@@ -186,6 +186,19 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                         },
                         Integrations = JsonSerializer.Serialize(Integrations.GetIntegrations),
                     },
+                    CatalogueItemContacts = new List<SupplierContact>
+                    {
+                        new()
+                        {
+                            Id = 5,
+                            SupplierId = 99999,
+                            FirstName = "Jan",
+                            LastName = "Bob",
+                            Email = "test@test.com",
+                            Department = "Soaps and Socks",
+                            LastUpdated = DateTime.UtcNow,
+                        },
+                    },
                     CatalogueItemCapabilities = new List<CatalogueItemCapability>
                     {
                         new() { CapabilityId = 43, LastUpdated = DateTime.UtcNow, StatusId = 1 },

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Session/SessionServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Session/SessionServiceTests.cs
@@ -85,6 +85,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Session
             catalogueItem.CatalogueItemCapabilities.Clear();
             catalogueItem.CataloguePrices.Clear();
             catalogueItem.Supplier.CatalogueItems.Clear();
+            catalogueItem.CatalogueItemContacts.Clear();
 
             var service = new SessionService(GetAccessor());
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.Test.Framework/AutoFixtureCustomisations/CatalogueItemCustomization.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Test.Framework/AutoFixtureCustomisations/CatalogueItemCustomization.cs
@@ -47,6 +47,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations
                 AddCapabilities(item, context);
                 AddPrices(item, context);
                 InitializeSupplier(item, context);
+                AddCatalogueItemContacts(item, context);
 
                 return item;
             }
@@ -81,6 +82,13 @@ namespace NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations
 
                 item.Supplier = supplier;
                 item.SupplierId = supplier.Id;
+            }
+
+            private static void AddCatalogueItemContacts(CatalogueItem item, ISpecimenContext context)
+            {
+                var contact = context.Create<SupplierContact>();
+                contact.AssignedCatalogueItems.Add(item);
+                item.CatalogueItemContacts.Add(contact);
             }
         }
     }


### PR DESCRIPTION
Fix the bug on the solutions marketing page where the selected supplier contact was not updating when changed.

The reason for this was that the supplier contacts save into the supplier contacts are saved into the supplier contacts table, but the marketing page was using the marketing contacts table.

Updated Marketing page to get marketing contats from CatalogueItemContacts Table Reference.

Update GetSolutionWithSupplierDetails to not bring back the marketing contacts.

Fix Tests and Update Seed Data