### PR TITLE
Add Calculation Types to Flat Prices

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Catalogue/Models/CataloguePriceCalculationType.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Catalogue/Models/CataloguePriceCalculationType.cs
@@ -9,12 +9,12 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models
         [Description("Buyers pay one fixed price no matter what quantity they want to buy.")]
         SingleFixed = 1,
 
-        [Display(Name = "Tiered cumulative")]
+        [Display(Name = "Cumulative")]
         [Description("Buyers pay one price for the quantity of units that fall into the first tier, another price for units that fall into the next tier and so on.")]
         Cumulative = 2,
 
-        [Display(Name = "Tiered volume")]
-        [Description("Buyers pay the same price for all units based on how many they buy and the tier that quantity falls into.")]
+        [Display(Name = "Volume")]
+        [Description("Buyers pay the same price for all units based on how many they buy.")]
         Volume = 3,
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/ListPrice/IListPriceService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/ListPrice/IListPriceService.cs
@@ -10,6 +10,7 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.ListPrice
             CatalogueItemId catalogueItemId,
             int? cataloguePriceId,
             ProvisioningType provisioningType,
+            CataloguePriceCalculationType calculationType,
             decimal price,
             string unitDescription);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/ListPrice/ListPriceService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/ListPrice/ListPriceService.cs
@@ -22,6 +22,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.ListPrice
             CatalogueItemId catalogueItemId,
             int? cataloguePriceId,
             ProvisioningType provisioningType,
+            CataloguePriceCalculationType calculationType,
             decimal price,
             string unitDescription)
         {
@@ -33,6 +34,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.ListPrice
 
             return await results.AnyAsync(
                 p => p.ProvisioningType == provisioningType
+                    && p.CataloguePriceCalculationType == calculationType
                     && p.CataloguePriceTiers.Any(pt => pt.Price == price)
                     && p.PricingUnit.Description == unitDescription);
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/ValidationSummary/ValidationSummaryTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/ValidationSummary/ValidationSummaryTagHelper.cs
@@ -69,7 +69,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
         private TagBuilder GetListItemBuilder(string linkElement, string errorMessage)
         {
             if (!string.IsNullOrWhiteSpace(RadioId)
-                && RadioId.Split(',').Contains(linkElement))
+                && RadioId.Split(',', StringSplitOptions.TrimEntries).Contains(linkElement))
             {
                 linkElement = $"{linkElement}_0";
             }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AdditionalServiceListPriceController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AdditionalServiceListPriceController.cs
@@ -54,13 +54,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                     nameof(AdditionalServicesController.EditAdditionalService),
                     typeof(AdditionalServicesController).ControllerName(),
                     new { solutionId, additionalServiceId }),
-                /* TODO - Reintroduce when Tiered Pricing is Introduced.
-                    AddListPriceUrl = Url.Action(
-                        nameof(ListPriceType),
-                        new { solutionId, additonalServiceId }),
-                */
-
-                // TODO - Delete when Tiered Pricing is Introducted.
                 AddListPriceUrl = Url.Action(
                     nameof(AddFlatListPrice),
                     new { solutionId, additionalServiceId }),
@@ -131,13 +124,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                             new { solutionId, additionalServiceId, cataloguePriceId }),
                 }
                 : new(solution, additionalService);
-            /* TODO - Reintroduce when Tiered Pricing is Introduced.
-            model.BackLink = Url.Action(
-                nameof(ListPriceType),
-                new { solutionId, additionalServiceId, selectedPriceType = CataloguePriceType.Tiered });
-            */
 
-            // TODO - Delete when Tiered Pricing is Introduced.
             model.BackLink = Url.Action(
                 nameof(Index),
                 new { solutionId, additionalServiceId });
@@ -169,7 +156,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
 
             var model = new AddEditFlatListPriceModel(additionalService)
             {
-                BackLink = Url.Action(nameof(ListPriceType), new { solutionId, additionalServiceId, selectedPriceType = CataloguePriceType.Flat }),
+                BackLink = Url.Action(nameof(Index), new { solutionId, additionalServiceId }),
             };
 
             return View("ListPrices/AddEditFlatListPrice", model);

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AdditionalServiceListPriceController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AdditionalServiceListPriceController.cs
@@ -54,8 +54,15 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                     nameof(AdditionalServicesController.EditAdditionalService),
                     typeof(AdditionalServicesController).ControllerName(),
                     new { solutionId, additionalServiceId }),
