### PR TITLE
Add Capping the Number of Tiers in Config

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.Framework/Settings/PriceTiersCapSettings.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Framework/Settings/PriceTiersCapSettings.cs
@@ -2,9 +2,11 @@
 
 namespace NHSD.GPIT.BuyingCatalogue.Framework.Settings
 {
-    [ExcludeFromCodeCoverage]
+    [ExcludeFromCodeCoverage(Justification = "Class currently only contains automatic properties")]
     public sealed class PriceTiersCapSettings
     {
+        public const string SectionName = "priceTiersCap";
+
         public int MaximumNumberOfPriceTiers { get; set; }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.Framework/Settings/PriceTiersCapSettings.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Framework/Settings/PriceTiersCapSettings.cs
@@ -1,0 +1,10 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace NHSD.GPIT.BuyingCatalogue.Framework.Settings
+{
+    [ExcludeFromCodeCoverage]
+    public sealed class PriceTiersCapSettings
+    {
+        public int MaximumNumberOfPriceTiers { get; set; }
+    }
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/CatalogueSolutionListPriceController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/CatalogueSolutionListPriceController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
+using NHSD.GPIT.BuyingCatalogue.Framework.Settings;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ListPriceModels;
 
@@ -18,10 +19,12 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
     public class CatalogueSolutionListPriceController : Controller
     {
         private readonly ISolutionListPriceService solutionListPriceService;
+        private readonly PriceTiersCapSettings priceTiersCapSettings;
 
-        public CatalogueSolutionListPriceController(ISolutionListPriceService solutionListPriceService)
+        public CatalogueSolutionListPriceController(ISolutionListPriceService solutionListPriceService, PriceTiersCapSettings tiersCapSettings)
         {
             this.solutionListPriceService = solutionListPriceService ?? throw new ArgumentNullException(nameof(solutionListPriceService));
+            priceTiersCapSettings = tiersCapSettings ?? throw new ArgumentNullException(nameof(tiersCapSettings));
         }
 
         [HttpGet]
@@ -158,7 +161,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             if (price is null)
                 return NotFound();
 
-            var model = new TieredPriceTiersModel(solution, price)
+            var model = new TieredPriceTiersModel(solution, price, priceTiersCapSettings.MaximumNumberOfPriceTiers)
             {
                 BackLink = Url.Action(nameof(AddTieredListPrice), new { solutionId, cataloguePriceId }),
             };
@@ -175,6 +178,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                 var price = solution.CataloguePrices.Single(p => p.CataloguePriceId == cataloguePriceId);
 
                 model.Tiers = price.CataloguePriceTiers.ToList();
+
+                model.MaximumNumberOfTiers = priceTiersCapSettings.MaximumNumberOfPriceTiers;
 
                 return View("ListPrices/TieredPriceTiers", model);
             }
@@ -237,7 +242,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             if (price is null)
                 return NotFound();
 
-            var model = new EditTieredListPriceModel(solution, price)
+            var model = new EditTieredListPriceModel(solution, price, priceTiersCapSettings.MaximumNumberOfPriceTiers)
             {
                 BackLink = Url.Action(nameof(Index), new { solutionId }),
             };

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/CatalogueSolutionListPriceController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/CatalogueSolutionListPriceController.cs
@@ -259,6 +259,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             if (!ModelState.IsValid)
             {
                 model.Tiers = price.CataloguePriceTiers.ToList();
+                model.MaximumNumberOfTiers = priceTiersCapSettings.MaximumNumberOfPriceTiers;
 
                 return View("ListPrices/EditTieredListPrice", model);
             }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ListPriceModels/EditTieredListPriceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ListPriceModels/EditTieredListPriceModel.cs
@@ -12,13 +12,15 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ListPriceModels
         {
         }
 
-        public EditTieredListPriceModel(CatalogueItem catalogueItem, CataloguePrice price)
+        public EditTieredListPriceModel(CatalogueItem catalogueItem, CataloguePrice price, int maximumNumberOfTiers)
             : base(catalogueItem, price)
         {
             Tiers = price.CataloguePriceTiers.ToList();
             SelectedPublicationStatus
                 = CataloguePricePublicationStatus
                 = price.PublishedStatus;
+
+            MaximumNumberOfTiers = maximumNumberOfTiers;
         }
 
         public PublicationStatus CataloguePricePublicationStatus { get; set; }
@@ -31,5 +33,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ListPriceModels
             .ToList();
 
         public IList<CataloguePriceTier> Tiers { get; set; }
+
+        public int MaximumNumberOfTiers { get; set; }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ListPriceModels/TieredPriceTiersModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ListPriceModels/TieredPriceTiersModel.cs
@@ -13,12 +13,13 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ListPriceModels
         {
         }
 
-        public TieredPriceTiersModel(CatalogueItem catalogueItem, CataloguePrice price)
+        public TieredPriceTiersModel(CatalogueItem catalogueItem, CataloguePrice price, int maximumNumberOfTiers)
         {
             CataloguePriceId = price.CataloguePriceId;
             CatalogueItemId = catalogueItem.Id;
             CatalogueItemName = catalogueItem.Name;
             Tiers = price.CataloguePriceTiers?.ToList();
+            MaximumNumberOfTiers = maximumNumberOfTiers;
         }
 
         public static IList<SelectableRadioOption<PublicationStatus>> AvailablePublicationStatuses => new List<SelectableRadioOption<PublicationStatus>>
@@ -36,5 +37,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ListPriceModels
         public IList<CataloguePriceTier> Tiers { get; set; }
 
         public PublicationStatus? SelectedPublicationStatus { get; set; } = PublicationStatus.Draft;
+
+        public int MaximumNumberOfTiers { get; set; }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/ListPrices/EditTieredListPrice.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/ListPrices/EditTieredListPrice.cshtml
@@ -98,12 +98,12 @@
             else
             {
 				if(Model.Tiers.Count < Model.MaximumNumberOfTiers){
-				<vc:nhs-action-link 
+				<vc:nhs-action-link
 					text="Add a pricing tier"
 					 url="@Url.Action(
 						nameof(CatalogueSolutionListPriceController.AddTieredPriceTier),
 						typeof(CatalogueSolutionListPriceController).ControllerName(),
-						new { solutionId = Model.CatalogueItemId, cataloguePriceId = Model.CataloguePriceId }
+						new { solutionId = Model.CatalogueItemId, cataloguePriceId = Model.CataloguePriceId, isEditing = true }
 						)" />
 				}else{
 					<nhs-inset-text data-test-id="maximum-tiers-reached-inset">

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/ListPrices/EditTieredListPrice.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/ListPrices/EditTieredListPrice.cshtml
@@ -97,11 +97,19 @@
             }
             else
             {
-                <br />
-                <vc:nhs-action-link text="Add a pricing tier" url="@Url.Action(
-                    nameof(CatalogueSolutionListPriceController.AddTieredPriceTier),
-                    typeof(CatalogueSolutionListPriceController).ControllerName(),
-                    new { solutionId = Model.CatalogueItemId, cataloguePriceId = Model.CataloguePriceId, isEditing = true })" />
+				if(Model.Tiers.Count < Model.MaximumNumberOfTiers){
+				<vc:nhs-action-link 
+					text="Add a pricing tier"
+					 url="@Url.Action(
+						nameof(CatalogueSolutionListPriceController.AddTieredPriceTier),
+						typeof(CatalogueSolutionListPriceController).ControllerName(),
+						new { solutionId = Model.CatalogueItemId, cataloguePriceId = Model.CataloguePriceId }
+						)" />
+				}else{
+					<nhs-inset-text data-test-id="maximum-tiers-reached-inset">
+						The maximum number of tiers you can add is @Model.MaximumNumberOfTiers. You cannot add any more tiers for this price.
+					</nhs-inset-text>
+				}
             }
 
             @if(Model.Tiers.Any())

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/ListPrices/TieredPriceTiers.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/ListPrices/TieredPriceTiers.cshtml
@@ -16,6 +16,7 @@
             advice="Provide information about the pricing tiers available for your Catalogue Solution.">
         </nhs-page-title>
 
+		@if(Model.Tiers.Count < Model.MaximumNumberOfTiers){
         <vc:nhs-action-link 
             text="Add a pricing tier"
              url="@Url.Action(
@@ -23,6 +24,11 @@
                 typeof(CatalogueSolutionListPriceController).ControllerName(),
                 new { solutionId = Model.CatalogueItemId, cataloguePriceId = Model.CataloguePriceId }
                 )" />
+		}else{
+			<nhs-inset-text data-test-id="maximum-tiers-reached-inset">
+				The maximum number of tiers you can add is @Model.MaximumNumberOfTiers. You cannot add any more tiers for this price.
+			</nhs-inset-text>
+		}
 
         @if(Model.Tiers.Any())
         {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/ServiceCollectionExtensions.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/ServiceCollectionExtensions.cs
@@ -156,6 +156,14 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp
             services.AddSingleton(pdfSettings);
         }
 
