### PR TITLE
Release 3.5.0 - Catalogue Item Id Generator bugfix

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/ValueGenerators/CatalogueItemIdValueGenerator.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/ValueGenerators/CatalogueItemIdValueGenerator.cs
@@ -25,10 +25,13 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.ValueGenerators
             if (catalogueItem.Id != default)
                 return catalogueItem.Id;
 
-            var latestCatalogueItem = await entry.Context.Set<CatalogueItem>()
-                .Where(i => i.CatalogueItemType == catalogueItem.CatalogueItemType && i.SupplierId == catalogueItem.SupplierId)
-                .OrderByDescending(i => i.Id)
-                .FirstOrDefaultAsync(cancellationToken);
+            var baseQuery = entry.Context.Set<CatalogueItem>()
+                .Where(i => i.CatalogueItemType == catalogueItem.CatalogueItemType && i.SupplierId == catalogueItem.SupplierId);
+
+            if (catalogueItem.CatalogueItemType == CatalogueItemType.AdditionalService)
+                baseQuery = baseQuery.Where(i => i.AdditionalService.SolutionId == catalogueItem.AdditionalService.SolutionId);
+
+            var latestCatalogueItem = await baseQuery.OrderByDescending(i => i.Id).FirstOrDefaultAsync(cancellationToken);
 
             var incrementedCatalogueItemId = catalogueItem.CatalogueItemType switch
             {

--- a/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/ValueGenerators/CatalogueItemIdValueGeneratorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/ValueGenerators/CatalogueItemIdValueGeneratorTests.cs
@@ -1,0 +1,215 @@
+﻿using System.Linq;
+using FluentAssertions;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests.ValueGenerators
+{
+    public static class CatalogueItemIdValueGeneratorTests
+    {
+        [Theory]
+        [InMemoryDbAutoData]
+        public static void GenerateId_Solution_ExpectedId(
+            Supplier supplier,
+            BuyingCatalogueDbContext context)
+        {
+            context.CatalogueItems.ToList().ForEach(ci => context.CatalogueItems.Remove(ci));
+            context.SaveChanges();
+
+            var catalogueItem = AddSolution(supplier, context);
+
+            catalogueItem.Id.Should().Be(new CatalogueItemId(catalogueItem.SupplierId, "001"));
+        }
+
+        [Theory]
+        [InMemoryDbAutoData]
+        public static void GenerateId_SupplierWithExistingSolution_IncrementsAsExpected(
+            Supplier supplier,
+            BuyingCatalogueDbContext context)
+        {
+            context.CatalogueItems.ToList().ForEach(ci => context.CatalogueItems.Remove(ci));
+            context.SaveChanges();
+
+            var existingCatalogueItem = AddSolution(supplier, context);
+            var newCatalogueItem = AddSolution(supplier, context);
+
+            newCatalogueItem.Id.Should().Be(new CatalogueItemId(newCatalogueItem.SupplierId, "002"));
+        }
+
+        [Theory]
+        [InMemoryDbAutoData]
+        public static void GenerateId_SolutionsAcrossSuppliers_ExpectedIds(
+            Supplier firstSupplier,
+            Supplier secondSupplier,
+            BuyingCatalogueDbContext context)
+        {
+            context.CatalogueItems.ToList().ForEach(ci => context.CatalogueItems.Remove(ci));
+            context.SaveChanges();
+
+            var firstSupplierSolution = AddSolution(firstSupplier, context);
+            var secondSupplierSolution = AddSolution(secondSupplier, context);
+
+            firstSupplierSolution.Id.Should().Be(new CatalogueItemId(firstSupplierSolution.SupplierId, "001"));
+            secondSupplierSolution.Id.Should().Be(new CatalogueItemId(secondSupplierSolution.SupplierId, "001"));
+        }
+
+        [Theory]
+        [InMemoryDbAutoData]
+        public static void GenerateId_AdditionalService_ExpectedId(
+            Supplier supplier,
+            BuyingCatalogueDbContext context)
+        {
+            context.CatalogueItems.ToList().ForEach(ci => context.CatalogueItems.Remove(ci));
+            context.SaveChanges();
+
+            var solution = AddSolution(supplier, context);
+
+            var additionalService = AddAdditionalService(supplier, solution, context);
+
+            additionalService.Id.Should().Be(new CatalogueItemId(additionalService.SupplierId, $"{solution.Id.ItemId}A01"));
+        }
+
+        [Theory]
+        [InMemoryDbAutoData]
+        public static void GenerateId_AdditionalServicesAcrossSuppliers_ExpectedIds(
+            Supplier firstSupplier,
+            Supplier secondSupplier,
+            BuyingCatalogueDbContext context)
+        {
+            context.CatalogueItems.ToList().ForEach(ci => context.CatalogueItems.Remove(ci));
+            context.SaveChanges();
+
+            var firstSolution = AddSolution(firstSupplier, context);
+            var secondSolution = AddSolution(secondSupplier, context);
+
+            var firstAdditionalService = AddAdditionalService(firstSupplier, firstSolution, context);
+            var secondAdditionalService = AddAdditionalService(secondSupplier, secondSolution, context);
+
+            firstAdditionalService.Id.Should().Be(new CatalogueItemId(firstAdditionalService.SupplierId, $"{firstSolution.Id.ItemId}A01"));
+            secondAdditionalService.Id.Should().Be(new CatalogueItemId(secondAdditionalService.SupplierId, $"{secondSolution.Id.ItemId}A01"));
+        }
+
+        [Theory]
+        [InMemoryDbAutoData]
+        public static void GenerateId_TwoSolutions_ExistingAdditionalService_ExpectedIds(
+            Supplier supplier,
+            BuyingCatalogueDbContext context)
+        {
+            context.CatalogueItems.ToList().ForEach(ci => context.CatalogueItems.Remove(ci));
+            context.SaveChanges();
+
+            var firstSolution = AddSolution(supplier, context);
+            var secondSolution = AddSolution(supplier, context);
+
+            var firstAdditionalService = AddAdditionalService(supplier, firstSolution, context);
+            var secondAdditionalService = AddAdditionalService(supplier, secondSolution, context);
+
+            firstAdditionalService.Id.Should().Be(new CatalogueItemId(firstAdditionalService.SupplierId, $"{firstSolution.Id.ItemId}A01"));
+            secondAdditionalService.Id.Should().Be(new CatalogueItemId(secondAdditionalService.SupplierId, $"{secondSolution.Id.ItemId}A01"));
+        }
+
+        [Theory]
+        [InMemoryDbAutoData]
+        public static void GenerateId_OneSolution_ExistingAdditionalService_ExpectedIds(
+            Supplier supplier,
+            BuyingCatalogueDbContext context)
+        {
+            context.CatalogueItems.ToList().ForEach(ci => context.CatalogueItems.Remove(ci));
+            context.SaveChanges();
+
+            var solution = AddSolution(supplier, context);
+
+            var firstAdditionalService = AddAdditionalService(supplier, solution, context);
+            var secondAdditionalService = AddAdditionalService(supplier, solution, context);
+
+            firstAdditionalService.Id.Should().Be(new CatalogueItemId(firstAdditionalService.SupplierId, $"{solution.Id.ItemId}A01"));
+            secondAdditionalService.Id.Should().Be(new CatalogueItemId(secondAdditionalService.SupplierId, $"{solution.Id.ItemId}A02"));
+        }
+
+        [Theory]
+        [InMemoryDbAutoData]
+        public static void GenerateId_AssociatedService_ExpectedId(
+            Supplier supplier,
+            BuyingCatalogueDbContext context)
+        {
+            context.CatalogueItems.ToList().ForEach(ci => context.CatalogueItems.Remove(ci));
+            context.SaveChanges();
+
+            var associatedService = AddAssociatedService(supplier, context);
+
+            associatedService.Id.Should().Be(new CatalogueItemId(associatedService.SupplierId, "S-001"));
+        }
+
+        [Theory]
+        [InMemoryDbAutoData]
+        public static void GenerateId_ExistingAssociatedService_ExpectedId(
+            Supplier supplier,
+            BuyingCatalogueDbContext context)
+        {
+            context.CatalogueItems.ToList().ForEach(ci => context.CatalogueItems.Remove(ci));
+            context.SaveChanges();
+
+            _ = AddAssociatedService(supplier, context);
+            var associatedService = AddAssociatedService(supplier, context);
+
+            associatedService.Id.Should().Be(new CatalogueItemId(associatedService.SupplierId, "S-002"));
+        }
+
+        private static CatalogueItem AddSolution(Supplier supplier, BuyingCatalogueDbContext context)
+        {
+            var solution = new CatalogueItem
+            {
+                CatalogueItemType = CatalogueItemType.Solution,
+                Name = "Solution",
+                Supplier = supplier,
+                SupplierId = supplier.Id,
+                Solution = new Solution(),
+            };
+
+            context.CatalogueItems.Add(solution);
+            context.SaveChanges();
+
+            return solution;
+        }
+
+        private static CatalogueItem AddAdditionalService(Supplier supplier, CatalogueItem solution, BuyingCatalogueDbContext context)
+        {
+            var additionalService = new CatalogueItem
+            {
+                CatalogueItemType = CatalogueItemType.AdditionalService,
+                AdditionalService = new AdditionalService
+                {
+                    Solution = solution.Solution,
+                    SolutionId = solution.Id,
+                },
+                Supplier = supplier,
+                SupplierId = supplier.Id,
+                Name = "Additional Service",
+            };
+
+            context.CatalogueItems.Add(additionalService);
+            context.SaveChanges();
+
+            return additionalService;
+        }
+
+        private static CatalogueItem AddAssociatedService(Supplier supplier, BuyingCatalogueDbContext context)
+        {
+            var associatedService = new CatalogueItem
+            {
+                CatalogueItemType = CatalogueItemType.AssociatedService,
+                AssociatedService = new AssociatedService { },
+                Supplier = supplier,
+                SupplierId = supplier.Id,
+                Name = "Associated Service",
+            };
+
+            context.CatalogueItems.Add(associatedService);
+            context.SaveChanges();
+
+            return associatedService;
+        }
+    }
+}


### PR DESCRIPTION
Update CatalogueItemIdValueGenerator to correctly scope the ID of an additional service to the solution that it belongs to.

Currently, in live, the query searches all additional services belonging to a supplier resulting in cross-contamination of additional service IDs. The correct behavior is to relate the additional service IDs to the solution.