+                /* TODO - Reintroduce when Tiered Pricing is Introduced.
+                    AddListPriceUrl = Url.Action(
+                        nameof(ListPriceType),
+                        new { solutionId, additonalServiceId }),
+                */
+
+                // TODO - Delete when Tiered Pricing is Introducted.
                 AddListPriceUrl = Url.Action(
-                    nameof(ListPriceType),
+                    nameof(AddFlatListPrice),
                     new { solutionId, additionalServiceId }),
             };
 
@@ -124,9 +131,16 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                             new { solutionId, additionalServiceId, cataloguePriceId }),
                 }
                 : new(solution, additionalService);
+            /* TODO - Reintroduce when Tiered Pricing is Introduced.
+            model.BackLink = Url.Action(
+                nameof(ListPriceType),
+                new { solutionId, additionalServiceId, selectedPriceType = CataloguePriceType.Tiered });
+            */
 
-            model.BackLink = Url.Action(nameof(ListPriceType), new { solutionId, additionalServiceId, selectedPriceType = CataloguePriceType.Tiered });
-
+            // TODO - Delete when Tiered Pricing is Introduced.
+            model.BackLink = Url.Action(
+                nameof(Index),
+                new { solutionId, additionalServiceId });
             return View("ListPrices/AddTieredListPrice", model);
         }
 
@@ -176,7 +190,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                 ProvisioningType = model.SelectedProvisioningType!.Value,
                 TimeUnit = model.GetBillingPeriod(),
                 PricingUnit = model.GetPricingUnit(),
-                CataloguePriceCalculationType = CataloguePriceCalculationType.SingleFixed,
+                CataloguePriceCalculationType = model.SelectedCalculationType!.Value,
                 CataloguePriceTiers = new HashSet<CataloguePriceTier>
                 {
                     new()

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AdditionalServiceListPriceController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AdditionalServiceListPriceController.cs
@@ -418,7 +418,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                 cataloguePriceId,
                 model.GetPricingUnit(),
                 model.SelectedProvisioningType!.Value,
-                CataloguePriceCalculationType.SingleFixed,
+                model.SelectedCalculationType!.Value,
                 model.GetBillingPeriod(),
                 model.GetQuantityCalculationType(),
                 model.Price!.Value);

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AssociatedServiceListPriceController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AssociatedServiceListPriceController.cs
@@ -176,7 +176,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                 ProvisioningType = model.SelectedProvisioningType!.Value,
                 TimeUnit = model.GetBillingPeriod(),
                 PricingUnit = model.GetPricingUnit(),
-                CataloguePriceCalculationType = CataloguePriceCalculationType.SingleFixed,
+                CataloguePriceCalculationType = model.SelectedCalculationType!.Value,
                 CataloguePriceTiers = new HashSet<CataloguePriceTier>
                 {
                     new()

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AssociatedServiceListPriceController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AssociatedServiceListPriceController.cs
@@ -55,7 +55,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                     typeof(AssociatedServicesController).ControllerName(),
                     new { solutionId, associatedServiceId }),
                 AddListPriceUrl = Url.Action(
-                    nameof(ListPriceType),
+                    nameof(AddFlatListPrice),
                     new { solutionId, associatedServiceId }),
             };
 
@@ -125,7 +125,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                 }
                 : new(solution, associatedService);
 
-            model.BackLink = Url.Action(nameof(ListPriceType), new { solutionId, associatedServiceId, selectedPriceType = CataloguePriceType.Tiered });
+            model.BackLink = Url.Action(nameof(Index), new { solutionId, associatedServiceId });
 
             return View("ListPrices/AddTieredListPrice", model);
         }
@@ -155,7 +155,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
 
             var model = new AddEditFlatListPriceModel(associatedService)
             {
-                BackLink = Url.Action(nameof(ListPriceType), new { solutionId, associatedServiceId, selectedPriceType = CataloguePriceType.Flat }),
+                BackLink = Url.Action(nameof(Index), new { solutionId, associatedServiceId }),
             };
 
             return View("ListPrices/AddEditFlatListPrice", model);

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AssociatedServiceListPriceController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AssociatedServiceListPriceController.cs
@@ -417,7 +417,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                 cataloguePriceId,
                 model.GetPricingUnit(),
                 model.SelectedProvisioningType!.Value,
