### PR TITLE
Update Order form task list Page

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/OrderDescriptionController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/OrderDescriptionController.cs
@@ -6,6 +6,7 @@ using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.OrderDescription;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.OrderTriage;
 
 namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
 {
@@ -56,14 +57,14 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         }
 
         [HttpGet("~/organisation/{odsCode}/order/neworder/description")]
-        public IActionResult NewOrderDescription(string odsCode)
+        public IActionResult NewOrderDescription(string odsCode, TriageOption? option = null)
         {
             var descriptionModel = new OrderDescriptionModel(odsCode, null)
             {
                 BackLink = Url.Action(
                             nameof(OrderController.NewOrder),
                             typeof(OrderController).ControllerName(),
-                            new { odsCode }),
+                            new { odsCode, option }),
             };
 
             return View("OrderDescription", descriptionModel);

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/Order/OrderModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/Order/OrderModel.cs
@@ -5,7 +5,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.Order
 {
     public sealed class OrderModel : OrderingBaseModel
     {
-        public OrderModel(string odsCode, EntityFramework.Ordering.Models.Order order, OrderTaskList orderSections)
+        public OrderModel(string odsCode, EntityFramework.Ordering.Models.Order order, OrderTaskList orderSections, string organisationName = "")
         {
             OdsCode = odsCode;
             SectionStatuses = orderSections;
@@ -13,7 +13,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.Order
             if (order is null)
             {
                 Title = "New order";
-                TitleAdvice = "Step 1 must be completed before a summary page and ID number are created for this order.";
+                TitleAdvice = "You must provide an order description before a unique ID is created for this order.";
+                OrganisationName = organisationName;
             }
             else
             {
@@ -21,6 +22,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.Order
                 CallOffId = order.CallOffId;
                 TitleAdvice = "Complete the following steps to create an order summary.";
                 Description = order.Description;
+                OrganisationName = order.OrderingParty.Name;
             }
         }
 
@@ -31,6 +33,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.Order
         public string DescriptionUrl { get; set; }
 
         public string TitleAdvice { get; set; }
+
+        public string OrganisationName { get; set; }
 
         public OrderTaskList SectionStatuses { get; set; }
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/Order/ReadyToStartModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/Order/ReadyToStartModel.cs
@@ -1,14 +1,18 @@
-﻿using NHSD.GPIT.BuyingCatalogue.WebApp.Models;
+﻿using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.OrderTriage;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Models;
 
 namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.Order
 {
     public class ReadyToStartModel : NavBaseModel
     {
-        public ReadyToStartModel(string odsCode)
+        public ReadyToStartModel(string odsCode, TriageOption? option)
         {
             OdsCode = odsCode;
+            Option = option;
         }
 
         public string OdsCode { get; set; }
+
+        public TriageOption? Option { get; set; }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/Order/Order.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/Order/Order.cshtml
@@ -11,31 +11,32 @@
         <div class="nhsuk-grid-column-full">
             <nhs-validation-summary />
             <nhs-page-title title="@ViewBag.Title"
-                            advice="@Model.TitleAdvice" />
+                            advice="@Model.TitleAdvice"
+							caption = "@Model.OrganisationName" />
 
-            <nhs-fieldset-form-container asp-for="@Model"
-                                         label-text="Order description"
-                                         label-hint="@Model.Description">
-                <br />
-                <br />
+				@if (!string.IsNullOrWhiteSpace(Model.Description)){
+					<h2 class="nhsuk-heading-s">Description</h2>
+					<p>@Model.Description</p>
+				}
+
                 <nhs-task-list>
                     <nhs-task-list-section label-text="Prepare order">
-                        <nhs-task-list-item label-text="Provide a description of your order"
+                        <nhs-task-list-item label-text="Order description"
                                             url="@Model.DescriptionUrl"
                                             status="@Model.SectionStatuses.DescriptionStatus" />
-                        <nhs-task-list-item label-text="Provide Call-off Ordering Party information"
+                        <nhs-task-list-item label-text="Call-off Ordering Party contact details"
                                             url="@Url.Action(
                                                 nameof(OrderingPartyController.OrderingParty),
                                                 typeof(OrderingPartyController).ControllerName(),
                                                 new { Model.OdsCode, Model.CallOffId})"
                                             status="@Model.SectionStatuses.OrderingPartyStatus" />
-                        <nhs-task-list-item label-text="Provide supplier information"
+                        <nhs-task-list-item label-text="Supplier information and contact details"
                                             url="@Url.Action(
                                                 nameof(SupplierController.Supplier),
                                                 typeof(SupplierController).ControllerName(),
                                                 new { Model.OdsCode, Model.CallOffId})"
                                             status="@Model.SectionStatuses.SupplierStatus" />
-                        <nhs-task-list-item label-text="Provide commencement date for this agreement"
+                        <nhs-task-list-item label-text="Commencement date for this Call-off Agreement"
                                             url="@Url.Action(
                                                 nameof(CommencementDateController.CommencementDate),
                                                 typeof(CommencementDateController).ControllerName(),
@@ -77,7 +78,6 @@
                                             status="@Model.SectionStatuses.ReviewAndCompleteStatus" />
                     </nhs-task-list-section>
                 </nhs-task-list>
-            </nhs-fieldset-form-container>
 
             <vc:nhs-secondary-button text="Preview order summary"
                                      url="@Url.Action(

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/Order/ReadyToStart.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/Order/ReadyToStart.cshtml
@@ -27,7 +27,7 @@
                                      url="@Url.Action(
                                             nameof(OrderController.NewOrder),
                                             typeof(OrderController).ControllerName(),
-                                            new { Model.OdsCode })"
+                                            new { Model.OdsCode, Model.Option })"
                                      use-primary-colour="true" /><br />
         </div>
     </div>

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/NewOrderDashboard.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/NewOrderDashboard.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
 using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
