### PR TITLE
Don't show unpublished Associated Services on order form

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/AssociatedServices/IAssociatedServicesService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/AssociatedServices/IAssociatedServicesService.cs
@@ -8,7 +8,9 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.AssociatedServices
 {
     public interface IAssociatedServicesService
     {
-        Task<List<CatalogueItem>> GetAssociatedServicesForSupplier(int? supplierId);
+        Task<List<CatalogueItem>> GetAllAssociatedServicesForSupplier(int? supplierId);
+
+        Task<List<CatalogueItem>> GetPublishedAssociatedServicesForSupplier(int? supplierId);
 
         Task<CatalogueItem> GetAssociatedService(CatalogueItemId associatedServiceId);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/AssociatedServices/AssociatedServicesService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/AssociatedServices/AssociatedServicesService.cs
@@ -20,7 +20,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.AssociatedServices
             this.dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         }
 
-        public Task<List<CatalogueItem>> GetAssociatedServicesForSupplier(int? supplierId)
+        public Task<List<CatalogueItem>> GetAllAssociatedServicesForSupplier(int? supplierId)
         {
             return dbContext.CatalogueItems
                 .Include(s => s.CatalogueItemCapabilities)
@@ -30,6 +30,21 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.AssociatedServices
                 .Where(
                     c => c.SupplierId == supplierId.GetValueOrDefault()
                         && c.CatalogueItemType == CatalogueItemType.AssociatedService)
+                .OrderBy(c => c.Name)
+                .ToListAsync();
+        }
+
+        public Task<List<CatalogueItem>> GetPublishedAssociatedServicesForSupplier(int? supplierId)
+        {
+            return dbContext.CatalogueItems
+                .Include(s => s.CatalogueItemCapabilities)
+                .ThenInclude(sc => sc.Capability)
+                .Include(c => c.Supplier)
+                .Include(c => c.AssociatedService)
+                .Where(
+                    c => c.SupplierId == supplierId.GetValueOrDefault()
+                        && c.CatalogueItemType == CatalogueItemType.AssociatedService
+                        && c.PublishedStatus == PublicationStatus.Published)
                 .OrderBy(c => c.Name)
                 .ToListAsync();
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AssociatedServicesController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AssociatedServicesController.cs
@@ -49,7 +49,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             if (solution is null)
                 return BadRequest($"No Solution found for Id: {solutionId}");
 
-            var associatedServices = await associatedServicesService.GetAssociatedServicesForSupplier(solution.Supplier.Id);
+            var associatedServices = await associatedServicesService.GetAllAssociatedServicesForSupplier(solution.Supplier.Id);
 
             var model = new AssociatedServicesModel(solution, associatedServices)
             {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/AssociatedServicesController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/AssociatedServicesController.cs
@@ -71,7 +71,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
 
             var state = orderSessionService.InitialiseStateForCreate(order, CatalogueItemType.AssociatedService, null, new OrderItemRecipientModel { OdsCode = odsCode, Name = organisation.Name });
 
-            var associatedServices = await associatedServicesService.GetAssociatedServicesForSupplier(order.SupplierId);
+            var associatedServices = await associatedServicesService.GetPublishedAssociatedServicesForSupplier(order.SupplierId);
 
             if (!associatedServices.Any())
             {
@@ -99,7 +99,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
 
             if (!ModelState.IsValid)
             {
-                model.Solutions = await associatedServicesService.GetAssociatedServicesForSupplier(state.SupplierId);
+                model.Solutions = await associatedServicesService.GetPublishedAssociatedServicesForSupplier(state.SupplierId);
                 return View(model);
             }
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/AssociatedServicesControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/AssociatedServicesControllerTests.cs
@@ -62,7 +62,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
                 .ReturnsAsync(catalogueItem);
 
             var catalogueItems = associatedServices.Select(a => a.CatalogueItem).ToList();
-            mockAssociatedServicesService.Setup(s => s.GetAssociatedServicesForSupplier(catalogueItem.Supplier.Id))
+            mockAssociatedServicesService.Setup(s => s.GetAllAssociatedServicesForSupplier(catalogueItem.Supplier.Id))
                 .ReturnsAsync(catalogueItems);
 
             var actual = await controller.AssociatedServices(catalogueItem.Id);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/AssociatedServicesControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/AssociatedServicesControllerTests.cs
@@ -88,7 +88,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
                 .ReturnsAsync(organisation);
 
             associatedServicesServiceMock
-                .Setup(s => s.GetAssociatedServicesForSupplier(It.IsAny<int>()))
+                .Setup(s => s.GetPublishedAssociatedServicesForSupplier(It.IsAny<int>()))
                 .ReturnsAsync(new List<CatalogueItem>());
 
             var actualResult = await controller.SelectAssociatedService(odsCode, order.CallOffId);
@@ -122,7 +122,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
                 .Returns(state);
 
             associatedServicesServiceMock
-                .Setup(s => s.GetAssociatedServicesForSupplier(It.IsAny<int>()))
+                .Setup(s => s.GetPublishedAssociatedServicesForSupplier(It.IsAny<int>()))
                 .ReturnsAsync(associatedServices);
 
             var actualResult = await controller.SelectAssociatedService(odsCode, state.CallOffId);


### PR DESCRIPTION
Update AssociatedServicesServices to add GetPublishedAssociatedServicesForSupplier
Change GetAssoicatedServicesForSupplier to GetAllAssociatedServicesForSupplier
Update Order form process to use Published version of the endpoint
Update tests to use new endpoint