-                CataloguePriceCalculationType.SingleFixed,
+                model.SelectedCalculationType!.Value,
                 model.GetBillingPeriod(),
                 model.GetQuantityCalculationType(),
                 model.Price!.Value);

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/CatalogueSolutionListPriceController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/CatalogueSolutionListPriceController.cs
@@ -40,13 +40,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                     nameof(CatalogueSolutionsController.ManageCatalogueSolution),
                     typeof(CatalogueSolutionsController).ControllerName(),
                     new { solutionId }),
-                /* TODO - Reintroduce when Tiered Pricing is Introduced.
-                  AddListPriceUrl = Url.Action(
-                    nameof(ListPriceType),
-                    new { solutionId }),
-                 */
-
-                // TODO - Delete when Tiered Pricing is Introducted.
                 AddListPriceUrl = Url.Action(
                     nameof(AddFlatListPrice),
                     new { solutionId }),
@@ -95,20 +88,14 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                 return NotFound();
 
             AddTieredListPriceModel model = cataloguePriceId is not null
-                ? new AddTieredListPriceModel(solution, solution.CataloguePrices.Single(p => p.CataloguePriceId == cataloguePriceId))
+                ? new(solution, solution.CataloguePrices.Single(p => p.CataloguePriceId == cataloguePriceId))
                 {
                     DeleteListPriceUrl = Url.Action(
                         nameof(DeleteListPrice),
                         new { solutionId, cataloguePriceId }),
                 }
-                : new AddTieredListPriceModel(solution);
-            /* TODO - Reintroduce when Tiered Pricing is Introduced.
-            model.BackLink = Url.Action(
-                nameof(ListPriceType),
-                new { solutionId, selectedPriceType = CataloguePriceType.Tiered });
-            */
+                : new(solution);
 
-            // TODO - Delete when Tiered Pricing is Introduced
             model.BackLink = Url.Action(
                 nameof(Index),
                 new { solutionId });
@@ -136,11 +123,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
 
             var model = new AddEditFlatListPriceModel(solution)
             {
-                /* TODO - Reintroduce when Tiered Pricing is Introduced.
-                BackLink = Url.Action(nameof(ListPriceType), new { solutionId }),
-                */
-
-                // TODO - Delete when Tiered Pricing is Introduced.
                 BackLink = Url.Action(nameof(Index), new { solutionId }),
             };
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/CatalogueSolutionListPriceController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/CatalogueSolutionListPriceController.cs
@@ -40,8 +40,15 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                     nameof(CatalogueSolutionsController.ManageCatalogueSolution),
                     typeof(CatalogueSolutionsController).ControllerName(),
                     new { solutionId }),
-                AddListPriceUrl = Url.Action(
+                /* TODO - Reintroduce when Tiered Pricing is Introduced.
+                  AddListPriceUrl = Url.Action(
                     nameof(ListPriceType),
+                    new { solutionId }),
+                 */
+
+                // TODO - Delete when Tiered Pricing is Introducted.
+                AddListPriceUrl = Url.Action(
+                    nameof(AddFlatListPrice),
                     new { solutionId }),
             };
 
@@ -95,8 +102,16 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                         new { solutionId, cataloguePriceId }),
                 }
                 : new AddTieredListPriceModel(solution);
+            /* TODO - Reintroduce when Tiered Pricing is Introduced.
+            model.BackLink = Url.Action(
+                nameof(ListPriceType),
+                new { solutionId, selectedPriceType = CataloguePriceType.Tiered });
+            */
 
-            model.BackLink = Url.Action(nameof(ListPriceType), new { solutionId, selectedPriceType = CataloguePriceType.Tiered });
+            // TODO - Delete when Tiered Pricing is Introduced
+            model.BackLink = Url.Action(
+                nameof(Index),
+                new { solutionId });
 
             return View("ListPrices/AddTieredListPrice", model);
         }
@@ -121,7 +136,12 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
 
             var model = new AddEditFlatListPriceModel(solution)
             {
+                /* TODO - Reintroduce when Tiered Pricing is Introduced.
                 BackLink = Url.Action(nameof(ListPriceType), new { solutionId }),
+                */
+
+                // TODO - Delete when Tiered Pricing is Introduced.
+                BackLink = Url.Action(nameof(Index), new { solutionId }),
             };
 
             return View("ListPrices/AddEditFlatListPrice", model);
@@ -139,7 +159,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                 ProvisioningType = model.SelectedProvisioningType!.Value,
                 TimeUnit = model.GetBillingPeriod(),
                 PricingUnit = model.GetPricingUnit(),
