### PR TITLE
Update Supplier Contacts Page For Deletion

### DIFF
--- a/database/NHSD.GPITBuyingCatalogue.Database/Ordering/Tables/Contacts.sql
+++ b/database/NHSD.GPITBuyingCatalogue.Database/Ordering/Tables/Contacts.sql
@@ -11,8 +11,6 @@
     SysEndTime datetime2(0) GENERATED ALWAYS AS ROW END NOT NULL,
     PERIOD FOR SYSTEM_TIME (SysStartTime, SysEndTime),
     [Department] NVARCHAR(50) NULL, 
-    [SupplierContactId] INT NULL, 
     CONSTRAINT PK_Contacts PRIMARY KEY (Id),
-    CONSTRAINT FK_Contacts_LastUpdatedBy FOREIGN KEY (LastUpdatedBy) REFERENCES users.AspNetUsers(Id),
-    CONSTRAINT FK_Contacts_SupplierContact FOREIGN KEY (SupplierContactId) REFERENCES catalogue.SupplierContacts(Id),
+    CONSTRAINT FK_Contacts_LastUpdatedBy FOREIGN KEY (LastUpdatedBy) REFERENCES users.AspNetUsers(Id)
 ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = ordering.Contacts_History));

--- a/database/NHSD.GPITBuyingCatalogue.Database/Ordering/TemporalTables/Contacts_History.sql
+++ b/database/NHSD.GPITBuyingCatalogue.Database/Ordering/TemporalTables/Contacts_History.sql
@@ -9,6 +9,5 @@
     LastUpdatedBy int NULL,
     SysStartTime datetime2(0) NOT NULL,
     SysEndTime datetime2(0) NOT NULL, 
-    [Department] NVARCHAR(50) NULL, 
-    [SupplierContactId] INT NULL
+    [Department] NVARCHAR(50) NULL
 );

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Configuration/ContactEntityTypeConfiguration.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Configuration/ContactEntityTypeConfiguration.cs
@@ -21,11 +21,6 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Configuration
             builder.Property(c => c.Department).HasMaxLength(50);
             builder.Property(c => c.LastUpdated).HasDefaultValue(DateTime.UtcNow);
 
-            builder.HasOne(c => c.SupplierContact)
-                .WithMany()
-                .HasForeignKey(c => c.SupplierContactId)
-                .HasConstraintName("FK_Contacts_SupplierContactId");
-
             builder.HasOne(c => c.LastUpdatedByUser)
                 .WithMany()
                 .HasForeignKey(c => c.LastUpdatedBy)

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/Contact.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/Contact.cs
@@ -16,8 +16,6 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
 
         public int Id { get; set; }
 
-        public int? SupplierContactId { get; set; }
-
         [Required(ErrorMessage = "First Name Required")]
         [StringLength(100)]
         public string FirstName { get; set; }
@@ -41,8 +39,6 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
         public DateTime LastUpdated { get; set; }
 
         public int? LastUpdatedBy { get; set; }
-
-        public SupplierContact SupplierContact { get; set; }
 
         public AspNetUser LastUpdatedByUser { get; set; }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.Framework/Extensions/ContactExtensions.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Framework/Extensions/ContactExtensions.cs
@@ -11,7 +11,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Framework.Extensions
                 ? new Contact()
                 : new Contact
                 {
-                    SupplierContactId = model.SupplierContactId,
                     FirstName = model.FirstName,
                     LastName = model.LastName,
                     Email = model.EmailAddress,

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Suppliers/ISuppliersService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Suppliers/ISuppliersService.cs
@@ -26,6 +26,8 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Suppliers
 
         Task<IList<Supplier>> GetSuppliersBySearchTerm(string searchTerm);
 
+        Task<IList<CatalogueItem>> GetSolutionsReferencingSupplierContact(int supplierContactId);
+
         Task<Supplier> UpdateSupplierActiveStatus(int supplierId, bool newStatus);
 
         Task<Supplier> EditSupplierAddress(int supplierId, Address newAddress);

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Contacts/ContactDetailsService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Contacts/ContactDetailsService.cs
@@ -15,7 +15,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Contacts
             if (newOrUpdatedContact is null)
                 return existingContact;
 
-            existingContact.SupplierContactId = newOrUpdatedContact.SupplierContactId;
             existingContact.FirstName = newOrUpdatedContact.FirstName;
             existingContact.LastName = newOrUpdatedContact.LastName;
             existingContact.Email = newOrUpdatedContact.EmailAddress;

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/SupplierService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/SupplierService.cs
@@ -88,7 +88,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
 
             order.SupplierContact ??= new Contact();
 
-            order.SupplierContact.SupplierContactId = contact.Id == SupplierContact.TemporaryContactId ? null : contact.Id;
             order.SupplierContact.FirstName = contact.FirstName;
             order.SupplierContact.LastName = contact.LastName;
             order.SupplierContact.Department = contact.Department;

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Suppliers/SuppliersService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Suppliers/SuppliersService.cs
@@ -63,6 +63,11 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Suppliers
                 .ToListAsync();
         }
 
