### PR TITLE
Add Select Price Page 

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Catalogue/Models/CataloguePriceTier.Custom.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Catalogue/Models/CataloguePriceTier.Custom.cs
@@ -1,0 +1,16 @@
+﻿namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models
+{
+    public sealed partial class CataloguePriceTier
+    {
+        public string GetRangeDescription()
+        {
+            var rangeContent = LowerRange.ToString("n0");
+
+            rangeContent += (UpperRange is not null) ? $" to {UpperRange!.Value:n0}" : "+";
+
+            rangeContent += $" {CataloguePrice.PricingUnit.RangeDescription}";
+
+            return rangeContent;
+        }
+    }
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Catalogue/Models/CataloguePriceTier.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Catalogue/Models/CataloguePriceTier.cs
@@ -3,7 +3,7 @@ using NHSD.GPIT.BuyingCatalogue.EntityFramework.Users.Models;
 
 namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models
 {
-    public sealed class CataloguePriceTier : IAudited
+    public sealed partial class CataloguePriceTier : IAudited
     {
         public int Id { get; set; }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Solutions/ISolutionListPriceService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Solutions/ISolutionListPriceService.cs
@@ -8,6 +8,8 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions
     {
         Task<CatalogueItem> GetSolutionWithListPrices(CatalogueItemId solutionId);
 
+        Task<CatalogueItem> GetSolutionWithPublishedListPrices(CatalogueItemId solutionId);
+
         Task AddListPrice(CatalogueItemId solutionId, CataloguePrice cataloguePrice);
 
         Task<CataloguePrice> UpdateListPrice(

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Solutions/SolutionListPriceService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Solutions/SolutionListPriceService.cs
@@ -21,6 +21,15 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Solutions
         public async Task<CatalogueItem> GetSolutionWithListPrices(CatalogueItemId solutionId)
             => await GetSolutionWithListPrices(solutionId, tracked: false);
 
+        public async Task<CatalogueItem> GetSolutionWithPublishedListPrices(CatalogueItemId solutionId)
+        {
+            var solution = await GetSolutionWithListPrices(solutionId, tracked: false);
+
+            solution.CataloguePrices = solution.CataloguePrices.Where(cp => cp.PublishedStatus == PublicationStatus.Published).ToList();
+
+            return solution;
+        }
+
         public async Task AddListPrice(CatalogueItemId solutionId, CataloguePrice cataloguePrice)
         {
             if (cataloguePrice is null)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/SolutionSelection/PricesController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/SolutionSelection/PricesController.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.SolutionSelection.Prices;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers.SolutionSelection
+{
+    [Authorize]
+    [Area("Order")]
+    [Route("order/organisation/{internalOrgId}/order/{callOffId}/price")]
+    public class PricesController : Controller
+    {
+        private const string SelectPriceViewName = "SelectPrice";
+        private readonly IOrderService orderService;
+        private readonly ISolutionListPriceService listPriceService;
+
+        public PricesController(
+            IOrderService orderService,
+            ISolutionListPriceService listPriceService)
+        {
+            this.orderService = orderService ?? throw new ArgumentNullException(nameof(orderService));
+            this.listPriceService = listPriceService ?? throw new ArgumentNullException(nameof(listPriceService));
+        }
+
+        [HttpGet("select-price")]
+        public async Task<IActionResult> SelectPrice(string internalOrgId, CallOffId callOffId)
+        {
+            var order = await orderService.GetOrderThin(callOffId, internalOrgId);
+            var solutionWithPrices = await listPriceService.GetSolutionWithPublishedListPrices(order.GetSolution().CatalogueItemId);
+
+            var model = new SelectPriceModel(solutionWithPrices)
+            {
+                BackLink = Url.Action(
+                    nameof(ServiceRecipientsController.SolutionRecipients),
+                    typeof(ServiceRecipientsController).ControllerName(),
+                    new { internalOrgId, callOffId }),
+            };
+
+            return View(model);
+        }
+
+        [HttpPost("select-price")]
+        public async Task<IActionResult> SelectPrice(string internalOrgId, CallOffId callOffId, SelectPriceModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                var order = await orderService.GetOrderThin(callOffId, internalOrgId);
+                var solutionWithPrices = await listPriceService.GetSolutionWithPublishedListPrices(order.GetSolution().CatalogueItemId);
+                model.Prices = solutionWithPrices.CataloguePrices.OrderBy(cp => cp.CataloguePriceType).ToList();
+                return View(model);
+            }
+
+            // TODO: Replace with version that goes to price
+            return RedirectToAction(
+                nameof(OrderController.Order),
+                typeof(OrderController).ControllerName(),
+                new { internalOrgId, callOffId });
+        }
+
+        [HttpGet("additional-service/{catalogueItemId}/select-price")]
+        public async Task<IActionResult> AdditionalServiceSelectPrice(string internalOrgId, CallOffId callOffId, CatalogueItemId catalogueItemId)
+        {
+            var order = await orderService.GetOrderThin(callOffId, internalOrgId);
+            var solutionWithPrices = await listPriceService.GetSolutionWithPublishedListPrices(catalogueItemId);
+
+            var model = new SelectPriceModel(solutionWithPrices)
+            {
+                BackLink = Url.Action(
+                    nameof(ServiceRecipientsController.SolutionRecipients),
+                    typeof(ServiceRecipientsController).ControllerName(),
+                    new { internalOrgId, callOffId }),
+            };
+
+            return View(SelectPriceViewName, model);
+        }
+
+        [HttpPost("additional-service/{catalogueItemId}/select-price")]
+        public async Task<IActionResult> AdditionalServiceSelectPrice(string internalOrgId, CallOffId callOffId, CatalogueItemId catalogueItemId, SelectPriceModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                var order = await orderService.GetOrderThin(callOffId, internalOrgId);
+                var solutionWithPrices = await listPriceService.GetSolutionWithPublishedListPrices(catalogueItemId);
+                model.Prices = solutionWithPrices.CataloguePrices.OrderBy(cp => cp.CataloguePriceType).ToList();
+                return View(SelectPriceViewName, model);
+            }
+
+            // TODO: Replace with version that goes to price
+            return RedirectToAction(
+                nameof(OrderController.Order),
+                typeof(OrderController).ControllerName(),
+                new { internalOrgId, callOffId });
+        }
+
+        [HttpGet("associated-service/{catalogueItemId}/select-price")]
+        public async Task<IActionResult> AssociatedServiceSelectPrice(string internalOrgId, CallOffId callOffId, CatalogueItemId catalogueItemId)
+        {
+            var order = await orderService.GetOrderThin(callOffId, internalOrgId);
+            var solutionWithPrices = await listPriceService.GetSolutionWithPublishedListPrices(catalogueItemId);
+
+            var model = new SelectPriceModel(solutionWithPrices)
+            {
+                BackLink = Url.Action(
+                    nameof(ServiceRecipientsController.SolutionRecipients),
+                    typeof(ServiceRecipientsController).ControllerName(),
+                    new { internalOrgId, callOffId }),
+            };
+
+            return View(SelectPriceViewName, model);
+        }
+
+        [HttpPost("associated-service/{catalogueItemId}/select-price")]
+        public async Task<IActionResult> AssociatedServiceSelectPrice(string internalOrgId, CallOffId callOffId, CatalogueItemId catalogueItemId, SelectPriceModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                var order = await orderService.GetOrderThin(callOffId, internalOrgId);
+                var solutionWithPrices = await listPriceService.GetSolutionWithPublishedListPrices(catalogueItemId);
+                model.Prices = solutionWithPrices.CataloguePrices.OrderBy(cp => cp.CataloguePriceType).ToList();
+                return View(SelectPriceViewName, model);
+            }
+
+            // TODO: Replace with version that goes to price
+            return RedirectToAction(
+                nameof(OrderController.Order),
+                typeof(OrderController).ControllerName(),
+                new { internalOrgId, callOffId });
+        }
+    }
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/SolutionSelection/ServiceRecipientsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/SolutionSelection/ServiceRecipientsController.cs
@@ -121,8 +121,17 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers.SolutionSelec
             }
 
             var order = await orderService.GetOrderThin(callOffId, internalOrgId);
+            var solution = await listPriceService.GetSolutionWithPublishedListPrices(catalogueItemId);
 
             await AddServiceRecipients(order.Id, catalogueItemId, model);
+
+            if (solution.CataloguePrices.Count > 1)
+            {
+                return RedirectToAction(
+                    nameof(PricesController.AdditionalServiceSelectPrice),
+                    typeof(PricesController).ControllerName(),
+                    new { internalOrgId, callOffId });
+            }
 
             // TODO: Replace
             return RedirectToAction(
@@ -166,8 +175,17 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers.SolutionSelec
             }
 
             var order = await orderService.GetOrderThin(callOffId, internalOrgId);
+            var solution = await listPriceService.GetSolutionWithPublishedListPrices(catalogueItemId);
 
             await AddServiceRecipients(order.Id, catalogueItemId, model);
+
+            if (solution.CataloguePrices.Count > 1)
+            {
+                return RedirectToAction(
+                    nameof(PricesController.AssociatedServiceSelectPrice),
+                    typeof(PricesController).ControllerName(),
+                    new { internalOrgId, callOffId });
+            }
 
             // TODO: Replace
             return RedirectToAction(

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/SolutionSelection/ServiceRecipientsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/SolutionSelection/ServiceRecipientsController.cs
@@ -67,7 +67,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers.SolutionSelec
             }
 
             var order = await orderService.GetOrderThin(callOffId, internalOrgId);
-            var solution = await listPriceService.GetSolutionWithPublishedListPrices(order.GetSolution().CatalogueItemId);
+            var solution = await listPriceService.GetSolutionWithPublishedListPrices(order.GetSolution().CatalogueItem.Id);
 
             await AddServiceRecipients(order.Id, solution.Id, model);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/SolutionSelection/Prices/SelectPriceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/SolutionSelection/Prices/SelectPriceModel.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Extensions;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Models;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.SolutionSelection.Prices
+{
+    public sealed class SelectPriceModel : NavBaseModel
+    {
+        public SelectPriceModel()
+        {
+        }
+
+        public SelectPriceModel(CatalogueItem solution)
+        {
+            SolutionName = solution.Name;
+            SolutionType = solution.CatalogueItemType.Name();
+            Prices = solution.CataloguePrices.OrderBy(cp => cp.CataloguePriceType).ToList();
+        }
+
+        public List<CataloguePrice> Prices { get; set; }
+
+        public int? SelectedPriceId { get; set; }
+
+        public string SolutionName { get; set; }
+
+        public string SolutionType { get; set; }
+    }
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Validators/SolutionSelection/Prices/SelectPriceModelValidator.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Validators/SolutionSelection/Prices/SelectPriceModelValidator.cs
@@ -1,0 +1,17 @@
+﻿using FluentValidation;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.SolutionSelection.Prices;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Validators.SolutionSelection.Prices
+{
+    public class SelectPriceModelValidator : AbstractValidator<SelectPriceModel>
+    {
+        public const string NoSelectionMadeErrorMessage = "Select a price";
+
+        public SelectPriceModelValidator()
+        {
+            RuleFor(sp => sp.SelectedPriceId)
+                .NotNull()
+                .WithMessage(NoSelectionMadeErrorMessage);
+        }
+    }
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/Prices/SelectPrice.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/Prices/SelectPrice.cshtml
@@ -1,0 +1,68 @@
+﻿@using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+@model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.SolutionSelection.Prices.SelectPriceModel;
+@{
+	ViewBag.Title = $"List price for {Model.SolutionType}";
+}
+
+<partial name="Partials/_BackLink" model="Model" />
+
+<div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+		<nhs-validation-summary RadioId="@nameof(Model.SelectedPriceId)"/>
+
+		<nhs-page-title title="@ViewBag.Title"
+                caption="@Model!.SolutionName"
+                advice="There is more than one list price for this @Model.SolutionType. Select one, and if you've agreed a different price with the supplier, it can be altered later." />
+
+		<h2>Available prices</h2>
+
+		@for(int i = 0; i < Model.Prices.Count; i++)
+		{
+			var price = Model.Prices[i];
+			<h3 class="nhsuk-heading-s" data-test-id="@($"price-title-{i + 1}")">@($"Price {i + 1}: {price.PricingUnit.Description}")</h3>
+			<p>
+			@if(price.CataloguePriceType == CataloguePriceType.Tiered)
+			{				
+				var tiers = price.CataloguePriceTiers.OrderBy(t => t.LowerRange);
+				for(int j = 0; j < tiers.Count(); j++)
+				{
+					var tier = tiers.ElementAt(j);
+					@($"Tier {j + 1}: £{tier.Price} for {tier.GetRangeDescription()}")<br/>
+				}
+			}
+			else
+			{
+				var tier = price.CataloguePriceTiers.First();
+				@($"£{tier.Price} {price.PricingUnit.Description}")
+			}
+			</p>
+		}
+		<form method="post">
+			<nhs-fieldset-form-label 
+				asp-for="@Model"
+				label-text ="Select a price"
+				label-hint ="Select one option.">
+				<nhs-radio-button-container>
+					@for(int i = 0; i < Model.Prices.Count; i++)
+					{
+						var price = Model.Prices[i];
+						<nhs-radio-button 
+							asp-for="SelectedPriceId"
+							value="price.CataloguePriceId"
+							display-text="@($"Price {i + 1}: {price.PricingUnit.Description}")"
+							index="i"></nhs-radio-button>
+					}
+				</nhs-radio-button-container>
+			</nhs-fieldset-form-label>
+			<br/>
+
+			<input type="hidden" asp-for="@Model.BackLink" />
+			<input type="hidden" asp-for="@Model.SolutionName" />
+			<input type="hidden" asp-for="@Model.SolutionType" />
+
+			<nhs-submit-button text="Continue"/>
+
+		</form>
+
+	</div>
+</div>

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Actions/Common/CommonActions.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Actions/Common/CommonActions.cs
@@ -41,6 +41,9 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Actions.Common
         internal void ClickFirstCheckbox() =>
             Driver.FindElements(By.CssSelector("input[type=checkbox]")).First().Click();
 
+        internal void ClickFirstRadio() =>
+            Driver.FindElements(By.CssSelector("input[type=radio]")).First().Click();
+
         internal void ClickAllCheckboxes() =>
             Driver.FindElements(By.CssSelector("input[type=checkbox]")).ToList().ForEach(element => element.Click());
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Prices/SelectPrices.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Prices/SelectPrices.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.Ordering.Prices;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers.SolutionSelection;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Prices
+{
+    public class SelectPrices : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    {
+        private const string InternalOrgId = "CG-03F";
+        private const int OrderId = 90012;
+        private static readonly CallOffId CallOffId = new(OrderId, 1);
+
+        private static readonly Dictionary<string, string> Parameters = new()
+        {
+            { nameof(InternalOrgId), InternalOrgId },
+            { nameof(CallOffId), $"{CallOffId}" },
+        };
+
+        public SelectPrices(LocalWebApplicationFactory factory)
+            : base(
+                  factory,
+                  typeof(PricesController),
+                  nameof(PricesController.SelectPrice),
+                  Parameters)
+        {
+        }
+
+        [Fact]
+        public void SelectPrice_AllSectionsDisplayed()
+        {
+            CommonActions.PageTitle().Should().BeEquivalentTo("List price for Catalogue Solution - E2E With Contact Multiple Prices".FormatForComparison());
+            CommonActions.GoBackLinkDisplayed().Should().BeTrue();
+            CommonActions.SaveButtonDisplayed().Should().BeTrue();
+            CommonActions.ElementIsDisplayed(SelectPriceObjects.SelectPriceRadio).Should().BeTrue();
+            CommonActions.ElementIsDisplayed(SelectPriceObjects.PriceTitle(1)).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SelectPrice_NoSelection_Error()
+        {
+            CommonActions.ClickSave();
+
+            CommonActions.PageLoadedCorrectGetIndex(typeof(PricesController), nameof(PricesController.SelectPrice)).Should().BeTrue();
+
+            CommonActions.ErrorSummaryDisplayed().Should().BeTrue();
+            CommonActions.ErrorSummaryLinksExist().Should().BeTrue();
+
+            CommonActions.ElementIsDisplayed(SelectPriceObjects.SelectPriceError).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SelectPrice_SelectionMade_ExpectedResult()
+        {
+            CommonActions.ClickFirstRadio();
+
+            CommonActions.ClickSave();
+
+            CommonActions.PageLoadedCorrectGetIndex(typeof(OrderController), nameof(OrderController.Order)).Should().BeTrue();
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Prices/SelectPricesAdditionalServices.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Prices/SelectPricesAdditionalServices.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.Ordering.Prices;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers.SolutionSelection;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Prices
+{
+    public class SelectPricesAdditionalServices : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    {
+        private const string InternalOrgId = "CG-03F";
+        private const int OrderId = 90012;
+        private static readonly CallOffId CallOffId = new(OrderId, 1);
+        private static readonly CatalogueItemId CatalogueItemId = new(99998, "001A99");
+
+        private static readonly Dictionary<string, string> Parameters = new()
+        {
+            { nameof(InternalOrgId), InternalOrgId },
+            { nameof(CallOffId), $"{CallOffId}" },
+            { nameof(CatalogueItemId), CatalogueItemId.ToString() },
+        };
+
+        public SelectPricesAdditionalServices(LocalWebApplicationFactory factory)
+            : base(
+                  factory,
+                  typeof(PricesController),
+                  nameof(PricesController.AdditionalServiceSelectPrice),
+                  Parameters)
+        {
+        }
+
+        [Fact]
+        public void SelectPriceAdditionalServices_AllSectionsDisplayed()
+        {
+            CommonActions.PageTitle().Should().BeEquivalentTo("List price for Additional Service - E2E Multiple Prices Additional Service".FormatForComparison());
+            CommonActions.GoBackLinkDisplayed().Should().BeTrue();
+            CommonActions.SaveButtonDisplayed().Should().BeTrue();
+            CommonActions.ElementIsDisplayed(SelectPriceObjects.SelectPriceRadio).Should().BeTrue();
+            CommonActions.ElementIsDisplayed(SelectPriceObjects.PriceTitle(1)).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SelectPriceAdditionalServices_NoSelection_Error()
+        {
+            CommonActions.ClickSave();
+
+            CommonActions.PageLoadedCorrectGetIndex(typeof(PricesController), nameof(PricesController.AdditionalServiceSelectPrice)).Should().BeTrue();
+
+            CommonActions.ErrorSummaryDisplayed().Should().BeTrue();
+            CommonActions.ErrorSummaryLinksExist().Should().BeTrue();
+
+            CommonActions.ElementIsDisplayed(SelectPriceObjects.SelectPriceError).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SelectPriceAdditionalServices_SelectionMade_ExpectedResult()
+        {
+            CommonActions.ClickFirstRadio();
+
+            CommonActions.ClickSave();
+
+            CommonActions.PageLoadedCorrectGetIndex(typeof(OrderController), nameof(OrderController.Order)).Should().BeTrue();
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Prices/SelectPricesAssociatedServices.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Prices/SelectPricesAssociatedServices.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.Ordering.Prices;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers.SolutionSelection;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Prices
+{
+    public class SelectPricesAssociatedServices : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    {
+        private const string InternalOrgId = "CG-03F";
+        private const int OrderId = 90012;
+        private static readonly CallOffId CallOffId = new(OrderId, 1);
+        private static readonly CatalogueItemId CatalogueItemId = new(99998, "S-997");
+
+        private static readonly Dictionary<string, string> Parameters = new()
+        {
+            { nameof(InternalOrgId), InternalOrgId },
+            { nameof(CallOffId), $"{CallOffId}" },
+            { nameof(CatalogueItemId), CatalogueItemId.ToString() },
+        };
+
+        public SelectPricesAssociatedServices(LocalWebApplicationFactory factory)
+            : base(
+                  factory,
+                  typeof(PricesController),
+                  nameof(PricesController.AssociatedServiceSelectPrice),
+                  Parameters)
+        {
+        }
+
+        [Fact]
+        public void SelectPriceAssociatedServices_AllSectionsDisplayed()
+        {
+            CommonActions.PageTitle().Should().BeEquivalentTo("List price for Associated Service - E2E Multiple Prices Associated Service".FormatForComparison());
+            CommonActions.GoBackLinkDisplayed().Should().BeTrue();
+            CommonActions.SaveButtonDisplayed().Should().BeTrue();
+            CommonActions.ElementIsDisplayed(SelectPriceObjects.SelectPriceRadio).Should().BeTrue();
+            CommonActions.ElementIsDisplayed(SelectPriceObjects.PriceTitle(1)).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SelectPriceAssociatedServices_NoSelection_Error()
+        {
+            CommonActions.ClickSave();
+
+            CommonActions.PageLoadedCorrectGetIndex(typeof(PricesController), nameof(PricesController.AssociatedServiceSelectPrice)).Should().BeTrue();
+
+            CommonActions.ErrorSummaryDisplayed().Should().BeTrue();
+            CommonActions.ErrorSummaryLinksExist().Should().BeTrue();
+
+            CommonActions.ElementIsDisplayed(SelectPriceObjects.SelectPriceError).Should().BeTrue();
+        }
+
+        [Fact]
+        public void SelectPriceAssociatedServices_SelectionMade_ExpectedResult()
+        {
+            CommonActions.ClickFirstRadio();
+
+            CommonActions.ClickSave();
+
+            CommonActions.PageLoadedCorrectGetIndex(typeof(OrderController), nameof(OrderController.Order)).Should().BeTrue();
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Objects/Ordering/Prices/SelectPriceObjects.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Objects/Ordering/Prices/SelectPriceObjects.cs
@@ -1,0 +1,14 @@
+﻿using NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.Common;
+using OpenQA.Selenium;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Objects.Ordering.Prices
+{
+   public static class SelectPriceObjects
+    {
+        public static By SelectPriceRadio => By.ClassName("nhsuk-radios");
+
+        public static By SelectPriceError => By.Id("select-price-error");
+
+        public static By PriceTitle(int id) => ByExtensions.DataTestId($"price-title-{id}");
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/OrderSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/OrderSeedData.cs
@@ -17,6 +17,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
             AddOrderAtSupplierContactStage(context);
             AddOrderAtCommencementDateStage(context);
             AddOrderAtCatalogueSolutionStage(context);
+            AddOrderWithAddedCatalogueSolutionButNoData(context);
             AddOrderWithAddedCatalogueSolution(context);
             AddOrderWithAddedNoContactCatalogueSolution(context);
             AddOrderWithAddedNoContactSolutionAndNoContactAdditionalSolution(context);
@@ -196,6 +197,53 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                 },
                 CommencementDate = timeNow.AddDays(1),
             };
+
+            var user = GetBuyerUser(context, order.OrderingPartyId);
+
+            context.Add(order);
+
+            context.SaveChangesAs(user.Id);
+        }
+
+        private static void AddOrderWithAddedCatalogueSolutionButNoData(BuyingCatalogueDbContext context)
+        {
+            const int orderId = 90012;
+            var timeNow = DateTime.UtcNow;
+
+            var order = new Order
+            {
+                Id = orderId,
+                OrderingPartyId = GetOrganisationId(context),
+                Created = timeNow,
+                OrderStatus = OrderStatus.InProgress,
+                IsDeleted = false,
+                Description = "This is an Order Description",
+                OrderingPartyContact = new Contact
+                {
+                    FirstName = "Clark",
+                    LastName = "Kent",
+                    Email = "Clark.Kent@TheDailyPlanet.Fake",
+                    Phone = "123456789",
+                },
+                SupplierId = 99998,
+                SupplierContact = new Contact
+                {
+                    FirstName = "Bruce",
+                    LastName = "Wayne",
+                    Email = "bat.man@Gotham.Fake",
+                    Phone = "123456789",
+                },
+                CommencementDate = timeNow.AddDays(1),
+            };
+
+            var addedSolution = new OrderItem
+            {
+                Created = DateTime.UtcNow,
+                OrderId = orderId,
+                CatalogueItem = context.CatalogueItems.Single(c => c.Id == new CatalogueItemId(99998, "001")),
+            };
+
+            order.OrderItems.Add(addedSolution);
 
             var user = GetBuyerUser(context, order.OrderingPartyId);
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.Test.Framework/AutoFixtureCustomisations/OrderItemCustomization.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Test.Framework/AutoFixtureCustomisations/OrderItemCustomization.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using AutoFixture;
 using AutoFixture.Dsl;
 using AutoFixture.Kernel;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations.AutoFixtureExtensions;
 
@@ -18,7 +19,8 @@ namespace NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations
                 .Without(oi => oi.Order)
                 .Without(oi => oi.OrderId)
                 .Without(oi => oi.OrderItemPrice)
-                .Without(oi => oi.OrderItemRecipients);
+                .Without(oi => oi.OrderItemRecipients)
+                .Without(oi => oi.CatalogueItem);
 
             fixture.Customize<OrderItem>(ComposerTransformation);
         }
@@ -35,6 +37,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations
                 AddOrderItemRecipients(item, context);
                 AddOrderItemPrice(item, context);
                 AddOrderItemFunding(item, context);
+                AddOrderItemCatalogueItem(item, context);
 
                 return item;
             }
@@ -79,6 +82,14 @@ namespace NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations
                 price.OrderItem = item;
 
                 item.OrderItemPrice = price;
+            }
+
+            private static void AddOrderItemCatalogueItem(OrderItem item, ISpecimenContext context)
+            {
+                var solution = context.Create<CatalogueItem>();
+
+                item.CatalogueItemId = solution.Id;
+                item.CatalogueItem = solution;
             }
         }
     }

--- a/tests/NHSD.GPIT.BuyingCatalogue.Test.Framework/AutoFixtureCustomisations/OrderItemCustomization.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Test.Framework/AutoFixtureCustomisations/OrderItemCustomization.cs
@@ -20,7 +20,8 @@ namespace NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations
                 .Without(oi => oi.OrderId)
                 .Without(oi => oi.OrderItemPrice)
                 .Without(oi => oi.OrderItemRecipients)
-                .Without(oi => oi.CatalogueItem);
+                .Without(oi => oi.CatalogueItem)
+                .Without(oi => oi.CatalogueItemId);
 
             fixture.Customize<OrderItem>(ComposerTransformation);
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SolutionSelection/PriceControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SolutionSelection/PriceControllerTests.cs
@@ -1,0 +1,350 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using AutoFixture.Idioms;
+using AutoFixture.Xunit2;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Moq;
+using MoreLinq.Extensions;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions;
+using NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers.SolutionSelection;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.SolutionSelection.Prices;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.SolutionSelection
+{
+    public static class PriceControllerTests
+    {
+        [Fact]
+        public static void ClassIsCorrectlyDecorated()
+        {
+            typeof(PricesController).Should().BeDecoratedWith<AuthorizeAttribute>();
+            typeof(PricesController).Should().BeDecoratedWith<AreaAttribute>(a => a.RouteValue == "Order");
+        }
+
+        [Fact]
+        public static void Constructors_VerifyGuardClauses()
+        {
+            var fixture = new Fixture().Customize(new AutoMoqCustomization());
+            var assertion = new GuardClauseAssertion(fixture);
+            var constructors = typeof(PricesController).GetConstructors();
+
+            assertion.Verify(constructors);
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Get_SelectPrice_ReturnsExpectedResult(
+            string internalOrgId,
+            CallOffId callOffId,
+            EntityFramework.Ordering.Models.Order order,
+            [Frozen] Mock<IOrderService> mockOrderService,
+            [Frozen] Mock<ISolutionListPriceService> mockListPriceService,
+            PricesController controller)
+        {
+            order.OrderItems.First().CatalogueItem.CatalogueItemType = CatalogueItemType.Solution;
+
+            var orderItem = order.OrderItems.First();
+
+            mockOrderService
+                .Setup(x => x.GetOrderThin(callOffId, internalOrgId))
+                .ReturnsAsync(order);
+
+            mockListPriceService
+                .Setup(lps => lps.GetSolutionWithPublishedListPrices(orderItem.CatalogueItemId))
+                .ReturnsAsync(orderItem.CatalogueItem);
+
+            var result = await controller.SelectPrice(internalOrgId, callOffId);
+
+            mockOrderService.VerifyAll();
+            mockListPriceService.VerifyAll();
+
+            var actualResult = result.Should().BeOfType<ViewResult>().Subject;
+
+            var expected = new SelectPriceModel(orderItem.CatalogueItem);
+
+            actualResult.Model.Should().BeEquivalentTo(expected, m => m.Excluding(o => o.BackLink));
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Post_SelectPrice_ReturnsRedirect(
+            string internalOrgId,
+            CallOffId callOffId,
+            PricesController controller)
+        {
+            var model = new SelectPriceModel()
+            {
+                SelectedPriceId = 1,
+            };
+
+            var result = await controller.SelectPrice(internalOrgId, callOffId, model);
+
+            var actualResult = result.Should().BeOfType<RedirectToActionResult>().Subject;
+
+            actualResult.ControllerName.Should().Be(typeof(OrderController).ControllerName());
+            actualResult.ActionName.Should().Be(nameof(OrderController.Order));
+            actualResult.RouteValues.Should().BeEquivalentTo(new RouteValueDictionary
+            {
+                { "internalOrgId", internalOrgId },
+                { "callOffId", callOffId },
+            });
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Post_SelectPrice_ModelError_ReturnsModel(
+            string internalOrgId,
+            CallOffId callOffId,
+            [Frozen] SelectPriceModel model,
+            EntityFramework.Ordering.Models.Order order,
+            [Frozen] Mock<IOrderService> mockOrderService,
+            [Frozen] Mock<ISolutionListPriceService> mockListPriceService,
+            PricesController controller)
+        {
+            order.OrderItems.First().CatalogueItem.CatalogueItemType = CatalogueItemType.Solution;
+
+            var orderItem = order.OrderItems.First();
+
+            mockOrderService
+                .Setup(x => x.GetOrderThin(callOffId, internalOrgId))
+                .ReturnsAsync(order);
+
+            mockListPriceService
+                .Setup(lps => lps.GetSolutionWithPublishedListPrices(orderItem.CatalogueItemId))
+                .ReturnsAsync(orderItem.CatalogueItem);
+
+            controller.ModelState.AddModelError("key", "message");
+
+            var result = await controller.SelectPrice(internalOrgId, callOffId, model);
+
+            mockOrderService.VerifyAll();
+            mockListPriceService.VerifyAll();
+
+            var actualResult = result.Should().BeOfType<ViewResult>().Subject;
+
+            var expected = new SelectPriceModel(orderItem.CatalogueItem)
+            {
+                SelectedPriceId = model.SelectedPriceId,
+                SolutionName = model.SolutionName,
+                SolutionType = model.SolutionType,
+            };
+
+            actualResult.Model.Should().BeEquivalentTo(expected, m => m.Excluding(o => o.BackLink).Excluding(o => o.BackLinkText));
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Get_AdditionalServiceSelectPrice_ReturnsExpectedResult(
+            string internalOrgId,
+            CallOffId callOffId,
+            EntityFramework.Ordering.Models.Order order,
+            [Frozen] Mock<IOrderService> mockOrderService,
+            [Frozen] Mock<ISolutionListPriceService> mockListPriceService,
+            PricesController controller)
+        {
+            order.OrderItems.First().CatalogueItem.CatalogueItemType = CatalogueItemType.Solution;
+
+            var orderItem = order.OrderItems.First();
+
+            mockOrderService
+                .Setup(x => x.GetOrderThin(callOffId, internalOrgId))
+                .ReturnsAsync(order);
+
+            mockListPriceService
+                .Setup(lps => lps.GetSolutionWithPublishedListPrices(orderItem.CatalogueItemId))
+                .ReturnsAsync(orderItem.CatalogueItem);
+
+            var result = await controller.AdditionalServiceSelectPrice(internalOrgId, callOffId, orderItem.CatalogueItemId);
+
+            mockOrderService.VerifyAll();
+            mockListPriceService.VerifyAll();
+
+            var actualResult = result.Should().BeOfType<ViewResult>().Subject;
+
+            var expected = new SelectPriceModel(orderItem.CatalogueItem);
+
+            actualResult.Model.Should().BeEquivalentTo(expected, m => m.Excluding(o => o.BackLink));
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Post_AdditionalServiceSelectPrice_ReturnsRedirect(
+            string internalOrgId,
+            CallOffId callOffId,
+            CatalogueItemId catalogueItemId,
+            PricesController controller)
+        {
+            var model = new SelectPriceModel()
+            {
+                SelectedPriceId = 1,
+            };
+
+            var result = await controller.AdditionalServiceSelectPrice(internalOrgId, callOffId, catalogueItemId, model);
+
+            var actualResult = result.Should().BeOfType<RedirectToActionResult>().Subject;
+
+            actualResult.ControllerName.Should().Be(typeof(OrderController).ControllerName());
+            actualResult.ActionName.Should().Be(nameof(OrderController.Order));
+            actualResult.RouteValues.Should().BeEquivalentTo(new RouteValueDictionary
+            {
+                { "internalOrgId", internalOrgId },
+                { "callOffId", callOffId },
+            });
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Post_AdditionalServiceSelectPrice_ModelError_ReturnsModel(
+        string internalOrgId,
+        CallOffId callOffId,
+        [Frozen] SelectPriceModel model,
+        EntityFramework.Ordering.Models.Order order,
+        [Frozen] Mock<IOrderService> mockOrderService,
+        [Frozen] Mock<ISolutionListPriceService> mockListPriceService,
+        PricesController controller)
+        {
+            order.OrderItems.First().CatalogueItem.CatalogueItemType = CatalogueItemType.Solution;
+
+            var orderItem = order.OrderItems.First();
+
+            mockOrderService
+                .Setup(x => x.GetOrderThin(callOffId, internalOrgId))
+                .ReturnsAsync(order);
+
+            mockListPriceService
+                .Setup(lps => lps.GetSolutionWithPublishedListPrices(orderItem.CatalogueItemId))
+                .ReturnsAsync(orderItem.CatalogueItem);
+
+            controller.ModelState.AddModelError("key", "message");
+
+            var result = await controller.AdditionalServiceSelectPrice(internalOrgId, callOffId, orderItem.CatalogueItemId, model);
+
+            mockOrderService.VerifyAll();
+            mockListPriceService.VerifyAll();
+
+            var actualResult = result.Should().BeOfType<ViewResult>().Subject;
+
+            var expected = new SelectPriceModel(orderItem.CatalogueItem)
+            {
+                SelectedPriceId = model.SelectedPriceId,
+                SolutionName = model.SolutionName,
+                SolutionType = model.SolutionType,
+            };
+
+            actualResult.Model.Should().BeEquivalentTo(expected, m => m.Excluding(o => o.BackLink).Excluding(o => o.BackLinkText));
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Get_AssociatedServiceSelectPrice_ReturnsExpectedResult(
+            string internalOrgId,
+            CallOffId callOffId,
+            EntityFramework.Ordering.Models.Order order,
+            [Frozen] Mock<IOrderService> mockOrderService,
+            [Frozen] Mock<ISolutionListPriceService> mockListPriceService,
+            PricesController controller)
+        {
+            order.OrderItems.First().CatalogueItem.CatalogueItemType = CatalogueItemType.Solution;
+
+            var orderItem = order.OrderItems.First();
+
+            mockOrderService
+                .Setup(x => x.GetOrderThin(callOffId, internalOrgId))
+                .ReturnsAsync(order);
+
+            mockListPriceService
+                .Setup(lps => lps.GetSolutionWithPublishedListPrices(orderItem.CatalogueItemId))
+                .ReturnsAsync(orderItem.CatalogueItem);
+
+            var result = await controller.AssociatedServiceSelectPrice(internalOrgId, callOffId, orderItem.CatalogueItemId);
+
+            mockOrderService.VerifyAll();
+            mockListPriceService.VerifyAll();
+
+            var actualResult = result.Should().BeOfType<ViewResult>().Subject;
+
+            var expected = new SelectPriceModel(orderItem.CatalogueItem);
+
+            actualResult.Model.Should().BeEquivalentTo(expected, m => m.Excluding(o => o.BackLink));
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Post_AssociatedServiceSelectPrice_ReturnsRedirect(
+            string internalOrgId,
+            CallOffId callOffId,
+            CatalogueItemId catalogueItemId,
+            PricesController controller)
+        {
+            var model = new SelectPriceModel()
+            {
+                SelectedPriceId = 1,
+            };
+
+            var result = await controller.AssociatedServiceSelectPrice(internalOrgId, callOffId, catalogueItemId, model);
+
+            var actualResult = result.Should().BeOfType<RedirectToActionResult>().Subject;
+
+            actualResult.ControllerName.Should().Be(typeof(OrderController).ControllerName());
+            actualResult.ActionName.Should().Be(nameof(OrderController.Order));
+            actualResult.RouteValues.Should().BeEquivalentTo(new RouteValueDictionary
+            {
+                { "internalOrgId", internalOrgId },
+                { "callOffId", callOffId },
+            });
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Post_AssociatedServiceSelectPrice_ModelError_ReturnsModel(
+            string internalOrgId,
+            CallOffId callOffId,
+            [Frozen] SelectPriceModel model,
+            EntityFramework.Ordering.Models.Order order,
+            [Frozen] Mock<IOrderService> mockOrderService,
+            [Frozen] Mock<ISolutionListPriceService> mockListPriceService,
+            PricesController controller)
+        {
+            order.OrderItems.First().CatalogueItem.CatalogueItemType = CatalogueItemType.Solution;
+
+            var orderItem = order.OrderItems.First();
+
+            mockOrderService
+                .Setup(x => x.GetOrderThin(callOffId, internalOrgId))
+                .ReturnsAsync(order);
+
+            mockListPriceService
+                .Setup(lps => lps.GetSolutionWithPublishedListPrices(orderItem.CatalogueItemId))
+                .ReturnsAsync(orderItem.CatalogueItem);
+
+            controller.ModelState.AddModelError("key", "message");
+
+            var result = await controller.AssociatedServiceSelectPrice(internalOrgId, callOffId, orderItem.CatalogueItemId, model);
+
+            mockOrderService.VerifyAll();
+            mockListPriceService.VerifyAll();
+
+            var actualResult = result.Should().BeOfType<ViewResult>().Subject;
+
+            var expected = new SelectPriceModel(orderItem.CatalogueItem)
+            {
+                SelectedPriceId = model.SelectedPriceId,
+                SolutionName = model.SolutionName,
+                SolutionType = model.SolutionType,
+            };
+
+            actualResult.Model.Should().BeEquivalentTo(expected, m => m.Excluding(o => o.BackLink).Excluding(o => o.BackLinkText));
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SolutionSelection/ServiceRecipientsControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SolutionSelection/ServiceRecipientsControllerTests.cs
@@ -302,6 +302,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Sol
             EntityFramework.Ordering.Models.Order order,
             [Frozen] Mock<IOrderService> mockOrderService,
             [Frozen] Mock<IOrderItemRecipientService> mockOrderRecipientService,
+            [Frozen] Mock<ISolutionListPriceService> mockListPriceService,
             ServiceRecipientsController controller)
         {
             IEnumerable<ServiceRecipientDto> serviceRecipients = null;
@@ -309,6 +310,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Sol
             mockOrderService
                 .Setup(x => x.GetOrderThin(model.CallOffId, model.InternalOrgId))
                 .ReturnsAsync(order);
+
+            mockListPriceService
+                .Setup(x => x.GetSolutionWithPublishedListPrices(model.CatalogueItemId.Value))
+                .ReturnsAsync(order.OrderItems.First().CatalogueItem);
 
             mockOrderRecipientService
                 .Setup(x => x.AddOrderItemRecipients(order.Id, model.CatalogueItemId.Value, It.IsAny<IEnumerable<ServiceRecipientDto>>()))
@@ -323,6 +328,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Sol
 
             mockOrderService.VerifyAll();
             mockOrderRecipientService.VerifyAll();
+            mockListPriceService.VerifyAll();
 
             var expected = model.ServiceRecipients
                 .Where(x => x.Selected)
@@ -332,8 +338,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Sol
 
             var actualResult = result.Should().BeOfType<RedirectToActionResult>().Subject;
 
-            actualResult.ControllerName.Should().Be(typeof(OrderController).ControllerName());
-            actualResult.ActionName.Should().Be(nameof(OrderController.Order));
+            actualResult.ControllerName.Should().Be(typeof(PricesController).ControllerName());
+            actualResult.ActionName.Should().Be(nameof(PricesController.AdditionalServiceSelectPrice));
             actualResult.RouteValues.Should().BeEquivalentTo(new RouteValueDictionary
             {
                 { "internalOrgId", model.InternalOrgId },
@@ -423,6 +429,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Sol
             EntityFramework.Ordering.Models.Order order,
             [Frozen] Mock<IOrderService> mockOrderService,
             [Frozen] Mock<IOrderItemRecipientService> mockOrderRecipientService,
+            [Frozen] Mock<ISolutionListPriceService> mockListPriceService,
             ServiceRecipientsController controller)
         {
             IEnumerable<ServiceRecipientDto> serviceRecipients = null;
@@ -430,6 +437,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Sol
             mockOrderService
                 .Setup(x => x.GetOrderThin(model.CallOffId, model.InternalOrgId))
                 .ReturnsAsync(order);
+
+            mockListPriceService
+                .Setup(x => x.GetSolutionWithPublishedListPrices(model.CatalogueItemId.Value))
+                .ReturnsAsync(order.OrderItems.First().CatalogueItem);
 
             mockOrderRecipientService
                 .Setup(x => x.AddOrderItemRecipients(order.Id, model.CatalogueItemId.Value, It.IsAny<IEnumerable<ServiceRecipientDto>>()))
@@ -444,6 +455,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Sol
 
             mockOrderService.VerifyAll();
             mockOrderRecipientService.VerifyAll();
+            mockListPriceService.VerifyAll();
 
             var expected = model.ServiceRecipients
                 .Where(x => x.Selected)
@@ -453,8 +465,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Sol
 
             var actualResult = result.Should().BeOfType<RedirectToActionResult>().Subject;
 
-            actualResult.ControllerName.Should().Be(typeof(OrderController).ControllerName());
-            actualResult.ActionName.Should().Be(nameof(OrderController.Order));
+            actualResult.ControllerName.Should().Be(typeof(PricesController).ControllerName());
+            actualResult.ActionName.Should().Be(nameof(PricesController.AssociatedServiceSelectPrice));
             actualResult.RouteValues.Should().BeEquivalentTo(new RouteValueDictionary
             {
                 { "internalOrgId", model.InternalOrgId },

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SolutionSelection/ServiceRecipientsControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SolutionSelection/ServiceRecipientsControllerTests.cs
@@ -16,6 +16,7 @@ using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Organisations;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions;
 using NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers.SolutionSelection;
@@ -113,6 +114,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Sol
             EntityFramework.Ordering.Models.Order order,
             [Frozen] Mock<IOrderService> mockOrderService,
             [Frozen] Mock<IOrderItemRecipientService> mockOrderRecipientService,
+            [Frozen] Mock<ISolutionListPriceService> mockListPriceService,
             ServiceRecipientsController controller)
         {
             IEnumerable<ServiceRecipientDto> serviceRecipients = null;
@@ -126,6 +128,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Sol
                 .Setup(x => x.GetOrderThin(model.CallOffId, model.InternalOrgId))
                 .ReturnsAsync(order);
 
+            mockListPriceService.Setup(x => x.GetSolutionWithPublishedListPrices(catalogueItemId)).ReturnsAsync(order.OrderItems.First().CatalogueItem);
+
             mockOrderRecipientService
                 .Setup(x => x.AddOrderItemRecipients(order.Id, catalogueItemId, It.IsAny<IEnumerable<ServiceRecipientDto>>()))
                 .Callback<int, CatalogueItemId, IEnumerable<ServiceRecipientDto>>((_, _, recipients) => serviceRecipients = recipients)
@@ -135,6 +139,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Sol
 
             mockOrderService.VerifyAll();
             mockOrderRecipientService.VerifyAll();
+            mockListPriceService.VerifyAll();
 
             var expected = model.ServiceRecipients
                 .Where(x => x.Selected)

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/SolutionSelection/AssociatedServices/AddAssociatedServicesModelValidatorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/SolutionSelection/AssociatedServices/AddAssociatedServicesModelValidatorTests.cs
@@ -4,7 +4,7 @@ using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.SolutionSelection.Asso
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Validators.SolutionSelection.AssociatedServices;
 using Xunit;
 
-namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Validators.AssociatedServices
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Validators.SolutionSelection.AssociatedServices
 {
     public static class AddAssociatedServicesModelValidatorTests
     {

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/SolutionSelection/CatalogueSolutions/SelectSolutionModelValidatorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/SolutionSelection/CatalogueSolutions/SelectSolutionModelValidatorTests.cs
@@ -4,7 +4,7 @@ using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.SolutionSelection.Cata
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Validators.SolutionSelection.CatalogueSolutions;
 using Xunit;
 
-namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Validators.CatalogueSolutions
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Validators.SolutionSelection.CatalogueSolutions
 {
     public static class SelectSolutionModelValidatorTests
     {

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/SolutionSelection/Prices/SelectPriceModelValidatorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/SolutionSelection/Prices/SelectPriceModelValidatorTests.cs
@@ -21,5 +21,16 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Validators.Solu
             result.ShouldHaveValidationErrorFor(nameof(model.SelectedPriceId))
                 .WithErrorMessage(SelectPriceModelValidator.NoSelectionMadeErrorMessage);
         }
+
+        [Theory]
+        [CommonAutoData]
+        public static void Validate_AllCorrect_NoErrorThrown(
+            SelectPriceModel model,
+            SelectPriceModelValidator validator)
+        {
+            var result = validator.TestValidate(model);
+
+            result.ShouldNotHaveAnyValidationErrors();
+        }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/SolutionSelection/Prices/SelectPriceModelValidatorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/SolutionSelection/Prices/SelectPriceModelValidatorTests.cs
@@ -1,0 +1,25 @@
+﻿using FluentValidation.TestHelper;
+using NHSD.GPIT.BuyingCatalogue.Test.Framework.AutoFixtureCustomisations;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.SolutionSelection.Prices;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Validators.SolutionSelection.Prices;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Validators.SolutionSelection.Prices
+{
+    public static class SelectPriceModelValidatorTests
+    {
+        [Theory]
+        [CommonAutoData]
+        public static void Validate_NoSelectionMade_ThrowsValidationError(
+            SelectPriceModel model,
+            SelectPriceModelValidator validator)
+        {
+            model.SelectedPriceId = null;
+
+            var result = validator.TestValidate(model);
+
+            result.ShouldHaveValidationErrorFor(nameof(model.SelectedPriceId))
+                .WithErrorMessage(SelectPriceModelValidator.NoSelectionMadeErrorMessage);
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/SolutionSelection/ServiceRecipients/SelectRecipientsModelValidatorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/SolutionSelection/ServiceRecipients/SelectRecipientsModelValidatorTests.cs
@@ -5,7 +5,7 @@ using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.SolutionSelection.Serv
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Validators.SolutionSelection.ServiceRecipients;
 using Xunit;
 
-namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Validators.ServiceRecipients
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Validators.SolutionSelection.ServiceRecipients
 {
     public static class SelectRecipientsModelValidatorTests
     {


### PR DESCRIPTION
Add New Controller for Select Price Page in the OrderForm

Update the ServiceRecipient endpoints to point to the select price endpoints if there is more than one published price.

Update the CommonAutoData to generate a correct CatalogueItem + ID combo for an OrderItem. Before it was generating different ID's and causing tests to fail