-                CataloguePriceCalculationType = CataloguePriceCalculationType.SingleFixed,
+                CataloguePriceCalculationType = model.SelectedCalculationType!.Value,
                 CataloguePriceTiers = new HashSet<CataloguePriceTier>
                 {
                     new()
@@ -334,7 +354,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                 cataloguePriceId,
                 model.GetPricingUnit(),
                 model.SelectedProvisioningType!.Value,
-                CataloguePriceCalculationType.SingleFixed,
+                model.SelectedCalculationType!.Value,
                 model.GetBillingPeriod(),
                 model.GetQuantityCalculationType(),
                 model.Price!.Value);

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ListPriceModels/AddEditFlatListPriceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ListPriceModels/AddEditFlatListPriceModel.cs
@@ -35,6 +35,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ListPriceModels
 
             SelectedPublicationStatus = CataloguePricePublicationStatus = cataloguePrice.PublishedStatus;
             SelectedProvisioningType = cataloguePrice.ProvisioningType;
+            SelectedCalculationType = cataloguePrice.CataloguePriceCalculationType;
 
             AssignBillingPeriod(cataloguePrice);
             AssignQuantityCalculationType(cataloguePrice);
@@ -88,6 +89,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ListPriceModels
 
         public CataloguePriceQuantityCalculationType? OnDemandQuantityCalculationType { get; set; }
 
+        public CataloguePriceCalculationType? SelectedCalculationType { get; set; }
+
         public decimal? Price { get; set; }
 
         [StringLength(100)]
@@ -104,6 +107,19 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ListPriceModels
             .GetAvailablePublicationStatuses()
             .Select(p => new SelectableRadioOption<PublicationStatus>(p.Description(), p))
             .ToList();
+
+        public IEnumerable<SelectableRadioOption<CataloguePriceCalculationType>> AvailableCalculationTypes =>
+            new List<SelectableRadioOption<CataloguePriceCalculationType>>
+        {
+            new(
+                CataloguePriceCalculationType.SingleFixed.Name(),
+                CataloguePriceCalculationType.SingleFixed.Description(),
+                CataloguePriceCalculationType.SingleFixed),
+            new(
+                CataloguePriceCalculationType.Volume.Name(),
+                CataloguePriceCalculationType.Volume.Description(),
+                CataloguePriceCalculationType.Volume),
+        };
 
         public virtual PricingUnit GetPricingUnit()
             => new()
@@ -139,9 +155,11 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ListPriceModels
                 case ProvisioningType.OnDemand:
                     OnDemandBillingPeriod = cataloguePrice.TimeUnit;
                     break;
+
                 case ProvisioningType.Declarative:
                     DeclarativeBillingPeriod = cataloguePrice.TimeUnit;
                     break;
+
                 case ProvisioningType.PerServiceRecipient:
                     PerServiceRecipientBillingPeriod = cataloguePrice.TimeUnit;
                     break;
@@ -155,6 +173,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ListPriceModels
                 case ProvisioningType.OnDemand:
                     OnDemandQuantityCalculationType = cataloguePrice.CataloguePriceQuantityCalculationType;
                     break;
+
                 case ProvisioningType.Declarative:
                     DeclarativeQuantityCalculationType = cataloguePrice.CataloguePriceQuantityCalculationType;
                     break;

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ListPriceModels/AddEditFlatListPriceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ListPriceModels/AddEditFlatListPriceModel.cs
@@ -108,7 +108,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ListPriceModels
             .Select(p => new SelectableRadioOption<PublicationStatus>(p.Description(), p))
             .ToList();
 