@@ -29,9 +31,12 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering
         }
 
         [Fact]
-        public void NewOrderDashboard_AllSectionsDisplayed()
+        public async Task NewOrderDashboard_AllSectionsDisplayed()
         {
-            CommonActions.PageTitle().Should().BeEquivalentTo("New Order".FormatForComparison());
+            await using var context = GetEndToEndDbContext();
+            var organisation = await context.Organisations.SingleAsync(o => o.OdsCode == Parameters["OdsCode"]);
+
+            CommonActions.PageTitle().Should().BeEquivalentTo($"New Order-{organisation.Name}".FormatForComparison());
             CommonActions.GoBackLinkDisplayed().Should().BeTrue();
 
             CommonActions.ElementIsDisplayed(Objects.Ordering.OrderDashboard.TaskList)
@@ -50,8 +55,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering
             CommonActions.ClickGoBackLink();
 
             CommonActions.PageLoadedCorrectGetIndex(
-                typeof(DashboardController),
-                nameof(DashboardController.Organisation))
+                    typeof(OrderController),
+                    nameof(OrderController.ReadyToStart))
                     .Should().BeTrue();
         }
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Objects/Ordering/OrderDashboard.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Objects/Ordering/OrderDashboard.cs
@@ -6,8 +6,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.Ordering
     {
         public static By TaskList => By.ClassName("bc-c-task-list");
 
-        public static By OrderDescriptionLink => By.LinkText("Provide a description of your order");
+        public static By OrderDescriptionLink => By.LinkText("Order description");
 
-        public static By OrderDescriptionStatus => By.Id("Provide_a_description_of_your_order-status");
+        public static By OrderDescriptionStatus => By.Id("Order_description-status");
     }
 }


### PR DESCRIPTION
Update Section one subsection titles to new format
Update Description H2 to only appear when a description is added
Add Caption for Organisation Name.

Update Controller to use OrganisationService to be able to pull in the selected organisation info for the new order scenario.

Updated linking logic in new order scenario to allow the new order scenario to go all the way from the order decription page back through the Triage process (with selected options intact)

Updated Go back link for created order scenario to be "Go back to dashboard" to be more explicit where the user will be taken too.