### PR TITLE
Fix Funding Source Exception, Item ID and Service Instance Id Generation

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Configuration/ServiceInstanceItemEntityTypeConfiguration.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Configuration/ServiceInstanceItemEntityTypeConfiguration.cs
@@ -14,6 +14,8 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Configuration
             builder.Property(e => e.CatalogueItemId)
                 .HasMaxLength(14)
                 .HasConversion(id => id.ToString(), id => CatalogueItemId.ParseExact(id));
+
+            builder.Ignore(e => e.ServiceInstanceId);
         }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/ServiceInstanceItem.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/ServiceInstanceItem.cs
@@ -11,6 +11,12 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
 
         public string OdsCode { get; set; }
 
-        public string ServiceInstanceId { get; set; }
+        public string ServiceInstanceId
+        {
+            get
+            {
+                return $"SI1-{OdsCode}";
+            }
+        }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/FundingSource/FundingSourceController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/FundingSource/FundingSourceController.cs
@@ -42,9 +42,11 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers.FundingSource
         [HttpGet("{catalogueItemId}/funding-source")]
         public async Task<IActionResult> FundingSource(string internalOrgId, CallOffId callOffId, CatalogueItemId catalogueItemId)
         {
+            var order = await orderService.GetOrderThin(callOffId, internalOrgId);
+
             var item = await orderItemService.GetOrderItem(callOffId, internalOrgId, catalogueItemId);
 
-            var model = new Models.FundingSources.FundingSource(internalOrgId, callOffId, item)
+            var model = new Models.FundingSources.FundingSource(internalOrgId, callOffId, order, item)
             {
                 BackLink = Url.Action(
                     nameof(FundingSources),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/FundingSources/FundingSource.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/FundingSources/FundingSource.cs
@@ -9,7 +9,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.FundingSources
         {
         }
 
-        public FundingSource(string internalOrgId, CallOffId callOffId, OrderItem orderItem)
+        public FundingSource(string internalOrgId, CallOffId callOffId, EntityFramework.Ordering.Models.Order order, OrderItem orderItem)
         {
             Title = $"{orderItem.CatalogueItem.Name} funding source";
             Caption = $"Order {callOffId}";
@@ -17,7 +17,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.FundingSources
             CallOffId = callOffId;
             CatalogueItemName = orderItem.CatalogueItem.Name;
             SelectedFundingType = orderItem.FundingType;
-            TotalCost = orderItem.OrderItemPrice.CalculateTotalCost(orderItem.TotalQuantity);
+            TotalCost = orderItem.OrderItemPrice.CalculateTotalCostForContractLength(orderItem.TotalQuantity, order.MaximumTerm!.Value);
         }
 
         public string CatalogueItemName { get; set; }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/FundingSources/FundingSources.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/FundingSources/FundingSources.cs
@@ -12,14 +12,17 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.FundingSources
 
         public FundingSources(string internalOrgId, CallOffId callOffId, EntityFramework.Ordering.Models.Order order)
         {
-            Title = "Select funding sources";
+            Title = "Funding sources";
             InternalOrgId = internalOrgId;
             CallOffId = callOffId;
             Caption = $"Order {CallOffId}";
+            MaximumTerm = order.MaximumTerm!.Value;
 
-            OrderItemsNoFundingRequired = order.OrderItems.Where(oi => oi.FundingType == OrderItemFundingType.NoFundingRequired).ToList();
-            OrderItemsLocalOnly = order.OrderItems.Where(oi => oi.FundingType == OrderItemFundingType.LocalFundingOnly).ToList();
-            OrderItemsSelectable = order.OrderItems.Where(oi => !oi.IsForcedFunding).ToList();
+            var completedOrderItems = order.OrderItems.Where(oi => oi.OrderItemRecipients.Any() && oi.OrderItemPrice is not null && oi.AllQuantitiesEntered).ToList();
+
+            OrderItemsNoFundingRequired = completedOrderItems.Where(oi => oi.FundingType == OrderItemFundingType.NoFundingRequired).ToList();
+            OrderItemsLocalOnly = completedOrderItems.Where(oi => oi.FundingType == OrderItemFundingType.LocalFundingOnly).ToList();
+            OrderItemsSelectable = completedOrderItems.Where(oi => !oi.IsForcedFunding).ToList();
         }
 
         public CallOffId CallOffId { get; set; }
@@ -31,5 +34,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.FundingSources
         public List<OrderItem> OrderItemsLocalOnly { get; set; }
 
         public List<OrderItem> OrderItemsNoFundingRequired { get; set; }
+
+        public int MaximumTerm { get; set; }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/FundingSources/FundingSources.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/FundingSources/FundingSources.cs
@@ -18,7 +18,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.FundingSources
             Caption = $"Order {CallOffId}";
             MaximumTerm = order.MaximumTerm!.Value;
 
-            var completedOrderItems = order.OrderItems.Where(oi => oi.OrderItemRecipients.Any() && oi.OrderItemPrice is not null && oi.AllQuantitiesEntered).ToList();
+            var completedOrderItems = order.OrderItems.Where(oi => oi.AllQuantitiesEntered).ToList();
 
             OrderItemsNoFundingRequired = completedOrderItems.Where(oi => oi.FundingType == OrderItemFundingType.NoFundingRequired).ToList();
             OrderItemsLocalOnly = completedOrderItems.Where(oi => oi.FundingType == OrderItemFundingType.LocalFundingOnly).ToList();

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/FundingSource/FundingSources.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/FundingSource/FundingSources.cshtml
@@ -127,6 +127,6 @@
 	TagColour FormatFundingTypeColour(OrderItemFundingType fundingType) => 
 	fundingType == OrderItemFundingType.None ? TagColour.Grey : TagColour.Green;
 
-	decimal CalculateTotalCost(OrderItem item) => item.OrderItemPrice.CalculateTotalCost(item.TotalQuantity);
+	decimal CalculateTotalCost(OrderItem item) => item.OrderItemPrice.CalculateTotalCostForContractLength(item.TotalQuantity, Model.MaximumTerm);
 }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/Order/Summary.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/Order/Summary.cshtml
@@ -3,8 +3,6 @@
 @model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.Order.SummaryModel;
 @{
 	ViewBag.Title = Model.Title;
-
-	ViewContext.HttpContext.Items["RowCount"] = 0;
 }
 
 <style>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/Order/Summary.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/Order/Summary.cshtml
@@ -2,7 +2,9 @@
 @using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
 @model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.Order.SummaryModel;
 @{
-    ViewBag.Title = Model.Title;
+	ViewBag.Title = Model.Title;
+
+	ViewContext.HttpContext.Items["RowCount"] = 0;
 }
 
 <style>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/Order/_OrderItemSummary.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/Order/_OrderItemSummary.cshtml
@@ -25,13 +25,13 @@
             <nhs-table-column>Service instance ID</nhs-table-column>
             <nhs-table-column>Quantity</nhs-table-column>
 
-            @for (var i = 0; i < Model.OrderItemRecipients.Count; i++)
+            @for (var i = 0; i < Model.OrderItemRecipients.Count; i++, ViewContext.HttpContext.Items["RowCount"] = (int)ViewContext.HttpContext.Items["RowCount"] + 1)
             {
                 var serviceRecipient = Model.OrderItemRecipients.ElementAt(i);
                 <nhs-table-row-container>
                     <nhs-table-cell>@serviceRecipient.Recipient.Name</nhs-table-cell>
                     <nhs-table-cell>@serviceRecipient.Recipient.OdsCode</nhs-table-cell>
-                    <nhs-table-cell>@($"{Model.Order.CallOffId}-{serviceRecipient.Recipient.OdsCode}-{i + 1}")</nhs-table-cell>
+                    <nhs-table-cell>@($"{Model.Order.CallOffId}-{serviceRecipient.Recipient.OdsCode}-{ViewContext.HttpContext.Items["RowCount"]}")</nhs-table-cell>
                     <nhs-table-cell>@Model.Order.ServiceInstanceItems.First(p => p.OdsCode == serviceRecipient.Recipient.OdsCode).ServiceInstanceId</nhs-table-cell>
                     <nhs-table-cell>
                         @if (hasServiceRecipientQuantities)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/Order/_OrderItemSummary.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/Order/_OrderItemSummary.cshtml
@@ -1,6 +1,7 @@
 ﻿@using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models
 @using NHSD.GPIT.BuyingCatalogue.EntityFramework.Extensions
 @using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
+@using NHSD.GPIT.BuyingCatalogue.WebApp.Extensions;
 @model OrderItem
 
 @{
@@ -25,13 +26,12 @@
             <nhs-table-column>Service instance ID</nhs-table-column>
             <nhs-table-column>Quantity</nhs-table-column>
 
-            @for (var i = 0; i < Model.OrderItemRecipients.Count; i++, ViewContext.HttpContext.Items["RowCount"] = (int)ViewContext.HttpContext.Items["RowCount"] + 1)
+			@foreach(var serviceRecipient in Model.OrderItemRecipients)
             {
-                var serviceRecipient = Model.OrderItemRecipients.ElementAt(i);
                 <nhs-table-row-container>
                     <nhs-table-cell>@serviceRecipient.Recipient.Name</nhs-table-cell>
                     <nhs-table-cell>@serviceRecipient.Recipient.OdsCode</nhs-table-cell>
-                    <nhs-table-cell>@($"{Model.Order.CallOffId}-{serviceRecipient.Recipient.OdsCode}-{ViewContext.HttpContext.Items["RowCount"]}")</nhs-table-cell>
+                    <nhs-table-cell>@($"{Model.Order.CallOffId}-{serviceRecipient.Recipient.OdsCode}-{ViewContext.HttpContext.NextLineId()}")</nhs-table-cell>
                     <nhs-table-cell>@Model.Order.ServiceInstanceItems.First(p => p.OdsCode == serviceRecipient.Recipient.OdsCode).ServiceInstanceId</nhs-table-cell>
                     <nhs-table-cell>
                         @if (hasServiceRecipientQuantities)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Extensions/HttpContextExtensions.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Extensions/HttpContextExtensions.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.Extensions
+{
+    public static class HttpContextExtensions
+    {
+        public const string LineIdKey = "view-context-line-id";
+
+        public static int NextLineId(this HttpContext context)
+        {
+            var output = (int)(context.Items[LineIdKey] ?? 0);
+
+            context.Items[LineIdKey] = output + 1;
+
+            return output;
+        }
+    }
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
@@ -3,7 +3,8 @@
 @using NHSD.GPIT.BuyingCatalogue.Framework.Calculations
 @model NHSD.GPIT.BuyingCatalogue.WebApp.Models.OrderSummaryModel;
 @{
-    Layout = "";
+	Layout = "";
+	ViewContext.HttpContext.Items["RowCount"] = 0;
 }
 
 <!DOCTYPE html>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
@@ -4,7 +4,6 @@
 @model NHSD.GPIT.BuyingCatalogue.WebApp.Models.OrderSummaryModel;
 @{
 	Layout = "";
-	ViewContext.HttpContext.Items["RowCount"] = 0;
 }
 
 <!DOCTYPE html>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/OrderItem.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/OrderItem.cshtml
@@ -1,6 +1,7 @@
-﻿@using NHSD.GPIT.BuyingCatalogue.Framework.Calculations
-@using NHSD.GPIT.BuyingCatalogue.EntityFramework.Extensions
-@using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
+﻿@using NHSD.GPIT.BuyingCatalogue.Framework.Calculations;
+@using NHSD.GPIT.BuyingCatalogue.EntityFramework.Extensions;
+@using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+@using NHSD.GPIT.BuyingCatalogue.WebApp.Extensions;
 @model NHSD.GPIT.BuyingCatalogue.WebApp.Models.OrderSummaryItemModel
 
 <h3>@Model.OrderItem.CatalogueItem.Name</h3>
@@ -51,30 +52,29 @@
     }
     else
     {
-        @for (var i = 0; i < Model.OrderItem.OrderItemRecipients.Count; i++, ViewContext.HttpContext.Items["RowCount"] = (int)ViewContext.HttpContext.Items["RowCount"] + 1)
+        @foreach (var recipient in Model.OrderItem.OrderItemRecipients)
         {
-				var recipient = Model.OrderItem.OrderItemRecipients.ElementAt(i);
-				<tr>
-                <td>
-                    @recipient.Recipient.Name
-                </td>
-                <td>
-                    @recipient.Recipient.OdsCode
-                </td>
-                <td>
-                    @($"{Model.OrderItem.Order.CallOffId}-{recipient.Recipient.OdsCode}-{ViewContext.HttpContext.Items["RowCount"]}")
-                </td>
-                <td>
-                    @Model.ServiceInstanceId(recipient.OdsCode)
-                </td>
+			<tr>
+				<td>
+					@recipient.Recipient.Name
+				</td>
+				<td>
+					@recipient.Recipient.OdsCode
+				</td>
+				<td>
+					@($"{Model.OrderItem.Order.CallOffId}-{recipient.Recipient.OdsCode}-{ViewContext.HttpContext.NextLineId()}")
+				</td>
+				<td>
+					@Model.ServiceInstanceId(recipient.OdsCode)
+				</td>
 
-                @if (hasServiceRecipientQuantities)
-                {
-                    <td class="numeric">
-                        @(recipient.Quantity.HasValue ? $"{recipient.Quantity:N0}" : "-")
-                    </td>
-                }
-            </tr>
+				@if (hasServiceRecipientQuantities)
+				{
+					<td class="numeric">
+						@(recipient.Quantity.HasValue ? $"{recipient.Quantity:N0}" : "-")
+					</td>
+				}
+			</tr>
         }
 
         @if (hasServiceRecipientQuantities

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/OrderItem.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/OrderItem.cshtml
@@ -51,9 +51,10 @@
     }
     else
     {
-        @foreach (var (recipient, index) in Model.OrderItem.OrderItemRecipients.Select((x, i) => (x, i)))
+        @for (var i = 0; i < Model.OrderItem.OrderItemRecipients.Count; i++, ViewContext.HttpContext.Items["RowCount"] = (int)ViewContext.HttpContext.Items["RowCount"] + 1)
         {
-            <tr>
+				var recipient = Model.OrderItem.OrderItemRecipients.ElementAt(i);
+				<tr>
                 <td>
                     @recipient.Recipient.Name
                 </td>
@@ -61,7 +62,7 @@
                     @recipient.Recipient.OdsCode
                 </td>
                 <td>
-                    @($"{Model.OrderItem.Order.CallOffId}-{recipient.Recipient.OdsCode}-{index + 1}")
+                    @($"{Model.OrderItem.Order.CallOffId}-{recipient.Recipient.OdsCode}-{ViewContext.HttpContext.Items["RowCount"]}")
                 </td>
                 <td>
                     @Model.ServiceInstanceId(recipient.OdsCode)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/OrderItem.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/OrderItem.cshtml
@@ -54,27 +54,27 @@
     {
         @foreach (var recipient in Model.OrderItem.OrderItemRecipients)
         {
-			<tr>
-				<td>
-					@recipient.Recipient.Name
-				</td>
-				<td>
-					@recipient.Recipient.OdsCode
-				</td>
-				<td>
-					@($"{Model.OrderItem.Order.CallOffId}-{recipient.Recipient.OdsCode}-{ViewContext.HttpContext.NextLineId()}")
-				</td>
-				<td>
-					@Model.ServiceInstanceId(recipient.OdsCode)
-				</td>
+            <tr>
+                <td>
+                    @recipient.Recipient.Name
+                </td>
+                <td>
+                    @recipient.Recipient.OdsCode
+                </td>
+                <td>
+                    @($"{Model.OrderItem.Order.CallOffId}-{recipient.Recipient.OdsCode}-{ViewContext.HttpContext.NextLineId()}")
+                </td>
+                <td>
+                    @Model.ServiceInstanceId(recipient.OdsCode)
+                </td>
 
-				@if (hasServiceRecipientQuantities)
-				{
-					<td class="numeric">
-						@(recipient.Quantity.HasValue ? $"{recipient.Quantity:N0}" : "-")
-					</td>
-				}
-			</tr>
+                @if (hasServiceRecipientQuantities)
+                {
+                <td class="numeric">
+	                @(recipient.Quantity.HasValue ? $"{recipient.Quantity:N0}" : "-")
+                </td>
+                }
+            </tr>
         }
 
         @if (hasServiceRecipientQuantities

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/FundingSources/FundingSources.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/FundingSources/FundingSources.cs
@@ -53,7 +53,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.FundingSources
                 nameof(FundingSourceController.FundingSources),
                 ParametersDFOCVC);
 
-            CommonActions.PageTitle().Should().BeEquivalentTo($"Select funding sources - Order {DFOCVCCallOffId}".FormatForComparison());
+            CommonActions.PageTitle().Should().BeEquivalentTo($"Funding sources - Order {DFOCVCCallOffId}".FormatForComparison());
             CommonActions.GoBackLinkDisplayed().Should().BeTrue();
             CommonActions.SaveButtonDisplayed().Should().BeTrue();
             CommonActions.ElementIsDisplayed(Objects.Ordering.FundingSources.LocalOnlyFundingSourcesTable).Should().BeTrue();
@@ -64,7 +64,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.FundingSources
         [Fact]
         public void FundingSources_GPITFuturesSolution_AllSectionsDisplayed()
         {
-            CommonActions.PageTitle().Should().BeEquivalentTo($"Select funding sources - Order {GPITFuturesCallOffId}".FormatForComparison());
+            CommonActions.PageTitle().Should().BeEquivalentTo($"Funding sources - Order {GPITFuturesCallOffId}".FormatForComparison());
             CommonActions.GoBackLinkDisplayed().Should().BeTrue();
             CommonActions.SaveButtonDisplayed().Should().BeTrue();
             CommonActions.ElementIsDisplayed(Objects.Ordering.FundingSources.LocalOnlyFundingSourcesTable).Should().BeFalse();
@@ -80,7 +80,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.FundingSources
                 nameof(FundingSourceController.FundingSources),
                 ParametersNoFunding);
 
-            CommonActions.PageTitle().Should().BeEquivalentTo($"Select funding sources - Order {NoFundingCallOffId}".FormatForComparison());
+            CommonActions.PageTitle().Should().BeEquivalentTo($"Funding sources - Order {NoFundingCallOffId}".FormatForComparison());
             CommonActions.GoBackLinkDisplayed().Should().BeTrue();
             CommonActions.SaveButtonDisplayed().Should().BeTrue();
             CommonActions.ElementIsDisplayed(Objects.Ordering.FundingSources.LocalOnlyFundingSourcesTable).Should().BeFalse();

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
@@ -888,6 +888,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             CataloguePriceCalculationType = CataloguePriceCalculationType.Volume,
                             CataloguePriceType = CataloguePriceType.Flat,
                             PublishedStatus = PublicationStatus.Published,
+                            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerServiceRecipient,
                             PricingUnit = new PricingUnit
                             {
                                 Id = 1,
@@ -1323,6 +1324,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             CataloguePriceType = CataloguePriceType.Flat,
                             PublishedStatus = PublicationStatus.Published,
                             CataloguePriceCalculationType = CataloguePriceCalculationType.SingleFixed,
+                            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerServiceRecipient,
                             PricingUnit = new PricingUnit
                             {
                                 Id = 6,

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/CatalogueSolutionSeedData.cs
@@ -888,7 +888,6 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             CataloguePriceCalculationType = CataloguePriceCalculationType.Volume,
                             CataloguePriceType = CataloguePriceType.Flat,
                             PublishedStatus = PublicationStatus.Published,
-                            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerServiceRecipient,
                             PricingUnit = new PricingUnit
                             {
                                 Id = 1,
@@ -919,6 +918,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             CataloguePriceType = CataloguePriceType.Flat,
                             CataloguePriceCalculationType = CataloguePriceCalculationType.Volume,
                             PublishedStatus = PublicationStatus.Published,
+                            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerServiceRecipient,
                             PricingUnit = new PricingUnit
                             {
                                 Id = 2,
@@ -949,6 +949,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             CataloguePriceType = CataloguePriceType.Flat,
                             CataloguePriceCalculationType = CataloguePriceCalculationType.Volume,
                             PublishedStatus = PublicationStatus.Published,
+                            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerServiceRecipient,
                             PricingUnit = new PricingUnit
                             {
                                 Id = 3,
@@ -1324,7 +1325,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                             CataloguePriceType = CataloguePriceType.Flat,
                             PublishedStatus = PublicationStatus.Published,
                             CataloguePriceCalculationType = CataloguePriceCalculationType.SingleFixed,
-                            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerServiceRecipient,
+                            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerSolutionOrService,
                             PricingUnit = new PricingUnit
                             {
                                 Id = 6,

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/OrderSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/OrderSeedData.cs
@@ -356,6 +356,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                     Phone = "123456789",
                 },
                 CommencementDate = DateTime.UtcNow.AddDays(1),
+                InitialPeriod = 6,
+                MaximumTerm = 36,
             };
 
             var price = context.CatalogueItems
@@ -370,6 +372,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                 OrderItemPrice = price,
                 Created = DateTime.UtcNow,
                 OrderId = orderId,
+                Quantity = 10,
                 CatalogueItem = context.CatalogueItems.Single(c => c.Id == new CatalogueItemId(99999, "001")),
                 OrderItemFunding = new OrderItemFunding
                 {
@@ -417,6 +420,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                     Phone = "123456789",
                 },
                 CommencementDate = DateTime.UtcNow.AddDays(1),
+                InitialPeriod = 6,
+                MaximumTerm = 36,
             };
 
             var price = context.CatalogueItems
@@ -434,6 +439,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                 OrderItemPrice = price,
                 Created = DateTime.UtcNow,
                 OrderId = orderId,
+                Quantity = 10,
                 CatalogueItem = context.CatalogueItems.Single(c => c.Id == new CatalogueItemId(99999, "001")),
                 OrderItemFunding = new OrderItemFunding
                 {
@@ -481,6 +487,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                     Phone = "123456789",
                 },
                 CommencementDate = timeNow.AddDays(1),
+                InitialPeriod = 6,
+                MaximumTerm = 36,
             };
 
             var user = GetBuyerUser(context, order.OrderingPartyId);

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/OrderSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/OrderSeedData.cs
@@ -505,6 +505,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                 OrderItemPrice = price,
                 Created = DateTime.UtcNow,
                 OrderId = orderId,
+                Quantity = 10,
                 CatalogueItem = context.CatalogueItems.Single(c => c.Id == new CatalogueItemId(99998, "002")),
             };
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/FundingSource/FundingSourceControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/FundingSource/FundingSourceControllerTests.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
 using Moq;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
-using NHSD.GPIT.BuyingCatalogue.Framework.Calculations;
 using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders;
 using NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.AutoFixtureCustomisations;
@@ -57,12 +56,16 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Fun
             EntityFramework.Ordering.Models.Order order,
             [Frozen] OrderItem orderItem,
             [Frozen] Mock<IOrderItemService> orderItemServiceMock,
+            [Frozen] Mock<IOrderService> orderService,
             FundingSourceController controller)
         {
             orderItemServiceMock.Setup(oi => oi.GetOrderItem(order.CallOffId, internalOrgId, orderItem.CatalogueItemId))
                 .ReturnsAsync(orderItem);
 
-            var expectedViewData = new WebApp.Areas.Order.Models.FundingSources.FundingSource(internalOrgId, order.CallOffId, orderItem);
+            orderService.Setup(o => o.GetOrderThin(order.CallOffId, internalOrgId))
+                .ReturnsAsync(order);
+
+            var expectedViewData = new WebApp.Areas.Order.Models.FundingSources.FundingSource(internalOrgId, order.CallOffId, order, orderItem);
 
             var actual = await controller.FundingSource(internalOrgId, order.CallOffId, orderItem.CatalogueItemId);
 
@@ -81,7 +84,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Fun
             [Frozen] Mock<IOrderItemService> orderItemServiceMock,
             FundingSourceController controller)
         {
-            var model = new WebApp.Areas.Order.Models.FundingSources.FundingSource(internalOrgId, order.CallOffId, orderItem)
+            var model = new WebApp.Areas.Order.Models.FundingSources.FundingSource(internalOrgId, order.CallOffId, order, orderItem)
             {
                 SelectedFundingType = OrderItemFundingType.CentralFunding,
             };
@@ -112,7 +115,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Fun
             [Frozen] Mock<IOrderItemService> orderItemServiceMock,
             FundingSourceController controller)
         {
-            var model = new WebApp.Areas.Order.Models.FundingSources.FundingSource(internalOrgId, order.CallOffId, orderItem);
+            var model = new WebApp.Areas.Order.Models.FundingSources.FundingSource(internalOrgId, order.CallOffId, order, orderItem);
 
             controller.ModelState.AddModelError("test", "test");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/FundingSource/FundingSourceModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/FundingSource/FundingSourceModelTests.cs
@@ -1,4 +1,5 @@
-﻿using AutoFixture.Xunit2;
+﻿using System.Linq;
+using AutoFixture.Xunit2;
 using FluentAssertions;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.AutoFixtureCustomisations;
@@ -13,11 +14,13 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.FundingS
         public static void FundingSource_WithArguments_FundingNull_SetsCorrectly(
             string internalOrgId,
             [Frozen] CallOffId callOffId,
-            OrderItem orderItem)
+            EntityFramework.Ordering.Models.Order order)
         {
+            var orderItem = order.OrderItems.First();
+
             orderItem.OrderItemFunding = null;
 
-            var model = new WebApp.Areas.Order.Models.FundingSources.FundingSource(internalOrgId, callOffId, orderItem);
+            var model = new WebApp.Areas.Order.Models.FundingSources.FundingSource(internalOrgId, callOffId, order, orderItem);
 
             model.Title.Should().Be($"{orderItem.CatalogueItem.Name} funding source");
             model.CallOffId.Should().Be(callOffId);
@@ -31,9 +34,11 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.FundingS
         public static void FundingSource_WithArguments_FundingSet_SetsCorrectly(
             string internalOrgId,
             [Frozen] CallOffId callOffId,
-            OrderItem orderItem)
+            EntityFramework.Ordering.Models.Order order)
         {
-            var model = new WebApp.Areas.Order.Models.FundingSources.FundingSource(internalOrgId, callOffId, orderItem);
+            var orderItem = order.OrderItems.First();
+
+            var model = new WebApp.Areas.Order.Models.FundingSources.FundingSource(internalOrgId, callOffId, order, orderItem);
 
             model.Title.Should().Be($"{orderItem.CatalogueItem.Name} funding source");
             model.CallOffId.Should().Be(callOffId);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/FundingSource/FundingSourcesModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/FundingSource/FundingSourcesModelTests.cs
@@ -22,7 +22,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.FundingS
 
             var model = new FundingSources(internalOrgId, order.CallOffId, order);
 
-            model.Title.Should().Be("Select funding sources");
+            model.Title.Should().Be("Funding sources");
             model.CallOffId.Should().Be(order.CallOffId);
             model.InternalOrgId.Should().Be(internalOrgId);
             model.Caption.Should().Be($"Order {order.CallOffId}");
@@ -45,7 +45,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.FundingS
 
             var model = new FundingSources(internalOrgId, order.CallOffId, order);
 
-            model.Title.Should().Be("Select funding sources");
+            model.Title.Should().Be("Funding sources");
             model.CallOffId.Should().Be(order.CallOffId);
             model.InternalOrgId.Should().Be(internalOrgId);
             model.Caption.Should().Be($"Order {order.CallOffId}");
@@ -67,7 +67,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.FundingS
 
             var model = new FundingSources(internalOrgId, order.CallOffId, order);
 
-            model.Title.Should().Be("Select funding sources");
+            model.Title.Should().Be("Funding sources");
             model.CallOffId.Should().Be(order.CallOffId);
             model.InternalOrgId.Should().Be(internalOrgId);
             model.Caption.Should().Be($"Order {order.CallOffId}");
@@ -92,7 +92,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.FundingS
 
             var model = new FundingSources(internalOrgId, order.CallOffId, order);
 
-            model.Title.Should().Be("Select funding sources");
+            model.Title.Should().Be("Funding sources");
             model.CallOffId.Should().Be(order.CallOffId);
             model.InternalOrgId.Should().Be(internalOrgId);
             model.Caption.Should().Be($"Order {order.CallOffId}");
@@ -114,7 +114,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.FundingS
 
             var model = new FundingSources(internalOrgId, order.CallOffId, order);
 
-            model.Title.Should().Be("Select funding sources");
+            model.Title.Should().Be("Funding sources");
             model.CallOffId.Should().Be(order.CallOffId);
             model.InternalOrgId.Should().Be(internalOrgId);
             model.Caption.Should().Be($"Order {order.CallOffId}");


### PR DESCRIPTION
Fix funding source to not show partially completed items (to stop throwing an exception) - #20609

Fix funding source to calculate the total amount using the contract length

Fix Review pages to show ItemId as a global counting number

Fix review page service instance ID to always show and generate correctly - #20603