-        public IEnumerable<SelectableRadioOption<CataloguePriceCalculationType>> AvailableCalculationTypes =>
+        public virtual IEnumerable<SelectableRadioOption<CataloguePriceCalculationType>> AvailableCalculationTypes =>
             new List<SelectableRadioOption<CataloguePriceCalculationType>>
         {
             new(

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ListPriceModels/AddTieredListPriceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ListPriceModels/AddTieredListPriceModel.cs
@@ -63,7 +63,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ListPriceModels
             AssignQuantityCalculationType(cataloguePrice);
         }
 
-        public IEnumerable<SelectableRadioOption<CataloguePriceCalculationType>> AvailableCalculationTypes =>
+        public override IEnumerable<SelectableRadioOption<CataloguePriceCalculationType>> AvailableCalculationTypes =>
             new List<SelectableRadioOption<CataloguePriceCalculationType>>
             {
                 new(
@@ -81,8 +81,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ListPriceModels
             };
 
         public CatalogueItemId? ServiceId { get; set; }
-
-        public CataloguePriceCalculationType? SelectedCalculationType { get; set; }
 
         [StringLength(100)]
         public string RangeDefinition { get; set; }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ListPriceModels/ListPriceTypeModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ListPriceModels/ListPriceTypeModel.cs
@@ -23,11 +23,11 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ListPriceModels
         {
             new(
                 "Flat price",
-                "This is where the price remains the same no matter what quantity is ordered.",
+                "A flat price means a buyer is presented with a single pricing unit.",
                 CataloguePriceType.Flat),
             new(
                 "Tiered price",
-                "This is where the price per item changes based on the quantity ordered. Prices are different for each tier.",
+                "A tiered price means a buyer is presented with multiple pricing units.",
                 CataloguePriceType.Tiered),
         };
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Validators/ListPrices/AddEditFlatListPriceModelValidator.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Validators/ListPrices/AddEditFlatListPriceModelValidator.cs
@@ -31,6 +31,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Validators.ListPrices
                 .NotNull()
                 .WithMessage(SelectedPublicationStatusError);
 
+            RuleFor(m => m.SelectedCalculationType)
+                .NotNull()
+                .WithMessage(SharedListPriceValidationErrors.SelectedCalculationTypeError);
+
             RuleFor(m => m)
                 .Must(NotBeADuplicate)
                 .WithMessage(SharedListPriceValidationErrors.DuplicateListPriceError)
@@ -38,7 +42,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Validators.ListPrices
                 .OverridePropertyName(
                     m => m.SelectedProvisioningType,
                     m => m.Price,
-                    m => m.UnitDescription);
+                    m => m.UnitDescription,
+                    m => m.SelectedCalculationType);
 
             RuleFor(m => m.DeclarativeQuantityCalculationType)
                 .NotNull()
@@ -56,6 +61,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Validators.ListPrices
                 model.CatalogueItemId,
                 model.CataloguePriceId,
                 model.SelectedProvisioningType!.Value,
+                model.SelectedCalculationType!.Value,
                 model.Price!.Value,
                 model.UnitDescription).GetAwaiter().GetResult();
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/ListPrices/AddEditFlatListPrice.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/ListPrices/AddEditFlatListPrice.cshtml
@@ -11,7 +11,11 @@
 <partial name="Partials/_BackLink" model="Model" />
 <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-        <nhs-validation-summary RadioId="@nameof(Model.SelectedProvisioningType),@nameof(Model.SelectedPublicationStatus),@nameof(Model.OnDemandQuantityCalculationType),@nameof(Model.DeclarativeQuantityCalculationType)" />
+        <nhs-validation-summary RadioId="@nameof(Model.SelectedProvisioningType),
+									     @nameof(Model.SelectedPublicationStatus),
+										 @nameof(Model.OnDemandQuantityCalculationType),
+										 @nameof(Model.DeclarativeQuantityCalculationType),
+										 @nameof(Model.SelectedCalculationType)" />
         <nhs-page-title
             title="@ViewBag.Title"
             caption="@Model.CatalogueItemName"
@@ -90,6 +94,14 @@
                                     use-default-value="false"/>
                     </nhs-radio-button>
                 </nhs-radio-button-container>
