### PR TITLE
Fix Item-Id for Review and CSV pages generating differently.

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Csv/CsvService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Csv/CsvService.cs
@@ -53,6 +53,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Csv
                     ProductId = oir.OrderItem.CatalogueItemId.ToString(),
                     ProductName = oir.OrderItem.CatalogueItem.Name,
                     ProductType = oir.OrderItem.CatalogueItem.CatalogueItemType.DisplayName(),
+                    ProductTypeId = (int)oir.OrderItem.CatalogueItem.CatalogueItemType,
 
                     // TODO: Stop this reporting incorrectly when quantity is (erroneously) defined at both order item & recipient level
                     QuantityOrdered = oir.Quantity ?? oir.OrderItem.Quantity ?? 0,
@@ -66,10 +67,12 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Csv
                     Framework = frameworkId,
                     InitialTerm = oir.OrderItem.Order.InitialPeriod,
                     MaximumTerm = oir.OrderItem.Order.MaximumTerm,
-                }).ToListAsync();
+                })
+                .OrderBy(o => o.ProductTypeId).ThenBy(o => o.ServiceRecipientName)
+                .ToListAsync();
 
             for (int i = 0; i < items.Count; i++)
-                items[i].ServiceRecipientItemId = $"{items[i].CallOffId}-{items[i].ServiceRecipientId}-{i + 1}";
+                items[i].ServiceRecipientItemId = $"{items[i].CallOffId}-{items[i].ServiceRecipientId}-{i}";
 
             await WriteRecordsAsync<FullOrderCsvModel, FullOrderCsvModelMap>(stream, items);
         }
@@ -97,6 +100,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Csv
                     ProductId = oir.OrderItem.CatalogueItemId.ToString(),
                     ProductName = oir.OrderItem.CatalogueItem.Name,
                     ProductType = oir.OrderItem.CatalogueItem.CatalogueItemType.DisplayName(),
+                    ProductTypeId = (int)oir.OrderItem.CatalogueItem.CatalogueItemType,
 
                     // TODO: Stop this reporting incorrectly when quantity is (erroneously) defined at both order item & recipient level
                     QuantityOrdered = oir.Quantity ?? oir.OrderItem.Quantity ?? 0,

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Csv/FullOrderCsvModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Csv/FullOrderCsvModel.cs
@@ -31,6 +31,9 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Csv
 
         public string ProductType { get; set; }
 
+        // Used only for ordering the items correctly, is not to be displayed in the CSV
+        public int ProductTypeId { get; set; }
+
         public int QuantityOrdered { get; set; }
 
         public string UnitOfOrder { get; set; }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Csv/PatientOrderCsvModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Csv/PatientOrderCsvModel.cs
@@ -31,6 +31,9 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Csv
 
         public string ProductType { get; set; }
 
+        // Used only for ordering the items correctly, is not to be displayed in the CSV
+        public int ProductTypeId { get; set; }
+
         public int QuantityOrdered { get; set; }
 
         public string UnitOfOrder { get; set; }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/OrderService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/OrderService.cs
@@ -90,9 +90,9 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
                     .ThenInclude(i => i.OrderItemFunding)
                 .Include(o => o.OrderItems)
                     .ThenInclude(i => i.OrderItemPrice)
-                    .ThenInclude(ip => ip.OrderItemPriceTiers)
+                    .ThenInclude(ip => ip.OrderItemPriceTiers.OrderBy(ip => ip.LowerRange))
                 .Include(o => o.OrderItems)
-                    .ThenInclude(i => i.OrderItemRecipients)
+                    .ThenInclude(i => i.OrderItemRecipients.OrderBy(i => i.Recipient.Name))
                     .ThenInclude(r => r.Recipient)
                 .AsSplitQuery()
                 .SingleOrDefaultAsync();
@@ -143,8 +143,8 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
                 .Include(o => o.LastUpdatedByUser)
                 .Include(o => o.OrderItems).ThenInclude(i => i.CatalogueItem).ThenInclude(ci => ci.Solution).ThenInclude(s => s.FrameworkSolutions).ThenInclude(fs => fs.Framework)
                 .Include(o => o.OrderItems).ThenInclude(i => i.OrderItemFunding)
-                .Include(o => o.OrderItems).ThenInclude(i => i.OrderItemPrice).ThenInclude(ip => ip.OrderItemPriceTiers)
-                .Include(o => o.OrderItems).ThenInclude(i => i.OrderItemRecipients).ThenInclude(r => r.Recipient)
+                .Include(o => o.OrderItems).ThenInclude(i => i.OrderItemPrice).ThenInclude(ip => ip.OrderItemPriceTiers.OrderBy(pt => pt.LowerRange))
+                .Include(o => o.OrderItems).ThenInclude(i => i.OrderItemRecipients.OrderBy(i => i.Recipient.Name)).ThenInclude(r => r.Recipient)
                 .AsSplitQuery()
                 .SingleOrDefaultAsync(o =>
                     o.Id == callOffId.Id


### PR DESCRIPTION
Fix how the Item-Id is generated on review and csv by setting ordering rules.

Items will now be displayed in this order:
Type: Catalogue Solution-> Additional Service -> Associated Service
Then :Recipient Name

This ordering has been set for the Review Page, PDF and CSV so when we generate the Item-Id they will all generate in the same manner.

Also updated the OrderService to explictly order the tiers by their lower range, since this must also be constant