+        public static IServiceCollection ConfigurePriceTiersCap(this IServiceCollection services, IConfiguration configuration)
+        {
+            var priceTiersCapSettings = configuration.GetSection("PriceTiersCap").Get<PriceTiersCapSettings>();
+            services.AddSingleton(priceTiersCapSettings);
+
+            return services;
+        }
+
         public static IServiceCollection ConfigureTermsOfUseSettings(this IServiceCollection services, IConfiguration configuration)
         {
             var termsOfUseSettings = configuration.GetSection("termsOfUse").Get<TermsOfUseSettings>();

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/ServiceCollectionExtensions.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/ServiceCollectionExtensions.cs
@@ -158,7 +158,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp
 
         public static IServiceCollection ConfigurePriceTiersCap(this IServiceCollection services, IConfiguration configuration)
         {
-            var priceTiersCapSettings = configuration.GetSection("PriceTiersCap").Get<PriceTiersCapSettings>();
+            var priceTiersCapSettings = configuration.GetSection("priceTiersCap").Get<PriceTiersCapSettings>();
             services.AddSingleton(priceTiersCapSettings);
 
             return services;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Startup.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Startup.cs
@@ -80,7 +80,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp
                 .ConfigureRequestAccountMessageSettings(Configuration)
                 .ConfigureConsentCookieSettings(Configuration)
                 .ConfigureTermsOfUseSettings(Configuration)
-                .ConfigureAnalyticsSettings(Configuration);
+                .ConfigureAnalyticsSettings(Configuration)
+                .ConfigurePriceTiersCap(Configuration);
 
             services.ConfigureCookies(Configuration);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/appsettings.json
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/appsettings.json
@@ -88,5 +88,8 @@
   },
   "termsOfUse": {
     "revisionDate": "2022-03-18T12:30:00"
+  },
+  "PriceTiersCap": {
+    "maximumNumberOfPriceTiers" : 5
   }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/appsettings.json
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/appsettings.json
@@ -89,7 +89,7 @@
   "termsOfUse": {
     "revisionDate": "2022-03-18T12:30:00"
   },
-  "PriceTiersCap": {
-    "maximumNumberOfPriceTiers" : 5
+  "priceTiersCap": {
+    "maximumNumberOfPriceTiers" : 7
   }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Solution/Tiered/AddTieredListPrice.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Solution/Tiered/AddTieredListPrice.cs
@@ -48,6 +48,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Solution.Tie
             CommonActions.ElementIsDisplayed(AddEditTieredListPriceObjects.UnitDescriptionInput).Should().BeTrue();
             CommonActions.ElementIsDisplayed(AddEditTieredListPriceObjects.UnitDefinitionInput).Should().BeTrue();
             CommonActions.ElementIsDisplayed(AddEditTieredListPriceObjects.RangeDefinitionInput).Should().BeTrue();
+            CommonActions.ElementExists(AddEditTieredListPriceObjects.MaximumTiersInset).Should().BeFalse();
 
             CommonActions.ElementIsDisplayed(AddEditTieredListPriceObjects.OnDemandBillingPeriodInput).Should().BeFalse();
             CommonActions.ElementIsDisplayed(AddEditTieredListPriceObjects.DeclarativeBillingPeriodInput).Should().BeFalse();

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Solution/Tiered/EditTieredListPrice.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Solution/Tiered/EditTieredListPrice.cs
@@ -17,11 +17,18 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Solution.Tie
     {
         private static readonly CatalogueItemId SolutionId = new CatalogueItemId(99998, "001");
         private static readonly int CataloguePriceId = 4;
+        private static readonly int MaximumTiersPriceId = 23;
 
         private static readonly Dictionary<string, string> Parameters = new()
         {
             { nameof(SolutionId), SolutionId.ToString() },
             { nameof(CataloguePriceId), CataloguePriceId.ToString() },
+        };
+
+        private static readonly Dictionary<string, string> MaximumTiersParameters = new()
+        {
+            { nameof(SolutionId), SolutionId.ToString() },
+            { nameof(CataloguePriceId), MaximumTiersPriceId.ToString() },
         };
 
         public EditTieredListPrice(LocalWebApplicationFactory factory)
@@ -52,6 +59,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Solution.Tie
             CommonActions.ElementIsDisplayed(AddEditTieredListPriceObjects.UnitDescriptionInput).Should().BeTrue();
             CommonActions.ElementIsDisplayed(AddEditTieredListPriceObjects.UnitDefinitionInput).Should().BeTrue();
             CommonActions.ElementIsDisplayed(AddEditTieredListPriceObjects.RangeDefinitionInput).Should().BeTrue();
+            CommonActions.ElementExists(AddEditTieredListPriceObjects.MaximumTiersInset).Should().BeFalse();
 
             CommonActions.ElementIsDisplayed(AddEditTieredListPriceObjects.OnDemandBillingPeriodInput).Should().BeFalse();
             CommonActions.ElementIsDisplayed(AddEditTieredListPriceObjects.DeclarativeBillingPeriodInput).Should().BeFalse();
@@ -80,6 +88,15 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Solution.Tie
 
             price.PublishedStatus = publishStatus;
             context.SaveChanges();
+        }
+
+        [Fact]
+        public void MaximumTiersReached_CorrectInsetDisplayed()
+        {
+            NavigateToUrl(typeof(CatalogueSolutionListPriceController), nameof(CatalogueSolutionListPriceController.EditTieredListPrice), MaximumTiersParameters);
+
+            CommonActions.ElementIsDisplayed(AddEditTieredListPriceObjects.AddTierLink).Should().BeFalse();
+            CommonActions.ElementIsDisplayed(AddEditTieredListPriceObjects.MaximumTiersInset).Should().BeTrue();
         }
 
         [Fact]

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
@@ -1124,6 +1124,22 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                                     UpperRange = null,
                                     LastUpdated = DateTime.UtcNow,
                                 },
+                                new()
+                                {
+                                    Id = 35,
+                                    CataloguePriceId = 23,
+                                    LowerRange = 150000,
+                                    UpperRange = null,
+                                    LastUpdated = DateTime.UtcNow,
+                                },
+                                new()
+                                {
+                                    Id = 36,
+                                    CataloguePriceId = 23,
+                                    LowerRange = 150000,
+                                    UpperRange = null,
+                                    LastUpdated = DateTime.UtcNow,
+                                },
                             },
                         },
                     },

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
@@ -1049,7 +1049,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                                 new()
                                 {
                                     Id = 7,
-                                    CataloguePriceId = 4,
+                                    CataloguePriceId = 5,
                                     LowerRange = 90000,
                                     UpperRange = 899999,
                                     LastUpdated = DateTime.UtcNow,
@@ -1057,8 +1057,70 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                                 new()
                                 {
                                     Id = 8,
-                                    CataloguePriceId = 4,
+                                    CataloguePriceId = 5,
                                     LowerRange = 900000,
+                                    UpperRange = null,
+                                    LastUpdated = DateTime.UtcNow,
+                                },
+                            },
+                        },
+                        new()
+                        {
+                            CataloguePriceId = 23,
+                            CatalogueItemId = new CatalogueItemId(99998, "001"),
+                            ProvisioningType = ProvisioningType.Patient,
+                            CataloguePriceType = CataloguePriceType.Tiered,
+                            CataloguePriceCalculationType = CataloguePriceCalculationType.Cumulative,
+                            PublishedStatus = PublicationStatus.Draft,
+                            PricingUnit = new PricingUnit
+                            {
+                                Id = 23,
+                                RangeDescription = "Patients",
+                                Description = "per tiered single fixed test patient Maximum Tiers Unpublished",
+                            },
+                            TimeUnit = TimeUnit.PerYear,
+                            CurrencyCode = "GBP",
+                            LastUpdated = DateTime.UtcNow,
+                            CataloguePriceTiers = new List<CataloguePriceTier>
+                            {
+                                new()
+                                {
+                                    Id = 30,
+                                    CataloguePriceId = 23,
+                                    LowerRange = 1,
+                                    UpperRange = 9999,
+                                    Price = 999.9999M,
+                                    LastUpdated = DateTime.UtcNow,
+                                },
+                                new()
+                                {
+                                    Id = 31,
+                                    CataloguePriceId = 23,
+                                    LowerRange = 10000,
+                                    UpperRange = 49000,
+                                    LastUpdated = DateTime.UtcNow,
+                                },
+                                new()
+                                {
+                                    Id = 32,
+                                    CataloguePriceId = 23,
+                                    LowerRange = 50000,
+                                    UpperRange = 99999,
+                                    LastUpdated = DateTime.UtcNow,
+                                },
+                                new()
+                                {
+                                    Id = 33,
+                                    CataloguePriceId = 23,
+                                    LowerRange = 100000,
+                                    UpperRange = 149999,
+                                    LastUpdated = DateTime.UtcNow,
+                                },
+                                new()
+                                {
+                                    Id = 34,
+                                    CataloguePriceId = 23,
+                                    LowerRange = 150000,
                                     UpperRange = null,
                                     LastUpdated = DateTime.UtcNow,
                                 },

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Objects/Admin/ListPrices/AddEditTieredListPriceObjects.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Objects/Admin/ListPrices/AddEditTieredListPriceObjects.cs
@@ -19,6 +19,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.Admin.ListPrices
 
         public static By PublishedInsetSection => ByExtensions.DataTestId("published-price-inset");
 
+        public static By MaximumTiersInset => ByExtensions.DataTestId("maximum-tiers-reached-inset");
+
         public static By TieredPriceTable => ByExtensions.DataTestId("tiered-price-table");
 
         public static By DeclarativeBillingPeriodInput => By.Id("conditional-SelectedProvisioningType_1");

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/CatalogueSolutionListPriceControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/CatalogueSolutionListPriceControllerTests.cs
@@ -237,12 +237,13 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
         public static async Task Get_TieredPriceTiers_ReturnsViewWithModel(
             Solution solution,
             CataloguePrice price,
+            [Frozen] PriceTiersCapSettings priceTiersSetting,
             [Frozen] Mock<ISolutionListPriceService> solutionListPriceService,
             CatalogueSolutionListPriceController controller)
         {
             solution.CatalogueItem.CataloguePrices.Add(price);
 
-            var model = new TieredPriceTiersModel(solution.CatalogueItem, price, 0);
+            var model = new TieredPriceTiersModel(solution.CatalogueItem, price, priceTiersSetting.MaximumNumberOfPriceTiers);
 
             solutionListPriceService.Setup(s => s.GetCatalogueItemWithListPrices(solution.CatalogueItemId))
                 .ReturnsAsync(solution.CatalogueItem);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/CatalogueSolutionListPriceControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/CatalogueSolutionListPriceControllerTests.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Routing;
 using Moq;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.Framework.Settings;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions;
 using NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.AutoFixtureCustomisations;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers;
@@ -241,7 +242,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
         {
             solution.CatalogueItem.CataloguePrices.Add(price);
 
-            var model = new TieredPriceTiersModel(solution.CatalogueItem, price);
+            var model = new TieredPriceTiersModel(solution.CatalogueItem, price, 0);
 
             solutionListPriceService.Setup(s => s.GetCatalogueItemWithListPrices(solution.CatalogueItemId))
                 .ReturnsAsync(solution.CatalogueItem);
@@ -500,6 +501,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
         public static async Task Get_EditTieredListPrice_ReturnsViewWithModel(
             Solution solution,
             CataloguePrice price,
+            [Frozen] PriceTiersCapSettings priceTiersSetting,
             [Frozen] Mock<ISolutionListPriceService> solutionListPriceService,
             CatalogueSolutionListPriceController controller)
         {
@@ -508,7 +510,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             solutionListPriceService.Setup(s => s.GetCatalogueItemWithListPrices(solution.CatalogueItemId))
                 .ReturnsAsync(solution.CatalogueItem);
 
-            var model = new EditTieredListPriceModel(solution.CatalogueItem, price);
+            var model = new EditTieredListPriceModel(solution.CatalogueItem, price, priceTiersSetting.MaximumNumberOfPriceTiers);
 
             var result = (await controller.EditTieredListPrice(solution.CatalogueItemId, price.CataloguePriceId)).As<ViewResult>();
 


### PR DESCRIPTION
Added a new config setting for capping price tiers.

Have the Edit and Add Tiered Price pages only show the add tier button if the number of tiers is less than the maximum.

Update tests