+            </nhs-fieldset-form-label>
+
+			<nhs-fieldset-form-label asp-for="SelectedCalculationType" label-text="Calculation type" size="Medium">
+						<nhs-radio-buttons asp-for="SelectedCalculationType"
+											values="@Model.AvailableCalculationTypes.Cast<object>()"
+											display-name="Name"
+											value-name="Value"
+											hint-name="Advice"/>
             </nhs-fieldset-form-label>
 
             <nhs-bookended-input

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Flat/AddFlatListPriceBase.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Flat/AddFlatListPriceBase.cs
@@ -16,6 +16,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base.Flat
 {
     public abstract class AddFlatListPriceBase : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
     {
+        private const string ActionName = "AddFlatListPrice";
+
         protected AddFlatListPriceBase(
             LocalWebApplicationFactory factory,
             Type controller,
@@ -23,7 +25,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base.Flat
             : base(
                 factory,
                 controller,
-                "AddFlatListPrice",
+                ActionName,
                 parameters)
         {
         }
@@ -77,13 +79,17 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base.Flat
 
             CommonActions.PageLoadedCorrectGetIndex(
                 Controller,
-                "ListPriceType").Should().BeTrue();
+                "Index").Should().BeTrue();
         }
 
         [Fact]
         public void Submit_NoInput_ThrowsError()
         {
             CommonActions.ClickSave();
+
+            CommonActions.PageLoadedCorrectGetIndex(
+                Controller,
+                ActionName).Should().BeTrue();
 
             CommonActions.ErrorSummaryDisplayed().Should().BeTrue();
             CommonActions.ErrorSummaryLinksExist().Should().BeTrue();
@@ -102,11 +108,16 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base.Flat
 
             CommonActions.ClickRadioButtonWithValue(price.ProvisioningType.ToString());
             CommonActions.ClickRadioButtonWithValue(price.PublishedStatus.ToString());
+            CommonActions.ClickRadioButtonWithValue(price.CataloguePriceCalculationType.ToString());
 
             CommonActions.ElementAddValue(ListPriceObjects.UnitDescriptionInput, price.PricingUnit.Description);
             CommonActions.ElementAddValue(ListPriceObjects.PriceInput, price.CataloguePriceTiers.First().Price.ToString());
 
             CommonActions.ClickSave();
+
+            CommonActions.PageLoadedCorrectGetIndex(
+                Controller,
+                ActionName).Should().BeTrue();
 
             CommonActions.ErrorSummaryDisplayed().Should().BeTrue();
             CommonActions.ErrorSummaryLinksExist().Should().BeTrue();
@@ -114,6 +125,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base.Flat
             CommonActions.ElementShowingCorrectErrorMessage(ListPriceObjects.ProvisioningTypeInputError, "Error: A list price with these details already exists").Should().BeTrue();
             CommonActions.ElementShowingCorrectErrorMessage(ListPriceObjects.UnitDescriptionInputError, "A list price with these details already exists").Should().BeTrue();
             CommonActions.ElementShowingCorrectErrorMessage(ListPriceObjects.PriceInputError, "A list price with these details already exists").Should().BeTrue();
+            CommonActions.ElementShowingCorrectErrorMessage(ListPriceObjects.CalculationTypeInputError, "Error: A list price with these details already exists").Should().BeTrue();
         }
 
         [Fact]
@@ -121,6 +133,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base.Flat
         {
             CommonActions.ClickRadioButtonWithValue(ProvisioningType.Patient.ToString());
             CommonActions.ClickRadioButtonWithValue(PublicationStatus.Published.ToString());
+            CommonActions.ClickRadioButtonWithValue(CataloguePriceCalculationType.SingleFixed.ToString());
 
             TextGenerators.TextInputAddText(ListPriceObjects.UnitDescriptionInput, 100);
             CommonActions.ElementAddValue(ListPriceObjects.PriceInput, "3.14");

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Flat/EditFlatListPriceBase.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Flat/EditFlatListPriceBase.cs
@@ -16,7 +16,10 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base.Flat
 {
     public abstract class EditFlatListPriceBase : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
     {
+        private const string ActionName = "EditFlatListPrice";
+
         private readonly IDictionary<string, string> parameters;
+
         protected EditFlatListPriceBase(
             LocalWebApplicationFactory factory,
             Type controller,
@@ -24,7 +27,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base.Flat
             : base(
                 factory,
                 controller,
-                "EditFlatListPrice",
+                ActionName,
                 parameters)
         {
             this.parameters = parameters;
@@ -132,11 +135,16 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base.Flat
 
             CommonActions.ClickRadioButtonWithValue(price.ProvisioningType.ToString());
             CommonActions.ClickRadioButtonWithValue(price.PublishedStatus.ToString());
+            CommonActions.ClickRadioButtonWithValue(price.CataloguePriceCalculationType.ToString());
 
             CommonActions.ElementAddValue(ListPriceObjects.UnitDescriptionInput, price.PricingUnit.Description);
             CommonActions.ElementAddValue(ListPriceObjects.PriceInput, price.CataloguePriceTiers.First().Price.ToString());
 
             CommonActions.ClickSave();
+
+            CommonActions.PageLoadedCorrectGetIndex(
+                Controller,
+                ActionName).Should().BeTrue();
 
             CommonActions.ErrorSummaryDisplayed().Should().BeTrue();
             CommonActions.ErrorSummaryLinksExist().Should().BeTrue();
@@ -144,6 +152,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base.Flat
             CommonActions.ElementShowingCorrectErrorMessage(ListPriceObjects.ProvisioningTypeInputError, "Error: A list price with these details already exists").Should().BeTrue();
             CommonActions.ElementShowingCorrectErrorMessage(ListPriceObjects.UnitDescriptionInputError, "A list price with these details already exists").Should().BeTrue();
             CommonActions.ElementShowingCorrectErrorMessage(ListPriceObjects.PriceInputError, "A list price with these details already exists").Should().BeTrue();
+            CommonActions.ElementShowingCorrectErrorMessage(ListPriceObjects.CalculationTypeInputError, "Error: A list price with these details already exists").Should().BeTrue();
         }
 
         [Fact]
@@ -197,7 +206,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base.Flat
 
             NavigateToUrl(
                 Controller,
-                "EditFlatListPrice",
+                ActionName,
                 updatedParameters);
 
             CommonActions.ElementIsDisplayed(ListPriceObjects.DeletePriceLink).Should().BeTrue();

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/ManageListPricesBase.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/ManageListPricesBase.cs
@@ -87,7 +87,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base
 
             CommonActions.PageLoadedCorrectGetIndex(
                 Controller,
-                "ListPriceType").Should().BeTrue();
+                "AddFlatListPrice").Should().BeTrue();
         }
 
         [Fact]

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Tiered/AddTieredListPriceBase.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Tiered/AddTieredListPriceBase.cs
@@ -76,7 +76,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base.Tiered
 
             CommonActions.PageLoadedCorrectGetIndex(
                 Controller,
-                "ListPriceType").Should().BeTrue();
+                "Index").Should().BeTrue();
         }
 
         [Fact]

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/ListPrice/ListPriceServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/ListPrice/ListPriceServiceTests.cs
@@ -233,6 +233,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.ListPrice
         {
             price.CataloguePriceTiers = new HashSet<CataloguePriceTier> { tier };
             price.CataloguePriceType = CataloguePriceType.Flat;
+            price.CataloguePriceCalculationType = CataloguePriceCalculationType.SingleFixed;
 
             solution.CatalogueItem.CataloguePrices.Add(price);
 
@@ -243,6 +244,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.ListPrice
                 solution.CatalogueItemId,
                 null,
                 price.ProvisioningType,
+                price.CataloguePriceCalculationType,
                 tier.Price,
                 price.PricingUnit.Description);
 
@@ -260,6 +262,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.ListPrice
         {
             price.CataloguePriceTiers = new HashSet<CataloguePriceTier> { tier };
             price.CataloguePriceType = CataloguePriceType.Flat;
+            price.CataloguePriceCalculationType = CataloguePriceCalculationType.SingleFixed;
 
             solution.CatalogueItem.CataloguePrices.Add(price);
 
@@ -270,6 +273,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.ListPrice
                 solution.CatalogueItemId,
                 price.CataloguePriceId,
                 price.ProvisioningType,
+                price.CataloguePriceCalculationType,
                 tier.Price,
                 price.PricingUnit.Description);
 
@@ -289,6 +293,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.ListPrice
         {
             price.CataloguePriceTiers = new HashSet<CataloguePriceTier> { tier };
             price.CataloguePriceType = CataloguePriceType.Flat;
+            price.CataloguePriceCalculationType = CataloguePriceCalculationType.SingleFixed;
 
             solution.CatalogueItem.CataloguePrices.Add(price);
 
@@ -299,6 +304,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.ListPrice
                 solution.CatalogueItemId,
                 null,
                 newPrice.ProvisioningType,
+                price.CataloguePriceCalculationType,
                 newTier.Price,
                 newPrice.PricingUnit.Description);
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/AdditionalServiceListPriceControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/AdditionalServiceListPriceControllerTests.cs
@@ -1543,7 +1543,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
                         && match.Definition == pricingUnit.Definition
                         && match.RangeDescription == pricingUnit.RangeDescription),
                     model.SelectedProvisioningType!.Value,
