### PR TITLE
Order Management search suggestions

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/IOrderAdminService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/IOrderAdminService.cs
@@ -11,7 +11,7 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders
     {
         Task<Order> GetOrder(CallOffId callOffId);
 
-        Task<PagedList<AdminManageOrder>> GetPagedOrders(PageOptions options, string search = null);
+        Task<PagedList<AdminManageOrder>> GetPagedOrders(PageOptions options, string search = null, string searchTermType = null);
 
         Task<IList<SearchFilterModel>> GetOrdersBySearchTerm(string search);
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsAutocomplete/NhsAutocomplete.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsAutocomplete/NhsAutocomplete.cshtml
@@ -1,6 +1,6 @@
 ﻿@model NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.Autocomplete.NhsAutocompleteModel;
 @{
-    var blacklistedQueryStrings = new[]
+    var ignoredQueryStrings = new[]
             { 
                 Model.QueryParameterName,
                 "searchTermType",
@@ -16,7 +16,7 @@
             <div id="@(Model.Id + "-container")"></div>
         </div>
         <input class="nhsuk-search__input" id="@(Model.Id + "-form-input")" name="@Model.QueryParameterName" type="search" autocomplete="off" value="@Model.SearchText">
-        @foreach(var queryParam in Context.Request.Query.Where(q => !blacklistedQueryStrings.Contains(q.Key)))
+        @foreach(var queryParam in Context.Request.Query.Where(q => !ignoredQueryStrings.Contains(q.Key)))
         {
             <input type="hidden" name="@queryParam.Key" value="@queryParam.Value">
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsAutocomplete/NhsAutocomplete.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsAutocomplete/NhsAutocomplete.cshtml
@@ -1,4 +1,8 @@
 ﻿@model NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.Autocomplete.NhsAutocompleteModel;
+@{
+    var blacklistedQueryStrings = new[]
+            { Model.QueryParameterName, "page" };
+}
 
 <div id="@(Model.Id + "-form-input-wrap-search")" class="autocomplete-wrap-search">
     <label id="@(Model.Id + "-form-input-label")" for="@(Model.Id + "-form-input")">@Model.TitleText</label>
@@ -8,7 +12,7 @@
             <div id="@(Model.Id + "-container")"></div>
         </div>
         <input class="nhsuk-search__input" id="@(Model.Id + "-form-input")" name="@Model.QueryParameterName" type="search" autocomplete="off" value="@Model.SearchText">
-        @foreach(var queryParam in Context.Request.Query.Where(q => q.Key != Model.QueryParameterName || q.Key != "page"))
+        @foreach(var queryParam in Context.Request.Query.Where(q => !blacklistedQueryStrings.Contains(q.Key)))
         {
             <input type="hidden" name="@queryParam.Key" value="@queryParam.Value">
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsAutocomplete/NhsAutocomplete.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsAutocomplete/NhsAutocomplete.cshtml
@@ -1,7 +1,11 @@
 ﻿@model NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.Autocomplete.NhsAutocompleteModel;
 @{
     var blacklistedQueryStrings = new[]
-            { Model.QueryParameterName, "page" };
+            { 
+                Model.QueryParameterName,
+                "searchTermType",
+                "page"
+            };
 }
 
 <div id="@(Model.Id + "-form-input-wrap-search")" class="autocomplete-wrap-search">

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/ManageOrdersController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/ManageOrdersController.cs
@@ -46,12 +46,13 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
         [HttpGet]
         public async Task<IActionResult> Index(
             [FromQuery] string page = "",
-            [FromQuery] string search = "")
+            [FromQuery] string search = "",
+            [FromQuery] string searchTermType = "")
         {
             const int PageSize = 10;
             var pageOptions = new PageOptions(page, PageSize);
 
-            var orders = await orderAdminService.GetPagedOrders(pageOptions, search);
+            var orders = await orderAdminService.GetPagedOrders(pageOptions, search, searchTermType);
 
             var model = new ManageOrdersDashboardModel(orders.Items, orders.Options)
             {
@@ -74,7 +75,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                 {
                     Title = r.Title,
                     Category = r.Category,
-                    Url = currentPageUrl.AppendQueryParameterToUrl(nameof(search), r.Title).ToString(),
+                    Url = currentPageUrl.AppendQueryParameterToUrl(nameof(search), r.Title).AppendQueryParameterToUrl("searchTermType", r.Category).ToString(),
                 }));
         }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/ManageOrdersController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/ManageOrdersController.cs
@@ -74,7 +74,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                 {
                     Title = r.Title,
                     Category = r.Category,
-                    Url = currentPageUrl.AppendQueryParameterToUrl(nameof(search), r.Category).ToString(),
+                    Url = currentPageUrl.AppendQueryParameterToUrl(nameof(search), r.Title).ToString(),
                 }));
         }
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageOrders/Dashboard.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageOrders/Dashboard.cs
@@ -181,8 +181,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageOrders
                 CommonActions.WaitUntilElementIsDisplayed(ManageOrdersDashboardObjects.SearchListBox);
                 CommonActions.WaitUntilElementIsDisplayed(ManageOrdersDashboardObjects.SearchResultDescription(0));
 