+        public async Task<IList<CatalogueItem>> GetSolutionsReferencingSupplierContact(int supplierContactId) =>
+            await dbContext.CatalogueItems
+                .Where(ci => ci.CatalogueItemContacts.Any(cic => cic.Id == supplierContactId))
+                .ToListAsync();
+
         public async Task<Supplier> AddSupplier(EditSupplierModel model)
         {
             if (model is null)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/SuppliersController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/SuppliersController.cs
@@ -262,7 +262,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             return RedirectToAction(
                 nameof(ManageSupplierContacts),
                 typeof(SuppliersController).ControllerName(),
-                new { supplierId = supplierId });
+                new { supplierId });
         }
 
         [HttpGet("{supplierId}/contacts/{contactId}")]
@@ -270,9 +270,11 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
         {
             var supplier = await suppliersService.GetSupplier(supplierId);
 
+            var solutions = await suppliersService.GetSolutionsReferencingSupplierContact(contactId);
+
             var contact = supplier.SupplierContacts.Single(sc => sc.Id == contactId);
 
-            var model = new EditContactModel(contact, supplier)
+            var model = new EditContactModel(contact, supplier, solutions)
             {
                 BackLink = Url.Action(
                     nameof(ManageSupplierContacts),
@@ -287,7 +289,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
         public async Task<IActionResult> EditSupplierContact(int supplierId, int contactId, EditContactModel model)
         {
             if (!ModelState.IsValid)
+            {
+                model.SolutionsReferencingThisContact = await suppliersService.GetSolutionsReferencingSupplierContact(contactId);
                 return View(model);
+            }
 
             var updatedContact = new SupplierContact
             {
@@ -304,7 +309,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             return RedirectToAction(
                 nameof(ManageSupplierContacts),
                 typeof(SuppliersController).ControllerName(),
-                new { supplierId = supplierId });
+                new { supplierId });
         }
 
         [HttpGet("{supplierId}/contacts/{contactId}/delete")]

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/SupplierModels/EditContactModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/SupplierModels/EditContactModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Models;
@@ -21,13 +22,16 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.SupplierModels
             SupplierName = supplier.Name;
         }
 
-        public EditContactModel(SupplierContact contact, Supplier supplier)
+        public EditContactModel(SupplierContact contact, Supplier supplier, IList<CatalogueItem> solutionsReferencing)
         {
             if (contact is null)
                 throw new ArgumentNullException(nameof(contact));
 
             if (supplier is null)
                 throw new ArgumentNullException(nameof(supplier));
+
+            if (solutionsReferencing is null)
+                throw new ArgumentNullException(nameof(solutionsReferencing));
 
             ContactId = contact.Id;
             SupplierId = contact.SupplierId;
@@ -39,6 +43,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.SupplierModels
 
             Title = $"{FirstName} {LastName} contact details";
             SupplierName = supplier.Name;
+            SolutionsReferencingThisContact = solutionsReferencing;
         }
 
         public int? ContactId { get; init; }
@@ -63,5 +68,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.SupplierModels
         public string Title { get; init; }
 
         public string SupplierName { get; init; }
+
+        public IList<CatalogueItem> SolutionsReferencingThisContact { get; set; }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Suppliers/EditSupplierContact.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Suppliers/EditSupplierContact.cshtml
@@ -13,6 +13,39 @@
         <nhs-page-title title="@ViewBag.Title"
                         caption="@Model.SupplierName"
                         advice="Provide information for this contact." />
+		@if(Model.ContactId > 0){
+			@if(Model.SolutionsReferencingThisContact.Count > 0){
+				<nhs-table data-test-id="supplier-contact-related-solutions-table" label-text="Solutions referencing this supplier contact">
+					<nhs-table-column>Solution ID</nhs-table-column>
+					<nhs-table-column>Solution name</nhs-table-column>
+					<nhs-table-column>Action</nhs-table-column>
+						@foreach(var referentialSolution in Model.SolutionsReferencingThisContact)
+						{
+							<nhs-table-row-container>
+								<nhs-table-cell>@referentialSolution.Id</nhs-table-cell>
+								<nhs-table-cell>@referentialSolution.Name</nhs-table-cell>
+								<nhs-table-cell>
+									<a asp-action="@nameof(CatalogueSolutionsController.EditSupplierDetails)"
+									   asp-controller="@typeof(CatalogueSolutionsController).ControllerName()"
+									   asp-route-solutionId="@referentialSolution.Id"
+									   data-test-id="edit-contact-association-@referentialSolution.Id" style="white-space: nowrap;">
+									Edit
+									</a>
+								</nhs-table-cell>
+							</nhs-table-row-container>
+						}
+				</nhs-table>
+			}
+			else
+			{
+				<nhs-inset-text data-test-id="no-related-solutions-inset">
+					<b>Solutions referencing this supplier contact</b>
+					<br/><br/>
+					This supplier contact is currently not being referenced by any solutions.
+				</nhs-inset-text>
+			}
+		}
+
         <form method="post">
             <input type="hidden" asp-for="BackLink" />
             <input type="hidden" asp-for="BackLinkText" />
@@ -35,7 +68,7 @@
             <br />
             <nhs-submit-button />
         </form>
-        @if (Model.ContactId > 0)
+        @if (Model.ContactId > 0 && Model.SolutionsReferencingThisContact.Count == 0)
         {
         <vc:nhs-delete-button url="@Url.Action(
                 nameof(SuppliersController.DeleteSupplierContact),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/SupplierController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/SupplierController.cs
@@ -49,21 +49,18 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
             var supplier = await supplierService.GetSupplierFromBuyingCatalogue(order.Supplier.Id);
             var temporaryContact = sessionService.GetSupplierContact(callOffId, supplier.Id);
 
-            if (temporaryContact == null)
+            if (temporaryContact == null && order.SupplierContact != null)
             {
-                if (order.SupplierContact is { SupplierContactId: null })
+                temporaryContact = new SupplierContact
                 {
-                    temporaryContact = new SupplierContact
-                    {
-                        Id = SupplierContact.TemporaryContactId,
-                        SupplierId = supplier.Id,
-                        FirstName = order.SupplierContact.FirstName,
-                        LastName = order.SupplierContact.LastName,
-                        Department = order.SupplierContact.Department,
-                        PhoneNumber = order.SupplierContact.Phone,
-                        Email = order.SupplierContact.Email,
-                    };
-                }
+                    Id = SupplierContact.TemporaryContactId,
+                    SupplierId = supplier.Id,
+                    FirstName = order.SupplierContact.FirstName,
+                    LastName = order.SupplierContact.LastName,
+                    Department = order.SupplierContact.Department,
+                    PhoneNumber = order.SupplierContact.Phone,
+                    Email = order.SupplierContact.Email,
+                };
 
                 sessionService.SetSupplierContact(callOffId, supplier.Id, temporaryContact);
             }
@@ -71,7 +68,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers
             if (selected == null
                 && order.SupplierContact != null)
             {
-                selected = order.SupplierContact.SupplierContactId ?? SupplierContact.TemporaryContactId;
+                selected = SupplierContact.TemporaryContactId;
             }
 
             var model = new SupplierModel(internalOrgId, callOffId, order)

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageSuppliers/AddSupplierContact.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageSuppliers/AddSupplierContact.cs
@@ -44,6 +44,9 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageSuppliers
             CommonActions.ElementIsDisplayed(Objects.Admin.ManageSuppliers.ManageSuppliers.EditSupplierContactDepartment).Should().BeTrue();
             CommonActions.ElementIsDisplayed(Objects.Admin.ManageSuppliers.ManageSuppliers.EditSupplierContactPhoneNumber).Should().BeTrue();
             CommonActions.ElementIsDisplayed(Objects.Admin.ManageSuppliers.ManageSuppliers.EditSupplierContactEmail).Should().BeTrue();
+            CommonActions.ElementIsDisplayed(Objects.Admin.ManageSuppliers.ManageSuppliers.EditSupplierContactReferencingSolutionsTable).Should().BeFalse();
+            CommonActions.ElementIsDisplayed(Objects.Admin.ManageSuppliers.ManageSuppliers.EditSupplierContactNoReferencingSolutionsInset).Should().BeFalse();
+            CommonActions.ElementIsDisplayed(Objects.Admin.ManageSuppliers.ManageSuppliers.EditSupplierContactDeleteLink).Should().BeFalse();
         }
 
         [Fact]

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageSuppliers/EditSupplierContact.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageSuppliers/EditSupplierContact.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
@@ -163,9 +164,9 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageSuppliers
 
             var contact = await context.SupplierContacts.SingleAsync(sc => sc.Id == ReferencedContactId);
 
-            var solution = await context.CatalogueItems.SingleAsync(ci => ci.Id == ReferencingSolutionId);
+            var solution = await context.CatalogueItems.Include(ci => ci.CatalogueItemContacts).SingleAsync(ci => ci.Id == ReferencingSolutionId);
 
-            if (!solution.CatalogueItemContacts.Contains(contact))
+            if (!solution.CatalogueItemContacts.Any(cic => cic.Id == ReferencedContactId))
             {
                 solution.CatalogueItemContacts.Add(contact);
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Supplier/SupplierInformationSupplierSelected.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Supplier/SupplierInformationSupplierSelected.cs
@@ -192,7 +192,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Supplier
             {
                 FirstName = contact.FirstName,
                 LastName = contact.LastName,
-                Department = contact.LastName,
+                Department = contact.Department,
                 Email = contact.Email,
                 Phone = contact.PhoneNumber,
             };

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Supplier/SupplierInformationSupplierSelected.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Supplier/SupplierInformationSupplierSelected.cs
@@ -195,7 +195,6 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Supplier
                 Department = contact.LastName,
                 Email = contact.Email,
                 Phone = contact.PhoneNumber,
-                SupplierContactId = contact.Id,
             };
 
             await context.SaveChangesAsync();

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Objects/Admin/ManageSuppliers/ManageSuppliers.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Objects/Admin/ManageSuppliers/ManageSuppliers.cs
@@ -94,6 +94,12 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.Admin.ManageSuppl
 
         public static By EditSupplierContactContainerError => By.Id("edit-contact-error");
 
+        public static By EditSupplierContactReferencingSolutionsTable => ByExtensions.DataTestId("supplier-contact-related-solutions-table");
+
+        public static By EditSupplierContactNoReferencingSolutionsInset => ByExtensions.DataTestId("no-related-solutions-inset");
+
+        public static By EditSupplierContactDeleteLink => By.LinkText("Delete contact");
+
         public static By DeleteSupplierContactCancelLink => By.LinkText("Cancel");
 
         public static By SearchBar => By.Id("suppliers-suggestion-search");

--- a/tests/NHSD.GPIT.BuyingCatalogue.Framework.UnitTests/Extensions/ContactExtensionsTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Framework.UnitTests/Extensions/ContactExtensionsTests.cs
@@ -23,7 +23,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Framework.UnitTests.Extensions
 
             var expected = new Contact
             {
-                SupplierContactId = model.SupplierContactId,
                 FirstName = model.FirstName,
                 LastName = model.LastName,
                 Email = model.EmailAddress,

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/SuppliersControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/SuppliersControllerTests.cs
@@ -321,12 +321,16 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
         [CommonAutoData]
         public static async Task Get_EditSupplierContact_ReturnsViewWithExpectedViewModel(
             Supplier supplier,
+            List<CatalogueItem> solutions,
             [Frozen] Mock<ISuppliersService> mockSuppliersService,
             SuppliersController controller)
         {
             mockSuppliersService.Setup(s => s.GetSupplier(supplier.Id)).ReturnsAsync(supplier);
 
-            var expectedResult = new EditContactModel(supplier.SupplierContacts.First(), supplier)
+            mockSuppliersService.Setup(s => s.GetSolutionsReferencingSupplierContact(supplier.SupplierContacts.First().Id))
+                .ReturnsAsync(solutions);
+
+            var expectedResult = new EditContactModel(supplier.SupplierContacts.First(), supplier, solutions)
             {
                 BackLink = "testUrl",
             };

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/SupplierModels/EditContactModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/SupplierModels/EditContactModelTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.AutoFixtureCustomisations;
@@ -20,7 +21,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.Supplier
         [Fact]
         public static void ConstructorOverload_NullContact_ThrowsException()
         {
-            var actual = Assert.Throws<ArgumentNullException>(() => new EditContactModel(null, new Supplier()));
+            var actual = Assert.Throws<ArgumentNullException>(() => new EditContactModel(null, new Supplier(), new List<CatalogueItem>()));
 
             actual.ParamName.Should().Be("contact");
         }
@@ -28,9 +29,16 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.Supplier
         [Fact]
         public static void ConstructorOverload_NullSupplier_ThrowsException()
         {
-            var actual = Assert.Throws<ArgumentNullException>(() => new EditContactModel(new SupplierContact(), null));
+            var actual = Assert.Throws<ArgumentNullException>(() => new EditContactModel(new SupplierContact(), null, new List<CatalogueItem>()));
 
             actual.ParamName.Should().Be("supplier");
+        }
+
+        [Fact]
+        public static void ConstructorOverload_NullReferencingSolutions_ThrowsException()
+        {
+            var actual = Assert.Throws <ArgumentNullException>(() => new EditContactModel(new SupplierContact(), new Supplier(), null));
+            actual.ParamName.Should().Be("solutionsReferencing");
         }
 
         [Theory]
@@ -48,9 +56,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.Supplier
         [CommonAutoData]
         public static void WithValidConstructionOverload_PropertiesSetAsExpected(
             SupplierContact contact,
-            Supplier supplier)
+            Supplier supplier,
+            List<CatalogueItem> solutions)
         {
-            var actual = new EditContactModel(contact, supplier);
+            var actual = new EditContactModel(contact, supplier, solutions);
 
             actual.ContactId.Should().Be(contact.Id);
             actual.SupplierId.Should().Be(contact.SupplierId);
@@ -61,6 +70,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.Supplier
             actual.Department.Should().Be(contact.Department);
             actual.Title.Should().Be($"{contact.FirstName} {contact.LastName} contact details");
             actual.SupplierName.Should().Be(supplier.Name);
+            actual.SolutionsReferencingThisContact.Should().NotBeEmpty().And.HaveCount(solutions.Count);
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/SupplierModels/EditContactModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/SupplierModels/EditContactModelTests.cs
@@ -37,7 +37,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.Supplier
         [Fact]
         public static void ConstructorOverload_NullReferencingSolutions_ThrowsException()
         {
-            var actual = Assert.Throws <ArgumentNullException>(() => new EditContactModel(new SupplierContact(), new Supplier(), null));
+            var actual = Assert.Throws<ArgumentNullException>(() => new EditContactModel(new SupplierContact(), new Supplier(), null));
             actual.ParamName.Should().Be("solutionsReferencing");
         }
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Validators/EditContactModelValidatorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Validators/EditContactModelValidatorTests.cs
@@ -31,7 +31,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Validators
             suppliersService.Setup(s => s.GetSupplier(existingContact.SupplierId))
                 .ReturnsAsync(supplier);
 
-            var model = new EditContactModel(existingContact, supplier);
+            var model = new EditContactModel(existingContact, supplier, new List<CatalogueItem>());
 
             var result = validator.TestValidate(model);
 
@@ -57,7 +57,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Validators
             suppliersService.Setup(s => s.GetSupplier(existingContact.SupplierId))
                 .ReturnsAsync(supplier);
 
-            var model = new EditContactModel(existingContact, supplier);
+            var model = new EditContactModel(existingContact, supplier,new List<CatalogueItem>());
 
             var result = validator.TestValidate(model);
 
@@ -83,7 +83,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Validators
             suppliersService.Setup(s => s.GetSupplier(existingContact.SupplierId))
                 .ReturnsAsync(supplier);
 
-            var model = new EditContactModel(existingContact, supplier);
+            var model = new EditContactModel(existingContact, supplier, new List<CatalogueItem>());
 
             var result = validator.TestValidate(model);
 
@@ -109,7 +109,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Validators
             suppliersService.Setup(s => s.GetSupplier(existingContact.SupplierId))
                 .ReturnsAsync(supplier);
 
-            var model = new EditContactModel(existingContact, supplier);
+            var model = new EditContactModel(existingContact, supplier, new List<CatalogueItem>());
 
             var result = validator.TestValidate(model);
 
@@ -135,7 +135,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Validators
             suppliersService.Setup(s => s.GetSupplier(existingContact.SupplierId))
                 .ReturnsAsync(supplier);
 
-            var model = new EditContactModel(existingContact, supplier);
+            var model = new EditContactModel(existingContact, supplier, new List<CatalogueItem>());
 
             var result = validator.TestValidate(model);
 
@@ -159,7 +159,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Validators
             suppliersService.Setup(s => s.GetSupplier(existingContact.SupplierId))
                 .ReturnsAsync(supplier);
 
-            var model = new EditContactModel(existingContact, supplier);
+            var model = new EditContactModel(existingContact, supplier, new List<CatalogueItem>());
 
             var result = validator.TestValidate(model);
 
@@ -238,7 +238,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Validators
             suppliersService.Setup(s => s.GetSupplier(existingContact.SupplierId))
                 .ReturnsAsync(supplier);
 
-            var model = new EditContactModel(existingContact, supplier)
+            var model = new EditContactModel(existingContact, supplier, new List<CatalogueItem>())
             {
                 ContactId = existingContact.Id + 1,
             };
@@ -265,7 +265,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Validators
             suppliersService.Setup(s => s.GetSupplier(existingContact.SupplierId))
                 .ReturnsAsync(supplier);
 
-            var model = new EditContactModel(existingContact, supplier);
+            var model = new EditContactModel(existingContact, supplier, new List<CatalogueItem>());
 
             var result = validator.TestValidate(model);
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Validators/EditContactModelValidatorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Validators/EditContactModelValidatorTests.cs
@@ -57,7 +57,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Validators
             suppliersService.Setup(s => s.GetSupplier(existingContact.SupplierId))
                 .ReturnsAsync(supplier);
 
-            var model = new EditContactModel(existingContact, supplier,new List<CatalogueItem>());
+            var model = new EditContactModel(existingContact, supplier, new List<CatalogueItem>());
 
             var result = validator.TestValidate(model);
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SupplierControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SupplierControllerTests.cs
@@ -78,6 +78,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
             var model = new SupplierModel(internalOrgId, order.CallOffId, order)
             {
                 Contacts = supplier.SupplierContacts.ToList(),
+                SelectedContactId = SupplierContact.TemporaryContactId,
             };
 
             orderServiceMock

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SupplierControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SupplierControllerTests.cs
@@ -78,7 +78,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
             var model = new SupplierModel(internalOrgId, order.CallOffId, order)
             {
                 Contacts = supplier.SupplierContacts.ToList(),
-                SelectedContactId = order.SupplierContact.SupplierContactId,
             };
 
             orderServiceMock
@@ -114,8 +113,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
                 Contacts = supplier.SupplierContacts.ToList(),
                 SelectedContactId = SupplierContact.TemporaryContactId,
             };
-
-            order.SupplierContact.SupplierContactId = null;
 
             mockOrderService
                 .Setup(s => s.GetOrderWithSupplier(order.CallOffId, internalOrgId))


### PR DESCRIPTION
Update supplier contacts edit page to show if any solutions are referencing that contact, and if they are, show which ones (with an edit link to the supplier details page in the solutions management section) and disable deleting.