-                    CataloguePriceCalculationType.SingleFixed,
+                    model.SelectedCalculationType!.Value,
                     model.GetBillingPeriod(),
                     model.GetQuantityCalculationType(),
                     model.Price!.Value),
@@ -1591,7 +1591,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
                         && match.Definition == pricingUnit.Definition
                         && match.RangeDescription == pricingUnit.RangeDescription),
                     model.SelectedProvisioningType!.Value,
-                    CataloguePriceCalculationType.SingleFixed,
+                    model.SelectedCalculationType!.Value,
                     model.GetBillingPeriod(),
                     model.GetQuantityCalculationType(),
                     model.Price!.Value),

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/AssociatedServiceListPriceControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/AssociatedServiceListPriceControllerTests.cs
@@ -1543,7 +1543,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
                         && match.Definition == pricingUnit.Definition
                         && match.RangeDescription == pricingUnit.RangeDescription),
                     model.SelectedProvisioningType!.Value,
-                    CataloguePriceCalculationType.SingleFixed,
+                    model.SelectedCalculationType!.Value,
                     model.GetBillingPeriod(),
                     model.GetQuantityCalculationType(),
                     model.Price!.Value),
@@ -1591,7 +1591,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
                         && match.Definition == pricingUnit.Definition
                         && match.RangeDescription == pricingUnit.RangeDescription),
                     model.SelectedProvisioningType!.Value,