-                CommonActions.ElementTextEqualTo(ManageOrdersDashboardObjects.SearchResultDescription(0), callOffId.FormatForComparison()).Should().BeTrue();
-                CommonActions.ElementTextEqualTo(ManageOrdersDashboardObjects.SearchResultTitle(0), "Call-off ID".FormatForComparison()).Should().BeTrue();
+                CommonActions.ElementTextEqualTo(ManageOrdersDashboardObjects.SearchResultTitle(0), callOffId.FormatForComparison()).Should().BeTrue();
+                CommonActions.ElementTextEqualTo(ManageOrdersDashboardObjects.SearchResultDescription(0), "Call-off ID".FormatForComparison()).Should().BeTrue();
             });
         }
 
@@ -201,8 +201,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageOrders
                 CommonActions.WaitUntilElementIsDisplayed(ManageOrdersDashboardObjects.SearchListBox);
                 CommonActions.WaitUntilElementIsDisplayed(ManageOrdersDashboardObjects.SearchResultDescription(0));
 
-                CommonActions.ElementTextEqualTo(ManageOrdersDashboardObjects.SearchResultDescription(0), callOffId.FormatForComparison()).Should().BeTrue();
-                CommonActions.ElementTextEqualTo(ManageOrdersDashboardObjects.SearchResultTitle(0), "Organisation".FormatForComparison()).Should().BeTrue();
+                CommonActions.ElementTextEqualTo(ManageOrdersDashboardObjects.SearchResultTitle(0), organisationName.FormatForComparison()).Should().BeTrue();
+                CommonActions.ElementTextEqualTo(ManageOrdersDashboardObjects.SearchResultDescription(0), "Organisation".FormatForComparison()).Should().BeTrue();
             });
         }
 
@@ -213,7 +213,6 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageOrders
             {
                 using var context = GetEndToEndDbContext();
                 var order = context.Orders.Include(o => o.Supplier).First(o => o.Supplier != null);
-                var callOffId = order.CallOffId.ToString();
                 var supplierName = order.Supplier.Name;
 
                 await CommonActions.ElementAddValueWithDelay(ManageOrdersDashboardObjects.SearchBar, supplierName);
@@ -221,8 +220,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageOrders
                 CommonActions.WaitUntilElementIsDisplayed(ManageOrdersDashboardObjects.SearchListBox);
                 CommonActions.WaitUntilElementIsDisplayed(ManageOrdersDashboardObjects.SearchResultDescription(0));
 
-                CommonActions.ElementTextEqualTo(ManageOrdersDashboardObjects.SearchResultDescription(0), callOffId.FormatForComparison()).Should().BeTrue();
-                CommonActions.ElementTextEqualTo(ManageOrdersDashboardObjects.SearchResultTitle(0), "Supplier".FormatForComparison()).Should().BeTrue();
+                CommonActions.ElementTextEqualTo(ManageOrdersDashboardObjects.SearchResultTitle(0), supplierName.FormatForComparison()).Should().BeTrue();
+                CommonActions.ElementTextEqualTo(ManageOrdersDashboardObjects.SearchResultDescription(0), "Supplier".FormatForComparison()).Should().BeTrue();
             });
         }
 
@@ -234,7 +233,6 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageOrders
                 using var context = GetEndToEndDbContext();
                 var orders = context.Orders.Include(o => o.OrderItems).ThenInclude(oi => oi.CatalogueItem).Where(o => o.OrderItems.Any());
                 var order = orders.First(o => o.OrderItems.Any(oi => oi.CatalogueItem.CatalogueItemType == CatalogueItemType.Solution));
