### PR TITLE
Fix Buyers being able to view any order

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/ICommencementDateService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/ICommencementDateService.cs
@@ -6,6 +6,6 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders
 {
     public interface ICommencementDateService
     {
-        Task SetCommencementDate(CallOffId callOffId, DateTime? commencementDate);
+        Task SetCommencementDate(CallOffId callOffId, string odsCode, DateTime? commencementDate);
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/IDefaultDeliveryDateService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/IDefaultDeliveryDateService.cs
@@ -6,8 +6,8 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders
 {
     public interface IDefaultDeliveryDateService
     {
-        Task<DateTime?> GetDefaultDeliveryDate(CallOffId callOffId, CatalogueItemId catalogueItemId);
+        Task<DateTime?> GetDefaultDeliveryDate(CallOffId callOffId, string odsCode, CatalogueItemId catalogueItemId);
 
-        Task<DeliveryDateResult> SetDefaultDeliveryDate(CallOffId callOffId, CatalogueItemId catalogueItemId, DateTime deliveryDate);
+        Task<DeliveryDateResult> SetDefaultDeliveryDate(CallOffId callOffId, string odsCode, CatalogueItemId catalogueItemId, DateTime deliveryDate);
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/IFundingSourceService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/IFundingSourceService.cs
@@ -5,6 +5,6 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders
 {
     public interface IFundingSourceService
     {
-        Task SetFundingSource(CallOffId callOffId, bool? onlyGms);
+        Task SetFundingSource(CallOffId callOffId, string odsCode, bool? onlyGms);
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/IOrderDescriptionService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/IOrderDescriptionService.cs
@@ -5,6 +5,6 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders
 {
     public interface IOrderDescriptionService
     {
-        Task SetOrderDescription(CallOffId callOffId, string description);
+        Task SetOrderDescription(CallOffId callOffId, string odsCode, string description);
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/IOrderItemService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/IOrderItemService.cs
@@ -8,12 +8,12 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders
 {
     public interface IOrderItemService
     {
-        Task Create(CallOffId callOffId, CreateOrderItemModel model);
+        Task Create(CallOffId callOffId, string odsCode, CreateOrderItemModel model);
 
-        Task<List<OrderItem>> GetOrderItems(CallOffId callOffId, CatalogueItemType? catalogueItemType);
+        Task<List<OrderItem>> GetOrderItems(CallOffId callOffId, string odsCode, CatalogueItemType? catalogueItemType);
 
-        Task<OrderItem> GetOrderItem(CallOffId callOffId, CatalogueItemId catalogueItemId);
+        Task<OrderItem> GetOrderItem(CallOffId callOffId, string odsCode, CatalogueItemId catalogueItemId);
 
-        Task DeleteOrderItem(CallOffId callOffId, CatalogueItemId catalogueItemId);
+        Task DeleteOrderItem(CallOffId callOffId,  string odsCode, CatalogueItemId catalogueItemId);
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/IOrderService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/IOrderService.cs
@@ -6,24 +6,24 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders
 {
     public interface IOrderService
     {
-        public Task<Order> GetOrderThin(CallOffId callOffId);
+        public Task<Order> GetOrderThin(CallOffId callOffId, string odsCode);
 
-        public Task<Order> GetOrderWithDefaultDeliveryDatesAndOrderItems(CallOffId callOffId);
+        public Task<Order> GetOrderWithDefaultDeliveryDatesAndOrderItems(CallOffId callOffId, string odsCode);
 
-        public Task<Order> GetOrderWithSupplier(CallOffId callOffId);
+        public Task<Order> GetOrderWithSupplier(CallOffId callOffId, string odsCode);
 
-        public Task<Order> GetOrderForSummary(CallOffId callOffId);
+        public Task<Order> GetOrderForSummary(CallOffId callOffId, string odsCode);
 
         public Task<IList<Order>> GetOrders(int organisationId);
 
-        public Task<Order> GetOrderSummary(CallOffId callOffId);
+        public Task<Order> GetOrderSummary(CallOffId callOffId, string odsCode);
 
-        public Task<Order> GetOrderForStatusUpdate(CallOffId callOffId);
+        public Task<Order> GetOrderForStatusUpdate(CallOffId callOffId, string odsCode);
 
         public Task<Order> CreateOrder(string description, string odsCode);
 
-        public Task DeleteOrder(CallOffId callOffId);
+        public Task DeleteOrder(CallOffId callOffId, string odsCode);
 
-        public Task CompleteOrder(CallOffId callOffId);
+        public Task CompleteOrder(CallOffId callOffId, string odsCode);
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/IServiceRecipientService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/IServiceRecipientService.cs
@@ -6,7 +6,7 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders
 {
     public interface IServiceRecipientService
     {
-        Task<List<ServiceRecipient>> GetAllOrderItemRecipients(CallOffId callOffId);
+        Task<List<ServiceRecipient>> GetAllOrderItemRecipients(CallOffId callOffId, string odsCode);
 
         Task<IReadOnlyDictionary<string, ServiceRecipient>> AddOrUpdateServiceRecipients(
             IEnumerable<ServiceRecipient> recipients);

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/ISupplierService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/ISupplierService.cs
@@ -14,9 +14,9 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders
 
         public Task<Supplier> GetSupplierFromBuyingCatalogue(int id);
 
-        public Task AddOrderSupplier(CallOffId callOffId, int supplierId);
+        public Task AddOrderSupplier(CallOffId callOffId, string odsCode, int supplierId);
 
-        public Task AddOrUpdateOrderSupplierContact(CallOffId callOffId, Contact contact);
+        public Task AddOrUpdateOrderSupplierContact(CallOffId callOffId,  string odsCode, Contact contact);
 
         public Task SetSupplierSection(Order order, Supplier supplier, Contact contact);
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/CommencementDateService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/CommencementDateService.cs
@@ -17,11 +17,11 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
             this.dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         }
 
-        public async Task SetCommencementDate(CallOffId callOffId, DateTime? commencementDate)
+        public async Task SetCommencementDate(CallOffId callOffId, string odsCode, DateTime? commencementDate)
         {
             commencementDate.ValidateNotNull(nameof(commencementDate));
 
-            var order = await dbContext.Orders.SingleAsync(o => o.Id == callOffId.Id);
+            var order = await dbContext.Orders.SingleAsync(o => o.Id == callOffId.Id && o.OrderingParty.OdsCode == odsCode);
             order.CommencementDate = commencementDate.Value;
             await dbContext.SaveChangesAsync();
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/FundingSourceService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/FundingSourceService.cs
@@ -18,11 +18,11 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
             this.dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         }
 
-        public async Task SetFundingSource(CallOffId callOffId, bool? onlyGms)
+        public async Task SetFundingSource(CallOffId callOffId, string odsCode, bool? onlyGms)
         {
             onlyGms.ValidateNotNull(nameof(onlyGms));
 
-            var order = await dbContext.Orders.SingleAsync(o => o.Id == callOffId.Id);
+            var order = await dbContext.Orders.SingleAsync(o => o.Id == callOffId.Id && o.OrderingParty.OdsCode == odsCode);
             order.FundingSourceOnlyGms = onlyGms.Value;
             await dbContext.SaveChangesAsync();
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/OrderDescriptionService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/OrderDescriptionService.cs
@@ -17,11 +17,11 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
             this.dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         }
 
-        public async Task SetOrderDescription(CallOffId callOffId, string description)
+        public async Task SetOrderDescription(CallOffId callOffId, string odsCode, string description)
         {
             description.ValidateNotNullOrWhiteSpace(nameof(description));
 
-            var order = await dbContext.Orders.SingleAsync(o => o.Id == callOffId.Id);
+            var order = await dbContext.Orders.SingleAsync(o => o.Id == callOffId.Id && o.OrderingParty.OdsCode == odsCode);
             order.Description = description;
             await dbContext.SaveChangesAsync();
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/OrderItemService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/OrderItemService.cs
@@ -30,12 +30,12 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
             this.orderService = orderService ?? throw new ArgumentNullException(nameof(orderService));
         }
 
-        public async Task Create(CallOffId callOffId, CreateOrderItemModel model)
+        public async Task Create(CallOffId callOffId, string odsCode, CreateOrderItemModel model)
         {
             if (model is null)
                 throw new ArgumentNullException(nameof(model));
 
-            var order = await orderService.GetOrderWithDefaultDeliveryDatesAndOrderItems(callOffId);
+            var order = await orderService.GetOrderWithDefaultDeliveryDatesAndOrderItems(callOffId, odsCode);
 
             var catalogueItemId = model.CatalogueItemId;
             var catalogueItem = await dbContext.FindAsync<CatalogueItem>(catalogueItemId);
@@ -68,7 +68,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
             await dbContext.SaveChangesAsync();
         }
 
-        public async Task<List<OrderItem>> GetOrderItems(CallOffId callOffId, CatalogueItemType? catalogueItemType)
+        public async Task<List<OrderItem>> GetOrderItems(CallOffId callOffId,  string odsCode, CatalogueItemType? catalogueItemType)
         {
             Expression<Func<Order, IEnumerable<OrderItem>>> orderItems = catalogueItemType is null
                 ? o => o.OrderItems
@@ -78,7 +78,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
                 return null;
 
             return await dbContext.Orders
-                .Where(o => o.Id == callOffId.Id)
+                .Where(o => o.Id == callOffId.Id && o.OrderingParty.OdsCode == odsCode)
                 .Include(orderItems).ThenInclude(i => i.CatalogueItem)
                 .Include(orderItems).ThenInclude(i => i.OrderItemRecipients).ThenInclude(r => r.Recipient)
                 .Include(orderItems).ThenInclude(i => i.CataloguePrice).ThenInclude(p => p.PricingUnit)
@@ -87,13 +87,13 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
                 .ToListAsync();
         }
 
-        public Task<OrderItem> GetOrderItem(CallOffId callOffId, CatalogueItemId catalogueItemId)
+        public Task<OrderItem> GetOrderItem(CallOffId callOffId, string odsCode, CatalogueItemId catalogueItemId)
         {
             Expression<Func<Order, IEnumerable<OrderItem>>> orderItems = o =>
                 o.OrderItems.Where(i => i.CatalogueItem.Id == catalogueItemId);
 
             return dbContext.Orders
-                .Where(o => o.Id == callOffId.Id)
+                .Where(o => o.Id == callOffId.Id && o.OrderingParty.OdsCode == odsCode)
                 .Include(orderItems).ThenInclude(i => i.CatalogueItem)
                 .Include(orderItems).ThenInclude(i => i.OrderItemRecipients).ThenInclude(r => r.Recipient)
                 .Include(orderItems).ThenInclude(i => i.CataloguePrice).ThenInclude(p => p.PricingUnit)
@@ -101,10 +101,10 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
                 .SingleOrDefaultAsync();
         }
 
-        public async Task DeleteOrderItem(CallOffId callOffId, CatalogueItemId catalogueItemId)
+        public async Task DeleteOrderItem(CallOffId callOffId,  string odsCode, CatalogueItemId catalogueItemId)
         {
             var order = await dbContext.Orders
-                .Where(o => o.Id == callOffId.Id)
+                .Where(o => o.Id == callOffId.Id && o.OrderingParty.OdsCode == odsCode)
                 .Include(o => o.OrderItems)
                 .Include(o => o.OrderItems).ThenInclude(i => i.CatalogueItem).ThenInclude(a => a.AdditionalService)
                 .SingleAsync();

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/OrderService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/OrderService.cs
@@ -32,10 +32,12 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
             this.orderMessageSettings = orderMessageSettings ?? throw new ArgumentNullException(nameof(orderMessageSettings));
         }
 
-        public Task<Order> GetOrderThin(CallOffId callOffId)
+        public Task<Order> GetOrderThin(CallOffId callOffId, string odsCode)
         {
             return dbContext.Orders
-                .Where(o => o.Id == callOffId.Id)
+                .Where(o =>
+                    o.Id == callOffId.Id
+                    && o.OrderingParty.OdsCode == odsCode)
                 .Include(o => o.OrderingParty)
                 .Include(o => o.OrderingPartyContact)
                 .Include(o => o.Supplier)
@@ -43,29 +45,35 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
                 .SingleOrDefaultAsync();
         }
 
-        public Task<Order> GetOrderWithDefaultDeliveryDatesAndOrderItems(CallOffId callOffId)
+        public Task<Order> GetOrderWithDefaultDeliveryDatesAndOrderItems(CallOffId callOffId, string odsCode)
         {
             return dbContext.Orders
-                .Where(o => o.Id == callOffId.Id)
+                .Where(o =>
+                    o.Id == callOffId.Id
+                    && o.OrderingParty.OdsCode == odsCode)
                 .Include(o => o.OrderItems).ThenInclude(i => i.CatalogueItem)
                 .Include(o => o.OrderItems).ThenInclude(i => i.OrderItemRecipients).ThenInclude(r => r.Recipient)
                 .Include(o => o.DefaultDeliveryDates)
                 .SingleOrDefaultAsync();
         }
 
-        public Task<Order> GetOrderWithSupplier(CallOffId callOffId)
+        public Task<Order> GetOrderWithSupplier(CallOffId callOffId, string odsCode)
         {
             return dbContext.Orders
-                .Where(o => o.Id == callOffId.Id)
+                .Where(o =>
+                    o.Id == callOffId.Id
+                    && o.OrderingParty.OdsCode == odsCode)
                 .Include(o => o.Supplier)
                 .Include(o => o.SupplierContact)
                 .SingleOrDefaultAsync();
         }
 
-        public Task<Order> GetOrderForSummary(CallOffId callOffId)
+        public Task<Order> GetOrderForSummary(CallOffId callOffId, string odsCode)
         {
             return dbContext.Orders
-                .Where(o => o.Id == callOffId.Id)
+                .Where(o =>
+                    o.Id == callOffId.Id
+                    && o.OrderingParty.OdsCode == odsCode)
                 .Include(o => o.OrderingParty)
                 .Include(o => o.OrderingPartyContact)
                 .Include(o => o.Supplier)
@@ -87,10 +95,12 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
                 .ToListAsync();
         }
 
-        public Task<Order> GetOrderSummary(CallOffId callOffId)
+        public Task<Order> GetOrderSummary(CallOffId callOffId, string odsCode)
         {
             return dbContext.Orders
-                .Where(o => o.Id == callOffId.Id)
+                .Where(o =>
+                    o.Id == callOffId.Id
+                    && o.OrderingParty.OdsCode == odsCode)
                 .Include(o => o.OrderingParty)
                 .Include(o => o.OrderingPartyContact)
                 .Include(o => o.SupplierContact)
@@ -100,10 +110,12 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
                 .SingleOrDefaultAsync();
         }
 
-        public Task<Order> GetOrderForStatusUpdate(CallOffId callOffId)
+        public Task<Order> GetOrderForStatusUpdate(CallOffId callOffId, string odsCode)
         {
             return dbContext.Orders
-                .Where(o => o.Id == callOffId.Id)
+                .Where(o =>
+                    o.Id == callOffId.Id
+                    && o.OrderingParty.OdsCode == odsCode)
                 .Include(o => o.OrderingParty)
                 .Include(o => o.Supplier)
                 .Include(o => o.OrderItems).ThenInclude(i => i.CatalogueItem)
@@ -128,18 +140,21 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
             return order;
         }
 
-        public async Task DeleteOrder(CallOffId callOffId)
+        public async Task DeleteOrder(CallOffId callOffId, string odsCode)
         {
-            var order = await dbContext.Orders.Where(o => o.Id == callOffId.Id).SingleAsync();
+            var order = await dbContext.Orders.Where(o => o.Id == callOffId.Id && o.OrderingParty.OdsCode == odsCode).SingleAsync();
 
-            order.IsDeleted = true;
+            if (order != null)
+            {
+                order.IsDeleted = true;
 
-            await dbContext.SaveChangesAsync();
+                await dbContext.SaveChangesAsync();
+            }
         }
 
-        public async Task CompleteOrder(CallOffId callOffId)
+        public async Task CompleteOrder(CallOffId callOffId, string odsCode)
         {
-            var order = await GetOrderThin(callOffId);
+            var order = await GetOrderThin(callOffId, odsCode);
 
             order.Complete();
 

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/ServiceRecipientService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/ServiceRecipientService.cs
@@ -17,13 +17,13 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
         public ServiceRecipientService(BuyingCatalogueDbContext context) =>
             this.context = context ?? throw new ArgumentNullException(nameof(context));
 
-        public async Task<List<ServiceRecipient>> GetAllOrderItemRecipients(CallOffId callOffId)
+        public async Task<List<ServiceRecipient>> GetAllOrderItemRecipients(CallOffId callOffId, string odsCode)
         {
             if (!await context.Orders.AnyAsync(o => o.Id == callOffId.Id))
                 return null;
 
             return await context.Orders
-                .Where(o => o.Id == callOffId.Id)
+                .Where(o => o.Id == callOffId.Id && o.OrderingParty.OdsCode == odsCode)
                 .SelectMany(o => o.OrderItems)
                 .Where(o => o.CatalogueItem.CatalogueItemType == CatalogueItemType.Solution)
                 .SelectMany(o => o.OrderItemRecipients)

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/SupplierService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/SupplierService.cs
@@ -59,22 +59,22 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
                 .SingleAsync();
         }
 
-        public async Task AddOrderSupplier(CallOffId callOffId, int supplierId)
+        public async Task AddOrderSupplier(CallOffId callOffId, string odsCode, int supplierId)
         {
             var supplier = await GetSupplierFromBuyingCatalogue(supplierId);
-            var order = await orderService.GetOrderWithSupplier(callOffId);
+            var order = await orderService.GetOrderWithSupplier(callOffId, odsCode);
 
             order.Supplier = supplier;
 
             await dbContext.SaveChangesAsync();
         }
 
-        public async Task AddOrUpdateOrderSupplierContact(CallOffId callOffId, Contact contact)
+        public async Task AddOrUpdateOrderSupplierContact(CallOffId callOffId, string odsCode, Contact contact)
         {
             if (contact is null)
                 throw new ArgumentNullException(nameof(contact));
 
-            var order = await orderService.GetOrderWithSupplier(callOffId);
+            var order = await orderService.GetOrderWithSupplier(callOffId, odsCode);
 
             switch (order.SupplierContact)
             {

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Session/OrderSessionService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Session/OrderSessionService.cs
@@ -95,11 +95,11 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Session
                 return state;
             }
 
-            var orderItem = await orderItemService.GetOrderItem(callOffId, catalogueItemId);
+            var orderItem = await orderItemService.GetOrderItem(callOffId, odsCode, catalogueItemId);
 
             if (state is null)
             {
-                var order = await orderService.GetOrderThin(callOffId);
+                var order = await orderService.GetOrderThin(callOffId, odsCode);
                 var solution = await solutionsService.GetSolutionListPrices(orderItem.CatalogueItemId);
 
                 state = new CreateOrderItemModel

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/AdditionalServiceRecipientsDateController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/AdditionalServiceRecipientsDateController.cs
@@ -32,7 +32,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         {
             var state = orderSessionService.GetOrderStateFromSession(callOffId);
 
-            var defaultDeliveryDate = await defaultDeliveryDateService.GetDefaultDeliveryDate(callOffId, state.CatalogueItemId.GetValueOrDefault());
+            var defaultDeliveryDate = await defaultDeliveryDateService.GetDefaultDeliveryDate(callOffId, odsCode, state.CatalogueItemId.GetValueOrDefault());
 
             var model = new SelectAdditionalServiceRecipientsDateModel(state, defaultDeliveryDate)
             {
@@ -55,7 +55,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
 
             state.PlannedDeliveryDate = model.DeliveryDate;
 
-            await defaultDeliveryDateService.SetDefaultDeliveryDate(callOffId, state.CatalogueItemId.GetValueOrDefault(), model.DeliveryDate!.Value);
+            await defaultDeliveryDateService.SetDefaultDeliveryDate(callOffId, odsCode, state.CatalogueItemId.GetValueOrDefault(), model.DeliveryDate!.Value);
 
             orderSessionService.SetOrderStateToSession(state);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/AdditionalServicesController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/AdditionalServicesController.cs
@@ -44,8 +44,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         {
             orderSessionService.ClearSession(callOffId);
 
-            var order = await orderService.GetOrderThin(callOffId);
-            var orderItems = await orderItemService.GetOrderItems(callOffId, CatalogueItemType.AdditionalService);
+            var order = await orderService.GetOrderThin(callOffId, odsCode);
+            var orderItems = await orderItemService.GetOrderItems(callOffId, odsCode, CatalogueItemType.AdditionalService);
 
             var model = new AdditionalServiceModel(odsCode, order, orderItems)
             {
@@ -61,10 +61,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         [HttpGet("select/additional-service")]
         public async Task<IActionResult> SelectAdditionalService(string odsCode, CallOffId callOffId)
         {
-            var order = await orderService.GetOrderThin(callOffId);
+            var order = await orderService.GetOrderThin(callOffId, odsCode);
 
             // Get Catalogue Solutions related to the order
-            var orderItems = await orderItemService.GetOrderItems(callOffId, CatalogueItemType.Solution);
+            var orderItems = await orderItemService.GetOrderItems(callOffId, odsCode, CatalogueItemType.Solution);
             var solutionIds = orderItems.Select(i => i.CatalogueItemId).ToList();
 
             var state = orderSessionService.InitialiseStateForCreate(order, CatalogueItemType.AdditionalService, solutionIds, null);
@@ -97,7 +97,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
                 return View(model);
             }
 
-            var existingOrder = await orderItemService.GetOrderItem(callOffId, model.SelectedAdditionalServiceId.GetValueOrDefault());
+            var existingOrder = await orderItemService.GetOrderItem(callOffId, odsCode, model.SelectedAdditionalServiceId.GetValueOrDefault());
 
             if (existingOrder is not null)
             {
@@ -278,7 +278,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
             state.AgreedPrice = model.OrderItem.AgreedPrice;
             state.ServiceRecipients = model.OrderItem.ServiceRecipients;
 
-            await orderItemService.Create(callOffId, state);
+            await orderItemService.Create(callOffId, odsCode, state);
 
             orderSessionService.ClearSession(callOffId);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/AssociatedServicesController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/AssociatedServicesController.cs
@@ -48,8 +48,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         {
             orderSessionService.ClearSession(callOffId);
 
-            var order = await orderService.GetOrderThin(callOffId);
-            var orderItems = await orderItemService.GetOrderItems(callOffId, CatalogueItemType.AssociatedService);
+            var order = await orderService.GetOrderThin(callOffId, odsCode);
+            var orderItems = await orderItemService.GetOrderItems(callOffId, odsCode, CatalogueItemType.AssociatedService);
 
             var model = new AssociatedServiceModel(odsCode, order, orderItems)
             {
@@ -65,7 +65,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         [HttpGet("select/associated-service")]
         public async Task<IActionResult> SelectAssociatedService(string odsCode, CallOffId callOffId)
         {
-            var order = await orderService.GetOrderThin(callOffId);
+            var order = await orderService.GetOrderThin(callOffId, odsCode);
 
             var organisation = await organisationService.GetOrganisationByOdsCode(odsCode);
 
@@ -103,7 +103,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
                 return View(model);
             }
 
-            var existingOrder = await orderItemService.GetOrderItem(callOffId, model.SelectedSolutionId.Value);
+            var existingOrder = await orderItemService.GetOrderItem(callOffId, odsCode, model.SelectedSolutionId.Value);
 
             if (existingOrder != null)
             {
@@ -216,7 +216,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
             state.AgreedPrice = model.OrderItem.AgreedPrice;
             state.ServiceRecipients = model.OrderItem.ServiceRecipients;
 
-            await orderItemService.Create(callOffId, state);
+            await orderItemService.Create(callOffId, odsCode, state);
 
             orderSessionService.ClearSession(callOffId);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/CatalogueSolutionRecipientsDateController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/CatalogueSolutionRecipientsDateController.cs
@@ -32,7 +32,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         {
             var state = orderSessionService.GetOrderStateFromSession(callOffId);
 
-            var defaultDeliveryDate = await defaultDeliveryDateService.GetDefaultDeliveryDate(callOffId, state.CatalogueItemId.GetValueOrDefault());
+            var defaultDeliveryDate = await defaultDeliveryDateService.GetDefaultDeliveryDate(callOffId, odsCode, state.CatalogueItemId.GetValueOrDefault());
 
             var model = new SelectSolutionServiceRecipientsDateModel(state, defaultDeliveryDate)
             {
@@ -54,7 +54,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
             var state = orderSessionService.GetOrderStateFromSession(callOffId);
             state.PlannedDeliveryDate = model.DeliveryDate;
 
-            await defaultDeliveryDateService.SetDefaultDeliveryDate(callOffId, state.CatalogueItemId.GetValueOrDefault(), model.DeliveryDate!.Value);
+            await defaultDeliveryDateService.SetDefaultDeliveryDate(callOffId, odsCode, state.CatalogueItemId.GetValueOrDefault(), model.DeliveryDate!.Value);
 
             orderSessionService.SetOrderStateToSession(state);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/CatalogueSolutionsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/CatalogueSolutionsController.cs
@@ -40,8 +40,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         {
             orderSessionService.ClearSession(callOffId);
 
-            var order = await orderService.GetOrderThin(callOffId);
-            var orderItems = await orderItemService.GetOrderItems(callOffId, CatalogueItemType.Solution);
+            var order = await orderService.GetOrderThin(callOffId, odsCode);
+            var orderItems = await orderItemService.GetOrderItems(callOffId, odsCode, CatalogueItemType.Solution);
 
             var model = new CatalogueSolutionsModel(odsCode, order, orderItems)
             {
@@ -57,7 +57,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         [HttpGet("select/solution")]
         public async Task<IActionResult> SelectSolution(string odsCode, CallOffId callOffId)
         {
-            var order = await orderService.GetOrderThin(callOffId);
+            var order = await orderService.GetOrderThin(callOffId, odsCode);
 
             var state = orderSessionService.InitialiseStateForCreate(order, CatalogueItemType.Solution, null, null);
 
@@ -82,7 +82,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
                 return View(model);
             }
 
-            var existingOrder = await orderItemService.GetOrderItem(callOffId, model.SelectedSolutionId.GetValueOrDefault());
+            var existingOrder = await orderItemService.GetOrderItem(callOffId, odsCode, model.SelectedSolutionId.GetValueOrDefault());
 
             if (existingOrder is not null)
             {
@@ -263,7 +263,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
             state.AgreedPrice = model.OrderItem.AgreedPrice;
             state.ServiceRecipients = model.OrderItem.ServiceRecipients;
 
-            await orderItemService.Create(callOffId, state);
+            await orderItemService.Create(callOffId, odsCode, state);
 
             orderSessionService.ClearSession(callOffId);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/CommencementDateController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/CommencementDateController.cs
@@ -29,7 +29,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         [HttpGet]
         public async Task<IActionResult> CommencementDate(string odsCode, CallOffId callOffId)
         {
-            var order = await orderService.GetOrderThin(callOffId);
+            var order = await orderService.GetOrderThin(callOffId, odsCode);
 
             var model = new CommencementDateModel(odsCode, callOffId, order.CommencementDate)
             {
@@ -48,7 +48,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
             if (!ModelState.IsValid)
                 return View(model);
 
-            await commencementDateService.SetCommencementDate(callOffId, model.CommencementDate!.Value);
+            await commencementDateService.SetCommencementDate(callOffId, odsCode, model.CommencementDate!.Value);
 
             return RedirectToAction(
                 nameof(OrderController.Order),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/DeleteAdditionalServiceController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/DeleteAdditionalServiceController.cs
@@ -28,7 +28,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         [HttpGet]
         public async Task<IActionResult> DeleteAdditionalService(string odsCode, CallOffId callOffId, CatalogueItemId catalogueItemId, string catalogueItemName)
         {
-            var order = await orderService.GetOrderThin(callOffId);
+            var order = await orderService.GetOrderThin(callOffId, odsCode);
 
             var model = new DeleteAdditionalServiceModel(odsCode, callOffId, catalogueItemId, catalogueItemName, order.Description)
             {
@@ -44,7 +44,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         [HttpPost]
         public async Task<IActionResult> DeleteAdditionalService(string odsCode, CallOffId callOffId, CatalogueItemId catalogueItemId, string catalogueItemName, DeleteAdditionalServiceModel model)
         {
-            await orderItemService.DeleteOrderItem(callOffId, catalogueItemId);
+            await orderItemService.DeleteOrderItem(callOffId, odsCode, catalogueItemId);
 
             return RedirectToAction(
                 nameof(AdditionalServicesController.Index),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/DeleteAssociatedServiceController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/DeleteAssociatedServiceController.cs
@@ -32,7 +32,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
             CatalogueItemId catalogueItemId,
             string catalogueItemName)
         {
-            var order = await orderService.GetOrderThin(callOffId);
+            var order = await orderService.GetOrderThin(callOffId, odsCode);
 
             var model = new DeleteAssociatedServiceModel(odsCode, callOffId, catalogueItemId, catalogueItemName, order.Description)
             {
@@ -53,7 +53,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
             string catalogueItemName,
             DeleteAssociatedServiceModel model)
         {
-            await orderItemService.DeleteOrderItem(callOffId, catalogueItemId);
+            await orderItemService.DeleteOrderItem(callOffId, odsCode, catalogueItemId);
 
             return RedirectToAction(
                 nameof(AssociatedServicesController.Index),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/DeleteCatalogueSolutionController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/DeleteCatalogueSolutionController.cs
@@ -32,7 +32,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
             CatalogueItemId catalogueItemId,
             string catalogueItemName)
         {
-            var order = await orderService.GetOrderThin(callOffId);
+            var order = await orderService.GetOrderThin(callOffId, odsCode);
 
             var model = new DeleteSolutionModel(odsCode, callOffId, catalogueItemId, catalogueItemName, order.Description)
             {
@@ -53,7 +53,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
             string catalogueItemName,
             DeleteSolutionModel model)
         {
-            await orderItemService.DeleteOrderItem(callOffId, catalogueItemId);
+            await orderItemService.DeleteOrderItem(callOffId, odsCode, catalogueItemId);
 
             return RedirectToAction(
                 nameof(CatalogueSolutionsController.Index),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/DeleteOrderController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/DeleteOrderController.cs
@@ -24,7 +24,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         [HttpGet]
         public async Task<IActionResult> DeleteOrder(string odsCode, CallOffId callOffId)
         {
-            var order = await orderService.GetOrderThin(callOffId);
+            var order = await orderService.GetOrderThin(callOffId, odsCode);
 
             var model = new DeleteOrderModel(odsCode, order)
             {
@@ -40,7 +40,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         [HttpPost]
         public async Task<IActionResult> DeleteOrder(string odsCode, CallOffId callOffId, DeleteOrderModel model)
         {
-            await orderService.DeleteOrder(callOffId);
+            await orderService.DeleteOrder(callOffId, odsCode);
 
             return RedirectToAction(
                 nameof(DashboardController.Organisation),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/FundingSourceController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/FundingSourceController.cs
@@ -28,7 +28,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         [HttpGet]
         public async Task<IActionResult> FundingSource(string odsCode, CallOffId callOffId)
         {
-            var order = await orderService.GetOrderThin(callOffId);
+            var order = await orderService.GetOrderThin(callOffId, odsCode);
 
             var model = new FundingSourceModel(odsCode, callOffId, order.FundingSourceOnlyGms)
             {
@@ -49,7 +49,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
 
             var onlyGms = model.FundingSourceOnlyGms.EqualsIgnoreCase("Yes");
 
-            await fundingSourceService.SetFundingSource(callOffId, onlyGms);
+            await fundingSourceService.SetFundingSource(callOffId, odsCode, onlyGms);
 
             return RedirectToAction(
                 nameof(OrderController.Order),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/OrderController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/OrderController.cs
@@ -31,7 +31,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         [HttpGet]
         public async Task<IActionResult> Order(string odsCode, CallOffId callOffId)
         {
-            var order = await orderService.GetOrderThin(callOffId);
+            var order = await orderService.GetOrderThin(callOffId, odsCode);
 
             if (order.OrderStatus == OrderStatus.Complete)
             {
@@ -93,7 +93,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         [HttpGet("summary")]
         public async Task<IActionResult> Summary(string odsCode, CallOffId callOffId, string print = "false")
         {
-            var order = await orderService.GetOrderForSummary(callOffId);
+            var order = await orderService.GetOrderForSummary(callOffId, odsCode);
 
             var model = new SummaryModel(odsCode, order)
             {
@@ -132,7 +132,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         [HttpPost("summary")]
         public async Task<IActionResult> Summary(string odsCode, CallOffId callOffId)
         {
-            var order = await orderService.GetOrderForSummary(callOffId);
+            var order = await orderService.GetOrderForSummary(callOffId, odsCode);
 
             if (!order.CanComplete())
             {
@@ -141,7 +141,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
                 return View(model);
             }
 
-            await orderService.CompleteOrder(callOffId);
+            await orderService.CompleteOrder(callOffId, odsCode);
 
             return RedirectToAction();
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/OrderDescriptionController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/OrderDescriptionController.cs
@@ -28,7 +28,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         [HttpGet]
         public async Task<IActionResult> OrderDescription(string odsCode, CallOffId callOffId)
         {
-            var order = await orderService.GetOrderThin(callOffId);
+            var order = await orderService.GetOrderThin(callOffId, odsCode);
 
             var descriptionModel = new OrderDescriptionModel(odsCode, order)
             {
@@ -47,7 +47,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
             if (!ModelState.IsValid)
                 return View(model);
 
-            await orderDescriptionService.SetOrderDescription(callOffId, model.Description);
+            await orderDescriptionService.SetOrderDescription(callOffId, odsCode, model.Description);
 
             return RedirectToAction(
                 nameof(OrderController.Order),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/OrderingPartyController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/OrderingPartyController.cs
@@ -36,7 +36,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         [HttpGet]
         public async Task<IActionResult> OrderingParty(string odsCode, CallOffId callOffId)
         {
-            var order = await orderService.GetOrderThin(callOffId);
+            var order = await orderService.GetOrderThin(callOffId, odsCode);
             var organisation = await organisationService.GetOrganisationByOdsCode(odsCode);
 
             var model = new OrderingPartyModel(odsCode, order, organisation)
@@ -56,7 +56,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
             if (!ModelState.IsValid)
                 return View(model);
 
-            var order = await orderService.GetOrderThin(callOffId);
+            var order = await orderService.GetOrderThin(callOffId, odsCode);
 
             var contact = contactDetailsService.AddOrUpdatePrimaryContact(
                 order.OrderingPartyContact,

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/SupplierController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/SupplierController.cs
@@ -105,7 +105,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         [HttpGet("search/select")]
         public async Task<IActionResult> SupplierSearchSelect(string odsCode, CallOffId callOffId, [FromQuery] string search)
         {
-            var order = await orderService.GetOrderWithSupplier(callOffId);
+            var order = await orderService.GetOrderWithSupplier(callOffId, odsCode);
 
             if (order?.Supplier is not null)
             {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/SupplierController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/SupplierController.cs
@@ -28,7 +28,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         [HttpGet]
         public async Task<IActionResult> Supplier(string odsCode, CallOffId callOffId)
         {
-            var order = await orderService.GetOrderWithSupplier(callOffId);
+            var order = await orderService.GetOrderWithSupplier(callOffId, odsCode);
 
             if (order.Supplier is null)
             {
@@ -61,7 +61,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
                 return View(model);
             }
 
-            await supplierService.AddOrUpdateOrderSupplierContact(callOffId, model.PrimaryContact);
+            await supplierService.AddOrUpdateOrderSupplierContact(callOffId, odsCode, model.PrimaryContact);
 
             return RedirectToAction(
                 nameof(OrderController.Order),
@@ -72,7 +72,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
         [HttpGet("search")]
         public async Task<IActionResult> SupplierSearch(string odsCode, CallOffId callOffId)
         {
-            var order = await orderService.GetOrderWithSupplier(callOffId);
+            var order = await orderService.GetOrderWithSupplier(callOffId, odsCode);
 
             if (order.Supplier is not null)
             {
@@ -128,7 +128,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
             }
 
             // Model validation ensures that a supplier is selected
-            await supplierService.AddOrderSupplier(callOffId, model.SelectedSupplierId!.Value);
+            await supplierService.AddOrderSupplier(callOffId, odsCode, model.SelectedSupplierId!.Value);
 
             return RedirectToAction(
                 nameof(Supplier),

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Orders/CommencementDateServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Orders/CommencementDateServiceTests.cs
@@ -37,7 +37,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Orders
             context.Orders.Add(order);
             await context.SaveChangesAsync();
 
-            await service.SetCommencementDate(order.CallOffId, commencementDate);
+            await service.SetCommencementDate(order.CallOffId, order.OrderingParty.OdsCode, commencementDate);
 
             var updatedOrder = await context.Orders.SingleAsync();
             updatedOrder.CommencementDate.Should().Be(commencementDate);

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Orders/DefaultDeliveryDateServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Orders/DefaultDeliveryDateServiceTests.cs
@@ -42,7 +42,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Orders
 
             await context.SaveChangesAsync();
 
-            await service.SetDefaultDeliveryDate(order.CallOffId, order.DefaultDeliveryDates.First().CatalogueItemId, deliveryDate);
+            await service.SetDefaultDeliveryDate(order.CallOffId, order.OrderingParty.OdsCode, order.DefaultDeliveryDates.First().CatalogueItemId, deliveryDate);
 
             var actual = await context.Orders
                 .Include(o => o.DefaultDeliveryDates)

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Orders/FundingSourceServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Orders/FundingSourceServiceTests.cs
@@ -37,7 +37,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Orders
             context.Orders.Add(order);
             await context.SaveChangesAsync();
 
-            await service.SetFundingSource(order.CallOffId, fundingSource);
+            await service.SetFundingSource(order.CallOffId, order.OrderingParty.OdsCode, fundingSource);
 
             var updatedOrder = await context.Orders.SingleAsync();
             updatedOrder.FundingSourceOnlyGms.Should().Be(fundingSource);

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Orders/OrderDescriptionServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Orders/OrderDescriptionServiceTests.cs
@@ -37,7 +37,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Orders
             context.Orders.Add(order);
             await context.SaveChangesAsync();
 
-            await service.SetOrderDescription(order.CallOffId, description);
+            await service.SetOrderDescription(order.CallOffId, order.OrderingParty.OdsCode, description);
 
             var updatedOrder = await context.Orders.SingleAsync();
             updatedOrder.Description.Should().Be(description);

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Orders/OrderItemServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Orders/OrderItemServiceTests.cs
@@ -46,7 +46,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Orders
             await context.Orders.AddAsync(order);
             await context.SaveChangesAsync();
 
-            await service.DeleteOrderItem(order.CallOffId, orderItem2.CatalogueItemId);
+            await service.DeleteOrderItem(order.CallOffId, order.OrderingParty.OdsCode, orderItem2.CatalogueItemId);
 
             var updatedOrder = await context.Orders.FirstOrDefaultAsync();
 
@@ -72,7 +72,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Orders
             await context.Orders.AddAsync(order);
             await context.SaveChangesAsync();
 
-            await service.DeleteOrderItem(order.CallOffId, orderItem.CatalogueItemId);
+            await service.DeleteOrderItem(order.CallOffId, order.OrderingParty.OdsCode, orderItem.CatalogueItemId);
 
             var updatedOrder = await context.Orders.AsAsyncEnumerable().FirstOrDefaultAsync();
 
@@ -85,7 +85,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Orders
         [InMemoryDbAutoData]
         public static Task Create_NullModel_ThrowsException(OrderItemService service)
         {
-            return Assert.ThrowsAsync<ArgumentNullException>(() => service.Create(default, null));
+            return Assert.ThrowsAsync<ArgumentNullException>(() => service.Create(default, null, null));
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Orders/OrderServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Orders/OrderServiceTests.cs
@@ -54,7 +54,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Orders
             await context.Orders.AddAsync(order);
             await context.SaveChangesAsync();
 
-            await service.DeleteOrder(order.CallOffId);
+            await service.DeleteOrder(order.CallOffId, order.OrderingParty.OdsCode);
 
             var updatedOrder = await context.Orders.FirstOrDefaultAsync();
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Orders/SupplierServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Orders/SupplierServiceTests.cs
@@ -27,7 +27,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Orders
             SupplierService service)
         {
             return Assert.ThrowsAsync<ArgumentNullException>(
-                () => service.AddOrUpdateOrderSupplierContact(default, null));
+                () => service.AddOrUpdateOrderSupplierContact(default, null, null));
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/AdditionalServiceRecipientsDateControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/AdditionalServiceRecipientsDateControllerTests.cs
@@ -166,7 +166,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
 
             updatedState.PlannedDeliveryDate.Should().Be(DateTime.UtcNow.AddDays(1).Date);
 
-            defaultDeliveryDateServiceMock.Verify(c => c.SetDefaultDeliveryDate(state.CallOffId, state.CatalogueItemId.GetValueOrDefault(), DateTime.UtcNow.AddDays(1).Date), Times.Once());
+            defaultDeliveryDateServiceMock.Verify(c => c.SetDefaultDeliveryDate(state.CallOffId, odsCode, state.CatalogueItemId.GetValueOrDefault(), DateTime.UtcNow.AddDays(1).Date), Times.Once());
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/AdditionalServicesControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/AdditionalServicesControllerTests.cs
@@ -55,9 +55,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
         {
             var expectedViewData = new AdditionalServiceModel(odsCode, order, orderItems);
 
-            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId, odsCode)).ReturnsAsync(order);
 
-            orderItemServiceMock.Setup(s => s.GetOrderItems(order.CallOffId, CatalogueItemType.AdditionalService))
+            orderItemServiceMock.Setup(s => s.GetOrderItems(order.CallOffId, odsCode, CatalogueItemType.AdditionalService))
                 .ReturnsAsync(orderItems);
 
             var actualResult = await controller.Index(odsCode, order.CallOffId);
@@ -103,9 +103,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
         {
             var expectedViewData = new SelectAdditionalServiceModel(odsCode, state.CallOffId, additionalServices, state.CatalogueItemId);
 
-            orderServiceMock.Setup(s => s.GetOrderThin(state.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderThin(state.CallOffId, odsCode)).ReturnsAsync(order);
 
-            orderItemServiceMock.Setup(s => s.GetOrderItems(state.CallOffId, CatalogueItemType.Solution))
+            orderItemServiceMock.Setup(s => s.GetOrderItems(state.CallOffId, odsCode, CatalogueItemType.Solution))
                 .ReturnsAsync(orderItems);
 
             var solutionIds = orderItems.Select(i => i.CatalogueItemId).ToList();

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/AssociatedServicesControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/AssociatedServicesControllerTests.cs
@@ -57,9 +57,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
         {
             var expectedViewData = new AssociatedServiceModel(odsCode, order, orderItems);
 
-            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId, odsCode)).ReturnsAsync(order);
 
-            orderItemServiceMock.Setup(s => s.GetOrderItems(order.CallOffId, CatalogueItemType.AssociatedService))
+            orderItemServiceMock.Setup(s => s.GetOrderItems(order.CallOffId, odsCode, CatalogueItemType.AssociatedService))
                 .ReturnsAsync(orderItems);
 
             var actualResult = await controller.Index(odsCode, order.CallOffId);
@@ -82,7 +82,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
         {
             var expectedViewData = new NoAssociatedServicesFoundModel();
 
-            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId, odsCode)).ReturnsAsync(order);
 
             organisationServiceMock.Setup(s => s.GetOrganisationByOdsCode(It.IsAny<string>()))
                 .ReturnsAsync(organisation);
@@ -113,7 +113,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
         {
             var expectedViewData = new SelectAssociatedServiceModel(odsCode, state.CallOffId, associatedServices, state.CatalogueItemId);
 
-            orderServiceMock.Setup(s => s.GetOrderThin(state.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderThin(state.CallOffId, odsCode)).ReturnsAsync(order);
 
             organisationServiceMock.Setup(s => s.GetOrganisationByOdsCode(It.IsAny<string>()))
                 .ReturnsAsync(organisation);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/CatalogueSolutionRecipientsDateControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/CatalogueSolutionRecipientsDateControllerTests.cs
@@ -166,7 +166,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
 
             updatedState.PlannedDeliveryDate.Should().Be(DateTime.UtcNow.AddDays(1).Date);
 
-            defaultDeliveryDateServiceMock.Verify(c => c.SetDefaultDeliveryDate(state.CallOffId, state.CatalogueItemId.GetValueOrDefault(), DateTime.UtcNow.AddDays(1).Date), Times.Once());
+            defaultDeliveryDateServiceMock.Verify(c => c.SetDefaultDeliveryDate(state.CallOffId, odsCode, state.CatalogueItemId.GetValueOrDefault(), DateTime.UtcNow.AddDays(1).Date), Times.Once());
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/CatalogueSolutionsControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/CatalogueSolutionsControllerTests.cs
@@ -54,9 +54,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
         {
             var expectedViewData = new CatalogueSolutionsModel(odsCode, order, orderItems);
 
-            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId, odsCode)).ReturnsAsync(order);
 
-            orderItemServiceMock.Setup(s => s.GetOrderItems(order.CallOffId, CatalogueItemType.Solution))
+            orderItemServiceMock.Setup(s => s.GetOrderItems(order.CallOffId, odsCode, CatalogueItemType.Solution))
                 .ReturnsAsync(orderItems);
 
             var actualResult = await controller.Index(odsCode, order.CallOffId);
@@ -80,7 +80,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
         {
             var expectedViewData = new SelectSolutionModel(odsCode, state.CallOffId, solutions, state.CatalogueItemId);
 
-            orderServiceMock.Setup(s => s.GetOrderThin(state.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderThin(state.CallOffId, odsCode)).ReturnsAsync(order);
 
             orderSessionServiceMock.Setup(s => s.InitialiseStateForCreate(order, CatalogueItemType.Solution, null, null)).Returns(state);
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/CommencementDateControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/CommencementDateControllerTests.cs
@@ -49,7 +49,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
         {
             var expectedViewData = new CommencementDateModel(odsCode, order.CallOffId, order.CommencementDate);
 
-            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId, odsCode)).ReturnsAsync(order);
 
             var actualResult = await controller.CommencementDate(odsCode, order.CallOffId);
 
@@ -82,7 +82,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
             actualResult.As<RedirectToActionResult>().ControllerName.Should().Be(typeof(OrderController).ControllerName());
             actualResult.As<RedirectToActionResult>().RouteValues.Should().BeEquivalentTo(new RouteValueDictionary { { "odsCode", odsCode }, { "callOffId", state.CallOffId } });
 
-            commencementDateServiceMock.Verify(c => c.SetCommencementDate(state.CallOffId, DateTime.UtcNow.AddDays(1).Date), Times.Once);
+            commencementDateServiceMock.Verify(c => c.SetCommencementDate(state.CallOffId, odsCode, DateTime.UtcNow.AddDays(1).Date), Times.Once);
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/DeleteAdditionalServiceControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/DeleteAdditionalServiceControllerTests.cs
@@ -49,7 +49,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
         {
             var expectedViewData = new DeleteAdditionalServiceModel(odsCode, order.CallOffId, catalogueItemId, catalogueItemName, order.Description);
 
-            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId, odsCode)).ReturnsAsync(order);
 
             var actualResult = await controller.DeleteAdditionalService(odsCode, order.CallOffId, catalogueItemId, catalogueItemName);
 
@@ -74,7 +74,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
             actualResult.As<RedirectToActionResult>().ActionName.Should().Be(nameof(AdditionalServicesController.Index));
             actualResult.As<RedirectToActionResult>().ControllerName.Should().Be(typeof(AdditionalServicesController).ControllerName());
             actualResult.As<RedirectToActionResult>().RouteValues.Should().BeEquivalentTo(new RouteValueDictionary { { "odsCode", odsCode }, { "callOffId", callOffId } });
-            orderItemServiceMock.Verify(o => o.DeleteOrderItem(callOffId, catalogueItemId), Times.Once);
+            orderItemServiceMock.Verify(o => o.DeleteOrderItem(callOffId, odsCode, catalogueItemId), Times.Once);
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/DeleteAssociatedServiceControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/DeleteAssociatedServiceControllerTests.cs
@@ -49,7 +49,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
         {
             var expectedViewData = new DeleteAssociatedServiceModel(odsCode, order.CallOffId, catalogueItemId, catalogueItemName, order.Description);
 
-            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId, odsCode)).ReturnsAsync(order);
 
             var actualResult = await controller.DeleteAssociatedService(odsCode, order.CallOffId, catalogueItemId, catalogueItemName);
 
@@ -74,7 +74,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
             actualResult.As<RedirectToActionResult>().ActionName.Should().Be(nameof(AssociatedServicesController.Index));
             actualResult.As<RedirectToActionResult>().ControllerName.Should().Be(typeof(AssociatedServicesController).ControllerName());
             actualResult.As<RedirectToActionResult>().RouteValues.Should().BeEquivalentTo(new RouteValueDictionary { { "odsCode", odsCode }, { "callOffId", callOffId } });
-            orderItemServiceMock.Verify(o => o.DeleteOrderItem(callOffId, catalogueItemId), Times.Once);
+            orderItemServiceMock.Verify(o => o.DeleteOrderItem(callOffId, odsCode, catalogueItemId), Times.Once);
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/DeleteCatalogueSolutionControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/DeleteCatalogueSolutionControllerTests.cs
@@ -49,7 +49,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
         {
             var expectedViewData = new DeleteSolutionModel(odsCode, order.CallOffId, catalogueItemId, catalogueItemName, order.Description);
 
-            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId, odsCode)).ReturnsAsync(order);
 
             var actualResult = await controller.DeleteSolution(odsCode, order.CallOffId, catalogueItemId, catalogueItemName);
 
@@ -74,7 +74,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
             actualResult.As<RedirectToActionResult>().ActionName.Should().Be(nameof(CatalogueSolutionsController.Index));
             actualResult.As<RedirectToActionResult>().ControllerName.Should().Be(typeof(CatalogueSolutionsController).ControllerName());
             actualResult.As<RedirectToActionResult>().RouteValues.Should().BeEquivalentTo(new RouteValueDictionary { { "odsCode", odsCode }, { "callOffId", callOffId } });
-            orderItemServiceMock.Verify(o => o.DeleteOrderItem(callOffId, catalogueItemId), Times.Once);
+            orderItemServiceMock.Verify(o => o.DeleteOrderItem(callOffId, odsCode, catalogueItemId), Times.Once);
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/DeleteOrderControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/DeleteOrderControllerTests.cs
@@ -47,7 +47,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
         {
             var expectedViewData = new DeleteOrderModel(odsCode, order);
 
-            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId, odsCode)).ReturnsAsync(order);
 
             var actualResult = await controller.DeleteOrder(odsCode, order.CallOffId);
 
@@ -70,7 +70,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
             actualResult.As<RedirectToActionResult>().ActionName.Should().Be(nameof(DashboardController.Organisation));
             actualResult.As<RedirectToActionResult>().ControllerName.Should().Be(typeof(DashboardController).ControllerName());
             actualResult.As<RedirectToActionResult>().RouteValues.Should().BeEquivalentTo(new RouteValueDictionary { { "odsCode", odsCode } });
-            orderServiceMock.Verify(o => o.DeleteOrder(callOffId), Times.Once);
+            orderServiceMock.Verify(o => o.DeleteOrder(callOffId, odsCode), Times.Once);
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/FundingSourceControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/FundingSourceControllerTests.cs
@@ -48,7 +48,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
         {
             var expectedViewData = new FundingSourceModel(odsCode, order.CallOffId, order.FundingSourceOnlyGms);
 
-            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId, odsCode)).ReturnsAsync(order);
 
             var actualResult = await controller.FundingSource(odsCode, order.CallOffId);
 
@@ -71,7 +71,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
             actualResult.As<RedirectToActionResult>().ActionName.Should().Be(nameof(OrderController.Order));
             actualResult.As<RedirectToActionResult>().ControllerName.Should().Be(typeof(OrderController).ControllerName());
             actualResult.As<RedirectToActionResult>().RouteValues.Should().BeEquivalentTo(new RouteValueDictionary { { "odsCode", odsCode }, { "callOffId", callOffId } });
-            fundingSourceServiceMock.Verify(o => o.SetFundingSource(callOffId, model.FundingSourceOnlyGms.EqualsIgnoreCase("Yes")), Times.Once);
+            fundingSourceServiceMock.Verify(o => o.SetFundingSource(callOffId, odsCode, model.FundingSourceOnlyGms.EqualsIgnoreCase("Yes")), Times.Once);
         }
 
         [Theory]

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/OrderControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/OrderControllerTests.cs
@@ -55,7 +55,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
 
             var expectedViewData = new OrderModel(odsCode, order, orderTaskList) { DescriptionUrl = "testUrl" };
 
-            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId, odsCode)).ReturnsAsync(order);
 
             taskListServiceMock.Setup(s => s.GetTaskListStatusModelForOrder(order)).Returns(orderTaskList);
 
@@ -75,7 +75,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
         {
             order.OrderStatus = OrderStatus.Complete;
 
-            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId, odsCode)).ReturnsAsync(order);
 
             var actualResult = await controller.Order(odsCode, order.CallOffId);
 
@@ -109,7 +109,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
         {
             order.Description = null;
 
-            orderServiceMock.Setup(s => s.GetOrderForSummary(order.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderForSummary(order.CallOffId, odsCode)).ReturnsAsync(order);
 
             var actualResult = await controller.Summary(odsCode, order.CallOffId);
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/OrderDescriptionControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/OrderDescriptionControllerTests.cs
@@ -48,7 +48,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
         {
             var expectedViewData = new OrderDescriptionModel(odsCode, order) { BackLink = "testUrl" };
 
-            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId, odsCode)).ReturnsAsync(order);
 
             var actualResult = await controller.OrderDescription(odsCode, order.CallOffId);
 
@@ -71,7 +71,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
             actualResult.As<RedirectToActionResult>().ActionName.Should().Be(nameof(OrderController.Order));
             actualResult.As<RedirectToActionResult>().ControllerName.Should().Be(typeof(OrderController).ControllerName());
             actualResult.As<RedirectToActionResult>().RouteValues.Should().BeEquivalentTo(new RouteValueDictionary { { "odsCode", odsCode }, { "callOffId", callOffId } });
-            orderDescriptionServiceMock.Verify(o => o.SetOrderDescription(callOffId, model.Description), Times.Once);
+            orderDescriptionServiceMock.Verify(o => o.SetOrderDescription(callOffId, odsCode, model.Description), Times.Once);
         }
 
         [Theory]

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/OrderingPartyControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/OrderingPartyControllerTests.cs
@@ -48,7 +48,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
         {
             var expectedViewData = new OrderingPartyModel(odsCode, order, organisation);
 
-            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderThin(order.CallOffId, odsCode)).ReturnsAsync(order);
             organisationServiceMock.Setup(s => s.GetOrganisationByOdsCode(odsCode)).ReturnsAsync(organisation);
 
             var actualResult = await controller.OrderingParty(odsCode, order.CallOffId);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SupplierControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SupplierControllerTests.cs
@@ -223,7 +223,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
             SupplierController controller)
         {
             order.Supplier = supplier;
-            orderServiceMock.Setup(_ => _.GetOrderWithSupplier(callOffId))
+            orderServiceMock.Setup(_ => _.GetOrderWithSupplier(callOffId, odsCode))
                 .ReturnsAsync(order);
 
             var result = await controller.SupplierSearchSelect(odsCode, callOffId, search);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SupplierControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SupplierControllerTests.cs
@@ -49,7 +49,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
         {
             order.Supplier = null;
 
-            orderServiceMock.Setup(s => s.GetOrderWithSupplier(order.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderWithSupplier(order.CallOffId, odsCode)).ReturnsAsync(order);
 
             var actualResult = await controller.Supplier(odsCode, order.CallOffId);
 
@@ -71,7 +71,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
         {
             var expectedViewData = new SupplierModel(odsCode, order, supplier.SupplierContacts);
 
-            orderServiceMock.Setup(s => s.GetOrderWithSupplier(order.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderWithSupplier(order.CallOffId, odsCode)).ReturnsAsync(order);
             supplierServiceMock.Setup(s => s.GetSupplierFromBuyingCatalogue(order.Supplier.Id)).ReturnsAsync(supplier);
 
             var actualResult = await controller.Supplier(odsCode, order.CallOffId);
@@ -95,7 +95,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
             actualResult.As<RedirectToActionResult>().ActionName.Should().Be(nameof(OrderController.Order));
             actualResult.As<RedirectToActionResult>().ControllerName.Should().Be(typeof(OrderController).ControllerName());
             actualResult.As<RedirectToActionResult>().RouteValues.Should().BeEquivalentTo(new RouteValueDictionary { { "odsCode", odsCode }, { "callOffId", callOffId } });
-            supplierServiceMock.Verify(s => s.AddOrUpdateOrderSupplierContact(callOffId, model.PrimaryContact), Times.Once);
+            supplierServiceMock.Verify(s => s.AddOrUpdateOrderSupplierContact(callOffId, odsCode, model.PrimaryContact), Times.Once);
         }
 
         [Theory]
@@ -106,7 +106,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
             [Frozen] Mock<IOrderService> orderServiceMock,
             SupplierController controller)
         {
-            orderServiceMock.Setup(s => s.GetOrderWithSupplier(order.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderWithSupplier(order.CallOffId, odsCode)).ReturnsAsync(order);
 
             var actualResult = await controller.SupplierSearch(odsCode, order.CallOffId);
 
@@ -128,7 +128,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
 
             var expectedViewData = new SupplierSearchModel(odsCode, order);
 
-            orderServiceMock.Setup(s => s.GetOrderWithSupplier(order.CallOffId)).ReturnsAsync(order);
+            orderServiceMock.Setup(s => s.GetOrderWithSupplier(order.CallOffId, odsCode)).ReturnsAsync(order);
 
             var actualResult = await controller.SupplierSearch(odsCode, order.CallOffId);
 
@@ -227,7 +227,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
             actualResult.As<RedirectToActionResult>().ActionName.Should().Be(nameof(SupplierController.Supplier));
             actualResult.As<RedirectToActionResult>().ControllerName.Should().Be(typeof(SupplierController).ControllerName());
             actualResult.As<RedirectToActionResult>().RouteValues.Should().BeEquivalentTo(new RouteValueDictionary { { "odsCode", odsCode }, { "callOffId", callOffId } });
-            supplierServiceMock.Verify(s => s.AddOrderSupplier(callOffId, model.SelectedSupplierId.Value), Times.Once);
+            supplierServiceMock.Verify(s => s.AddOrderSupplier(callOffId, odsCode, model.SelectedSupplierId.Value), Times.Once);
         }
     }
 }


### PR DESCRIPTION
Fix Buyers being able to view any order even if they don't have permissions to view that order.

Update Most Order Related Services to require the current OdsCode so we can see if the user is in the context of a correct organisation for the given CallOffId.

Update all References to the Services to supply the OdsCode.

Update Tests to add OdsCode as a required reference to all order related service functions.