-                    CataloguePriceCalculationType.SingleFixed,
+                    model.SelectedCalculationType!.Value,
                     model.GetBillingPeriod(),
                     model.GetQuantityCalculationType(),
                     model.Price!.Value),

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/CatalogueSolutionListPriceControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/CatalogueSolutionListPriceControllerTests.cs
@@ -1342,7 +1342,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
                         && match.Definition == pricingUnit.Definition
                         && match.RangeDescription == pricingUnit.RangeDescription),
                     model.SelectedProvisioningType!.Value,
-                    CataloguePriceCalculationType.SingleFixed,
+                    model.SelectedCalculationType!.Value,
                     model.GetBillingPeriod(),
                     model.GetQuantityCalculationType(),
                     model.Price!.Value),
@@ -1387,7 +1387,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
                         && match.Definition == pricingUnit.Definition
                         && match.RangeDescription == pricingUnit.RangeDescription),
                     model.SelectedProvisioningType!.Value,
-                    CataloguePriceCalculationType.SingleFixed,
+                    model.SelectedCalculationType!.Value,
                     model.GetBillingPeriod(),
                     model.GetQuantityCalculationType(),
                     model.Price!.Value),

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Validators/ListPrices/AddEditFlatListPriceModelValidatorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Validators/ListPrices/AddEditFlatListPriceModelValidatorTests.cs
@@ -22,6 +22,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Validators.List
             model.Price = null;
             model.UnitDescription = null;
             model.SelectedPublicationStatus = null;
+            model.SelectedCalculationType = null;
 
             var result = validator.TestValidate(model);
 
@@ -36,6 +37,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Validators.List
 
             result.ShouldHaveValidationErrorFor(m => m.SelectedPublicationStatus)
                 .WithErrorMessage(AddEditFlatListPriceModelValidator.SelectedPublicationStatusError);
+
+            result.ShouldHaveValidationErrorFor(m => m.SelectedCalculationType)
+                .WithErrorMessage(SharedListPriceValidationErrors.SelectedCalculationTypeError);
         }
 
         [Theory]
@@ -79,12 +83,13 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Validators.List
                 model.CatalogueItemId,
                 model.CataloguePriceId,
                 model.SelectedProvisioningType!.Value,
+                model.SelectedCalculationType!.Value,
                 model.Price!.Value,
                 model.UnitDescription)).ReturnsAsync(true);
 
             var result = validator.TestValidate(model);
 
-            result.ShouldHaveValidationErrorFor("SelectedProvisioningType|Price|UnitDescription")
+            result.ShouldHaveValidationErrorFor($"{nameof(model.SelectedProvisioningType)}|{nameof(model.Price)}|{nameof(model.UnitDescription)}|{nameof(model.SelectedCalculationType)}")
                 .WithErrorMessage(SharedListPriceValidationErrors.DuplicateListPriceError);
         }
 
@@ -101,6 +106,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Validators.List
                 model.CatalogueItemId,
                 model.CataloguePriceId,
                 model.SelectedProvisioningType!.Value,
+                model.SelectedCalculationType!.Value,
                 model.Price!.Value,
                 model.UnitDescription)).ReturnsAsync(false);
 


### PR DESCRIPTION
Add Calculation types to flat price add/edit page

Change "Add a Price" link for Catalogue solutions and additional services to go straigh to add a flat price page.

Fix bug in the validation component that wouldn't match due to eronious whitespace characters when doing multiline RadioId tag.