-                var callOffId = order.CallOffId.ToString();
                 var solutionName = order.OrderItems.First().CatalogueItem.Name;
 
                 await CommonActions.ElementAddValueWithDelay(ManageOrdersDashboardObjects.SearchBar, solutionName);
@@ -242,8 +240,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageOrders
                 CommonActions.WaitUntilElementIsDisplayed(ManageOrdersDashboardObjects.SearchListBox);
                 CommonActions.WaitUntilElementIsDisplayed(ManageOrdersDashboardObjects.SearchResultDescription(0));
 
-                CommonActions.ElementTextEqualTo(ManageOrdersDashboardObjects.SearchResultDescription(0), callOffId.FormatForComparison()).Should().BeTrue();
-                CommonActions.ElementTextEqualTo(ManageOrdersDashboardObjects.SearchResultTitle(0), "Solution".FormatForComparison()).Should().BeTrue();
+                CommonActions.ElementTextEqualTo(ManageOrdersDashboardObjects.SearchResultTitle(0), solutionName.FormatForComparison()).Should().BeTrue();
+                CommonActions.ElementTextEqualTo(ManageOrdersDashboardObjects.SearchResultDescription(0), "Solution".FormatForComparison()).Should().BeTrue();
             });
         }
     }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/LocalWebApplicationFactory.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/LocalWebApplicationFactory.cs
@@ -54,6 +54,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils
 
         private static readonly string SqlliteConnectionStringFileSystem = $"DataSource={SqlliteFileSystemFileLocation}";
 
+        private static bool disposed = false;
+
         private readonly string pathToServiceInstanceViewSqlFile =
             Path.GetFullPath(Path.Combine(
                 Directory.GetCurrentDirectory(),
@@ -228,10 +230,11 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils
         {
             Driver?.Quit();
             base.Dispose(disposing);
-            if (disposing)
+            if (disposing && !disposed)
             {
                 host?.Dispose();
                 sqliteConnection?.Dispose();
+                disposed = true;
             }
         }
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/LocalWebApplicationFactory.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/LocalWebApplicationFactory.cs
@@ -54,8 +54,6 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils
 
         private static readonly string SqlliteConnectionStringFileSystem = $"DataSource={SqlliteFileSystemFileLocation}";
 
-        private bool disposed = false;
-
         private readonly string pathToServiceInstanceViewSqlFile =
             Path.GetFullPath(Path.Combine(
                 Directory.GetCurrentDirectory(),
@@ -63,6 +61,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils
                 @"ServiceInstanceItems.sql"));
 
         private readonly IWebHost host;
+
+        private bool disposed = false;
 
         private SqliteConnection sqliteConnection;
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/LocalWebApplicationFactory.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/LocalWebApplicationFactory.cs
@@ -54,7 +54,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils
 
         private static readonly string SqlliteConnectionStringFileSystem = $"DataSource={SqlliteFileSystemFileLocation}";
 
-        private static bool disposed = false;
+        private bool disposed = false;
 
         private readonly string pathToServiceInstanceViewSqlFile =
             Path.GetFullPath(Path.Combine(

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/ManageOrdersControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/ManageOrdersControllerTests.cs
@@ -45,7 +45,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             ManageOrdersController controller)
         {
             var expectedModel = new ManageOrdersDashboardModel(orders.Items, orders.Options);
-            orderAdminService.Setup(s => s.GetPagedOrders(It.IsAny<PageOptions>(), It.IsAny<string>()))
+            orderAdminService.Setup(s => s.GetPagedOrders(It.IsAny<PageOptions>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(orders);
 
             var result = (await controller.Index()).As<ViewResult>();


### PR DESCRIPTION
Updates the search suggestion to use the correct title & description.

Also includes code to search the correct tables/values corresponding to the selection made by the user.
Example: If the user searches for Hull and selects the Hull Organisation option in the suggestion list, we only search Orders where the Organisation Name matches Hull, therefore all orders belonging to Hull are filtered on the table.

If the user selects the generic search button then all checks are performed (CallOffId, Organisation Name, Supplier Name, Solution Name)