### PR TITLE
Add Step 3 to task list

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Enums/TaskProgress.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Enums/TaskProgress.cs
@@ -7,5 +7,6 @@
         Optional,
         InProgress,
         Completed,
+        NotApplicable,
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Models/TaskList/OrderTaskList.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Models/TaskList/OrderTaskList.cs
@@ -16,6 +16,12 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models.TaskList
 
         public TaskProgress FundingSource { get; set; } = TaskProgress.CannotStart;
 
+        public TaskProgress ImplementationPlan { get; set; } = TaskProgress.CannotStart;
+
+        public TaskProgress AssociatedServiceBilling { get; set; } = TaskProgress.CannotStart;
+
+        public TaskProgress DataProcessingInformation { get; set; } = TaskProgress.CannotStart;
+
         public TaskProgress ReviewAndCompleteStatus { get; set; } = TaskProgress.CannotStart;
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Models/TaskList/OrderTaskListCompletedSections.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Models/TaskList/OrderTaskListCompletedSections.cs
@@ -14,6 +14,8 @@
 
         public bool SolutionsCompleted { get; set; }
 
+        public bool HasAssociatedServices { get; set; }
+
         public bool FundingInProgress { get; set; }
 
         public bool FundingCompleted { get; set; }

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Models/TaskList/TaskListOrderSections.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Models/TaskList/TaskListOrderSections.cs
@@ -14,12 +14,22 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models.TaskList
         SolutionOrService = 32,
         FundingSourceInProgress = 64,
         FundingSource = 128,
-        DescriptionComplete = Description,
+        ImplementationPlanInProgress = 256,
+        ImplementationPlan = 512,
+        AssociatedServiceBillingInProgress = 1024,
+        AssociatedServiceBilling = 2048,
+        AssociatedServiceBillingNotApplicable = 4096,
+        DataProcessingInformationInProgress = 8192,
+        DataProcessingInformation = 16384,
+
         OrderingPartyComplete = OrderingParty,
         SupplierComplete = Supplier | OrderingPartyComplete,
         SupplierContactComplete = SupplierContact | SupplierComplete,
         CommencementDateComplete = CommencementDate | SupplierContactComplete,
         SolutionOrServiceComplete = SolutionOrService | SolutionOrServiceInProgress | CommencementDateComplete,
         FundingSourceComplete = FundingSource | FundingSourceInProgress | SolutionOrServiceComplete,
+        ImplementationPlanComplete = ImplementationPlan | ImplementationPlanInProgress | FundingSourceComplete,
+        AssociatedServiceBillingComplete = AssociatedServiceBilling | AssociatedServiceBillingInProgress | ImplementationPlanComplete,
+        DataProcessingInformationCompleted = DataProcessingInformation | DataProcessingInformationInProgress | ImplementationPlanComplete,
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/TaskList/ITaskListService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/TaskList/ITaskListService.cs
@@ -6,7 +6,5 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.TaskList
     public interface ITaskListService
     {
         public Task<OrderTaskList> GetTaskListStatusModelForOrder(int? orderId);
-
-        public Task<OrderTaskListCompletedSections> GetOrderSectionFlags(int orderId);
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Helpers/TagHelperConstants.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Helpers/TagHelperConstants.cs
@@ -43,6 +43,7 @@
         internal const string AriaExpanded = "aria-expanded";
         internal const string AriaLive = "aria-live";
         internal const string Class = "class";
+        internal const string Style = "style";
         internal const string PathD = "d";
         internal const string Source = "src";
 

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Tags/NhsTagsTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Tags/NhsTagsTagHelper.cs
@@ -114,6 +114,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Tags
         {
             var selectedColourClass = progress switch
             {
+                TaskProgress.NotApplicable => TagColour.White,
                 TaskProgress.NotStarted => TagColour.Grey,
                 TaskProgress.CannotStart => TagColour.Grey,
                 TaskProgress.Optional => TagColour.White,
@@ -124,6 +125,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Tags
 
             var tagText = progress switch
             {
+                TaskProgress.NotApplicable => "Not applicable",
                 TaskProgress.NotStarted => "Not started",
                 TaskProgress.CannotStart => "Cannot start yet",
                 TaskProgress.Optional => "Optional",

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/TaskList/TaskListItemTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/TaskList/TaskListItemTagHelper.cs
@@ -136,7 +136,8 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.TaskLi
             var breakRow = new TagBuilder("br") { TagRenderMode = TagRenderMode.SelfClosing };
             var builder = new TagBuilder(TagHelperConstants.Span);
 
-            builder.MergeAttribute("style", "color:	#4c6272");
+            const string textColour = "color: #4c6272";
+            builder.MergeAttribute(TagHelperConstants.Style, textColour);
 
             builder
                 .InnerHtml

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/TaskList/TaskListItemTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/TaskList/TaskListItemTagHelper.cs
@@ -22,6 +22,9 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.TaskLi
         [HtmlAttributeName(TagHelperConstants.LabelTextName)]
         public string LabelText { get; set; }
 
+        [HtmlAttributeName(TagHelperConstants.LabelHintName)]
+        public string LabelHint { get; set; }
+
         [HtmlAttributeName(ItemUrlName)]
         public string Url { get; set; }
 
@@ -37,7 +40,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.TaskLi
 
             var taskNameSpan = GetTaskNameSpanBuilder();
 
-            if (Status == TaskProgress.CannotStart)
+            if (Status is TaskProgress.CannotStart or TaskProgress.NotApplicable)
             {
                 taskNameSpan.InnerHtml.Append(LabelText);
             }
@@ -47,10 +50,12 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.TaskLi
             }
 
             var statusTag = GetNhsTagBuilder(context);
+            var labelHint = GetLabelHintBuilder();
 
             output.Content
                 .AppendHtml(taskNameSpan)
-                .AppendHtml(statusTag);
+                .AppendHtml(statusTag)
+                .AppendHtml(labelHint);
         }
 
         private static TagBuilder GetTaskNameSpanBuilder()
@@ -70,7 +75,9 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.TaskLi
 
             builder.MergeAttribute(TagHelperConstants.AriaDescribedBy, TagBuilder.CreateSanitizedId($"{LabelText}-status", "_"));
 
-            builder.InnerHtml.Append(LabelText);
+            builder
+                .InnerHtml
+                .Append(LabelText);
 
             return builder;
         }
@@ -86,6 +93,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.TaskLi
             {
                 ChosenTagColour = Status switch
                 {
+                    TaskProgress.NotApplicable => NhsTagsTagHelper.TagColour.White,
                     TaskProgress.Completed => NhsTagsTagHelper.TagColour.Green,
                     TaskProgress.InProgress => NhsTagsTagHelper.TagColour.Yellow,
                     TaskProgress.Optional => NhsTagsTagHelper.TagColour.White,
@@ -94,6 +102,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.TaskLi
 
                 TagText = Status switch
                 {
+                    TaskProgress.NotApplicable => "Not applicable",
                     TaskProgress.CannotStart => "Cannot start yet",
                     TaskProgress.Optional => "Optional",
                     TaskProgress.InProgress => "In&nbsp;progress",
@@ -115,6 +124,24 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.TaskLi
             nhsTag.Process(context, nhsTagOutput);
 
             builder.InnerHtml.AppendHtml(nhsTagOutput);
+
+            return builder;
+        }
+
+        private TagBuilder GetLabelHintBuilder()
+        {
+            if (string.IsNullOrWhiteSpace(LabelHint))
+                return null;
+
+            var breakRow = new TagBuilder("br") { TagRenderMode = TagRenderMode.SelfClosing };
+            var builder = new TagBuilder(TagHelperConstants.Span);
+
+            builder.MergeAttribute("style", "color:	#4c6272");
+
+            builder
+                .InnerHtml
+                .AppendHtml(breakRow)
+                .Append(LabelHint);
 
             return builder;
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/Order/Order.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Views/Order/Order.cshtml
@@ -26,21 +26,29 @@
                 <nhs-task-list>
                     <nhs-task-list-section label-text="Prepare order">
                         <nhs-task-list-item label-text="Order description"
+                                            label-hint="Provide a description of your order."
+                                            data-test-id="test-order-description"
                                             url="@Model.DescriptionUrl"
                                             status="@Model.SectionStatuses.DescriptionStatus" />
                         <nhs-task-list-item label-text="Call-off Ordering Party contact details"
+                                            label-hint="Provide information about the primary contact for your order."
+                                            data-test-id="test-calloff-party"
                                             url="@Url.Action(
                                                 nameof(OrderingPartyController.OrderingParty),
                                                 typeof(OrderingPartyController).ControllerName(),
                                                 new { Model.InternalOrgId, Model.CallOffId})"
                                             status="@Model.SectionStatuses.OrderingPartyStatus" />
                         <nhs-task-list-item label-text="Supplier information and contact details"
+                                            label-hint="Find the supplier you want to order from and select a supplier contact."
+                                            data-test-id="test-supplier-contact"
                                             url="@Url.Action(
                                                 nameof(SupplierController.Supplier),
                                                 typeof(SupplierController).ControllerName(),
                                                 new { Model.InternalOrgId, Model.CallOffId})"
                                             status="@Model.SectionStatuses.SupplierStatus" />
                         <nhs-task-list-item label-text="Timescales for Call-off Agreement"
+                                            label-hint="Provide the approximate start date, the length of the contract and its initial period."
+                                            data-test-id="test-timescales"
                                             url="@Url.Action(
                                                 nameof(CommencementDateController.CommencementDate),
                                                 typeof(CommencementDateController).ControllerName(),
@@ -49,17 +57,49 @@
                     </nhs-task-list-section>
                     <nhs-task-list-section label-text="Add solutions and services">
                         <nhs-task-list-item label-text="Select solutions and services"
+                                            label-hint="Add Service Recipients, prices and quantities for what you’re ordering."
+                                            data-test-id="test-solutions-and-services"
                                             url="@SolutionSelectionUrlTarget(Model.SectionStatuses.SolutionOrService)"
                                             status="@Model.SectionStatuses.SolutionOrService" />
-						<nhs-task-list-item label-text="Select funding sources"
+                        <nhs-task-list-item label-text="Select funding sources"
+                                            label-hint="Review how you’ll be paying for your order."
+                                            data-test-id="test-funding-sources"
                                             url="@Url.Action(
                                                     nameof(FundingSourceController.FundingSources),
                                                     typeof(FundingSourceController).ControllerName(),
                                                     new { Model.InternalOrgId, Model.CallOffId })"
                                             status="@Model.SectionStatuses.FundingSource" />
                     </nhs-task-list-section>
+                    <nhs-task-list-section label-text="Complete contract">
+                        <nhs-task-list-item label-text="Implementation plan milestones"
+                                            label-hint="Select if you’re using the standard implementation plan milestones or have agreed a bespoke one."
+                                            data-test-id="test-implementation-milestones"
+                                            url="@Url.Action(
+                                                    nameof(OrderController.Order),
+                                                    typeof(OrderController).ControllerName(),
+                                                    new { Model.InternalOrgId, Model.CallOffId })"
+                                            status="@Model.SectionStatuses.ImplementationPlan" />
+                        <nhs-task-list-item label-text="Associated Service billing and requirements"
+                                            label-hint="Select how you’d like to be billed for any Associated Services in your order."
+                                            data-test-id="test-associated-service-billing"
+                                            url="@Url.Action(
+                                                    nameof(OrderController.Order),
+                                                    typeof(OrderController).ControllerName(),
+                                                    new { Model.InternalOrgId, Model.CallOffId })"
+                                            status="@Model.SectionStatuses.AssociatedServiceBilling" />
+                        <nhs-task-list-item label-text="Data processing information"
+                                            label-hint="Select if you want to make any changes to the default data processing information."
+                                            data-test-id="test-data-processing-info"
+                                            url="@Url.Action(
+                                                    nameof(OrderController.Order),
+                                                    typeof(OrderController).ControllerName(),
+                                                    new { Model.InternalOrgId, Model.CallOffId })"
+                                            status="@Model.SectionStatuses.DataProcessingInformation" />
+                    </nhs-task-list-section>
                     <nhs-task-list-section label-text="Complete order">
                         <nhs-task-list-item label-text="Review and complete order"
+                                            label-hint="Check the information you’ve provided is correct and complete your order."
+                                            data-test-id="test-review-and-complete-order"
                                             url="@Url.Action(
                                                     nameof(OrderController.Summary),
                                                     typeof(OrderController).ControllerName(),

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AdditionalServices/EditAdditionalService.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AdditionalServices/EditAdditionalService.cs
@@ -75,7 +75,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.Addition
                 .BeTrue();
         }
 
-       [Fact]
+        [Fact]
         public async Task Publish_IncompleteSections_ThrowsError()
         {
             await using var context = GetEndToEndDbContext();

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/OrderDashboard.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/OrderDashboard.cs
@@ -39,22 +39,65 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering
         public async Task OrderDashboard_AllSectionsDisplayed()
         {
             await using var context = GetEndToEndDbContext();
-            var organisation = await context.Organisations.SingleAsync(o => o.InternalIdentifier == Parameters["InternalOrgId"]);
+            var organisation =
+                await context.Organisations.SingleAsync(o => o.InternalIdentifier == Parameters["InternalOrgId"]);
 
-            CommonActions.PageTitle().Should().BeEquivalentTo($"Order {CallOffId}-{organisation.Name}".FormatForComparison());
+            CommonActions.PageTitle()
+                .Should()
+                .BeEquivalentTo($"Order {CallOffId}-{organisation.Name}".FormatForComparison());
             CommonActions.GoBackLinkDisplayed().Should().BeTrue();
 
             CommonActions.ElementIsDisplayed(Objects.Ordering.OrderDashboard.TaskList)
-                .Should().BeTrue();
+                .Should()
+                .BeTrue();
 
             CommonActions.ElementIsDisplayed(Objects.Ordering.OrderDashboard.OrderDescriptionLink)
-                .Should().BeTrue();
+                .Should()
+                .BeTrue();
 
             CommonActions.ElementIsDisplayed(Objects.Ordering.OrderDashboard.OrderDescriptionStatus)
-                .Should().BeTrue();
+                .Should()
+                .BeTrue();
+
+            CommonActions.ElementIsDisplayed(Objects.Ordering.OrderDashboard.CallOffParty)
+                .Should()
+                .BeTrue();
+
+            CommonActions.ElementIsDisplayed(Objects.Ordering.OrderDashboard.SupplierContact)
+                .Should()
+                .BeTrue();
+
+            CommonActions.ElementIsDisplayed(Objects.Ordering.OrderDashboard.Timescales)
+                .Should()
+                .BeTrue();
+
+            CommonActions.ElementIsDisplayed(Objects.Ordering.OrderDashboard.SolutionsAndServices)
+                .Should()
+                .BeTrue();
+
+            CommonActions.ElementIsDisplayed(Objects.Ordering.OrderDashboard.FundingSources)
+                .Should()
+                .BeTrue();
+
+            CommonActions.ElementIsDisplayed(Objects.Ordering.OrderDashboard.ImplementationMilestones)
+                .Should()
+                .BeTrue();
+
+            CommonActions.ElementIsDisplayed(Objects.Ordering.OrderDashboard.AssociatedServiceBilling)
+                .Should()
+                .BeTrue();
+
+            CommonActions.ElementIsDisplayed(Objects.Ordering.OrderDashboard.DataProcessingInformation)
+                .Should()
+                .BeTrue();
+
+            CommonActions.ElementIsDisplayed(Objects.Ordering.OrderDashboard.ReviewOrder)
+                .Should()
+                .BeTrue();
 
             CommonActions.ElementIsDisplayed(Objects.Ordering.OrderDashboard.LastUpdatedEndNote)
-                .Should().BeTrue();
+                .Should()
+                .BeTrue();
 
             CommonActions.ElementTextEqualTo(
                 Objects.Ordering.OrderDashboard.LastUpdatedEndNote,

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Objects/Ordering/OrderDashboard.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Objects/Ordering/OrderDashboard.cs
@@ -14,5 +14,23 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.Ordering
         public static By LastUpdatedEndNote => ByExtensions.DataTestId("last-updated-endnote");
 
         public static By SolutionSelectionLink => By.LinkText("Select solutions and services");
+
+        public static By CallOffParty => ByExtensions.DataTestId("test-calloff-party");
+
+        public static By SupplierContact => ByExtensions.DataTestId("test-supplier-contact");
+
+        public static By Timescales => ByExtensions.DataTestId("test-timescales");
+
+        public static By SolutionsAndServices => ByExtensions.DataTestId("test-solutions-and-services");
+
+        public static By FundingSources => ByExtensions.DataTestId("test-funding-sources");
+
+        public static By ImplementationMilestones => ByExtensions.DataTestId("test-implementation-milestones");
+
+        public static By AssociatedServiceBilling => ByExtensions.DataTestId("test-associated-service-billing");
+
+        public static By DataProcessingInformation => ByExtensions.DataTestId("test-data-processing-info");
+
+        public static By ReviewOrder => ByExtensions.DataTestId("test-review-and-complete-order");
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/TaskListServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/TaskListServiceTests.cs
@@ -254,7 +254,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList
                 CommencementDateStatus = TaskProgress.Completed,
                 SolutionOrService = TaskProgress.Completed,
                 FundingSource = TaskProgress.Completed,
-                ReviewAndCompleteStatus = TaskProgress.NotStarted,
+                ImplementationPlan = TaskProgress.NotStarted,
             };
 
             var model = new OrderTaskList();
@@ -269,6 +269,265 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList
                 | TaskListOrderSections.SolutionOrService
                 | TaskListOrderSections.FundingSourceInProgress
                 | TaskListOrderSections.FundingSource;
+
+            TaskListService.SetOrderTaskList(completedSections, model);
+
+            model.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public static void SetOrderTaskList_ImplementationPlan_InProgress()
+        {
+            var expected = new OrderTaskList()
+            {
+                DescriptionStatus = TaskProgress.Completed,
+                OrderingPartyStatus = TaskProgress.Completed,
+                SupplierStatus = TaskProgress.Completed,
+                CommencementDateStatus = TaskProgress.Completed,
+                SolutionOrService = TaskProgress.Completed,
+                FundingSource = TaskProgress.Completed,
+                ImplementationPlan = TaskProgress.InProgress,
+            };
+
+            var model = new OrderTaskList();
+
+            var completedSections =
+                TaskListOrderSections.Description
+                | TaskListOrderSections.OrderingParty
+                | TaskListOrderSections.Supplier
+                | TaskListOrderSections.SupplierContact
+                | TaskListOrderSections.CommencementDate
+                | TaskListOrderSections.SolutionOrServiceInProgress
+                | TaskListOrderSections.SolutionOrService
+                | TaskListOrderSections.FundingSourceInProgress
+                | TaskListOrderSections.FundingSource
+                | TaskListOrderSections.ImplementationPlanInProgress;
+
+            TaskListService.SetOrderTaskList(completedSections, model);
+
+            model.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public static void SetOrderTaskList_ImplementationPlan_Complete()
+        {
+            var expected = new OrderTaskList()
+            {
+                DescriptionStatus = TaskProgress.Completed,
+                OrderingPartyStatus = TaskProgress.Completed,
+                SupplierStatus = TaskProgress.Completed,
+                CommencementDateStatus = TaskProgress.Completed,
+                SolutionOrService = TaskProgress.Completed,
+                FundingSource = TaskProgress.Completed,
+                ImplementationPlan = TaskProgress.Completed,
+                AssociatedServiceBilling = TaskProgress.NotStarted,
+            };
+
+            var model = new OrderTaskList();
+
+            var completedSections =
+                TaskListOrderSections.Description
+                | TaskListOrderSections.OrderingParty
+                | TaskListOrderSections.Supplier
+                | TaskListOrderSections.SupplierContact
+                | TaskListOrderSections.CommencementDate
+                | TaskListOrderSections.SolutionOrServiceInProgress
+                | TaskListOrderSections.SolutionOrService
+                | TaskListOrderSections.FundingSourceInProgress
+                | TaskListOrderSections.FundingSource
+                | TaskListOrderSections.ImplementationPlanInProgress
+                | TaskListOrderSections.ImplementationPlan;
+
+            TaskListService.SetOrderTaskList(completedSections, model);
+
+            model.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public static void SetOrderTaskList_AssociatedServiceBilling_InProgress()
+        {
+            var expected = new OrderTaskList()
+            {
+                DescriptionStatus = TaskProgress.Completed,
+                OrderingPartyStatus = TaskProgress.Completed,
+                SupplierStatus = TaskProgress.Completed,
+                CommencementDateStatus = TaskProgress.Completed,
+                SolutionOrService = TaskProgress.Completed,
+                FundingSource = TaskProgress.Completed,
+                ImplementationPlan = TaskProgress.Completed,
+                AssociatedServiceBilling = TaskProgress.InProgress,
+            };
+
+            var model = new OrderTaskList();
+
+            var completedSections =
+                TaskListOrderSections.Description
+                | TaskListOrderSections.OrderingParty
+                | TaskListOrderSections.Supplier
+                | TaskListOrderSections.SupplierContact
+                | TaskListOrderSections.CommencementDate
+                | TaskListOrderSections.SolutionOrServiceInProgress
+                | TaskListOrderSections.SolutionOrService
+                | TaskListOrderSections.FundingSourceInProgress
+                | TaskListOrderSections.FundingSource
+                | TaskListOrderSections.ImplementationPlanInProgress
+                | TaskListOrderSections.ImplementationPlan
+                | TaskListOrderSections.AssociatedServiceBillingInProgress;
+
+            TaskListService.SetOrderTaskList(completedSections, model);
+
+            model.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public static void SetOrderTaskList_AssociatedServiceBilling_Completed()
+        {
+            var expected = new OrderTaskList()
+            {
+                DescriptionStatus = TaskProgress.Completed,
+                OrderingPartyStatus = TaskProgress.Completed,
+                SupplierStatus = TaskProgress.Completed,
+                CommencementDateStatus = TaskProgress.Completed,
+                SolutionOrService = TaskProgress.Completed,
+                FundingSource = TaskProgress.Completed,
+                ImplementationPlan = TaskProgress.Completed,
+                AssociatedServiceBilling = TaskProgress.Completed,
+                DataProcessingInformation = TaskProgress.NotStarted,
+            };
+
+            var model = new OrderTaskList();
+
+            var completedSections =
+                TaskListOrderSections.Description
+                | TaskListOrderSections.OrderingParty
+                | TaskListOrderSections.Supplier
+                | TaskListOrderSections.SupplierContact
+                | TaskListOrderSections.CommencementDate
+                | TaskListOrderSections.SolutionOrServiceInProgress
+                | TaskListOrderSections.SolutionOrService
+                | TaskListOrderSections.FundingSourceInProgress
+                | TaskListOrderSections.FundingSource
+                | TaskListOrderSections.ImplementationPlanInProgress
+                | TaskListOrderSections.ImplementationPlan
+                | TaskListOrderSections.AssociatedServiceBillingInProgress
+                | TaskListOrderSections.AssociatedServiceBilling;
+
+            TaskListService.SetOrderTaskList(completedSections, model);
+
+            model.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public static void SetOrderTaskList_AssociatedServiceBilling_NotApplicable()
+        {
+            var expected = new OrderTaskList()
+            {
+                DescriptionStatus = TaskProgress.Completed,
+                OrderingPartyStatus = TaskProgress.Completed,
+                SupplierStatus = TaskProgress.Completed,
+                CommencementDateStatus = TaskProgress.Completed,
+                SolutionOrService = TaskProgress.Completed,
+                FundingSource = TaskProgress.Completed,
+                ImplementationPlan = TaskProgress.Completed,
+                AssociatedServiceBilling = TaskProgress.NotApplicable,
+                DataProcessingInformation = TaskProgress.NotStarted,
+            };
+
+            var model = new OrderTaskList();
+
+            var completedSections =
+                TaskListOrderSections.Description
+                | TaskListOrderSections.OrderingParty
+                | TaskListOrderSections.Supplier
+                | TaskListOrderSections.SupplierContact
+                | TaskListOrderSections.CommencementDate
+                | TaskListOrderSections.SolutionOrServiceInProgress
+                | TaskListOrderSections.SolutionOrService
+                | TaskListOrderSections.FundingSourceInProgress
+                | TaskListOrderSections.FundingSource
+                | TaskListOrderSections.ImplementationPlanInProgress
+                | TaskListOrderSections.ImplementationPlan
+                | TaskListOrderSections.AssociatedServiceBillingNotApplicable;
+
+            TaskListService.SetOrderTaskList(completedSections, model);
+
+            model.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public static void SetOrderTaskList_DataProcessingInformation_InProgress()
+        {
+            var expected = new OrderTaskList()
+            {
+                DescriptionStatus = TaskProgress.Completed,
+                OrderingPartyStatus = TaskProgress.Completed,
+                SupplierStatus = TaskProgress.Completed,
+                CommencementDateStatus = TaskProgress.Completed,
+                SolutionOrService = TaskProgress.Completed,
+                FundingSource = TaskProgress.Completed,
+                ImplementationPlan = TaskProgress.Completed,
+                AssociatedServiceBilling = TaskProgress.Completed,
+                DataProcessingInformation = TaskProgress.InProgress,
+            };
+
+            var model = new OrderTaskList();
+
+            var completedSections =
+                TaskListOrderSections.Description
+                | TaskListOrderSections.OrderingParty
+                | TaskListOrderSections.Supplier
+                | TaskListOrderSections.SupplierContact
+                | TaskListOrderSections.CommencementDate
+                | TaskListOrderSections.SolutionOrServiceInProgress
+                | TaskListOrderSections.SolutionOrService
+                | TaskListOrderSections.FundingSourceInProgress
+                | TaskListOrderSections.FundingSource
+                | TaskListOrderSections.ImplementationPlanInProgress
+                | TaskListOrderSections.ImplementationPlan
+                | TaskListOrderSections.AssociatedServiceBillingInProgress
+                | TaskListOrderSections.AssociatedServiceBilling
+                | TaskListOrderSections.DataProcessingInformationInProgress;
+
+            TaskListService.SetOrderTaskList(completedSections, model);
+
+            model.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public static void SetOrderTaskList_DataProcessingInformation_Completed()
+        {
+            var expected = new OrderTaskList()
+            {
+                DescriptionStatus = TaskProgress.Completed,
+                OrderingPartyStatus = TaskProgress.Completed,
+                SupplierStatus = TaskProgress.Completed,
+                CommencementDateStatus = TaskProgress.Completed,
+                SolutionOrService = TaskProgress.Completed,
+                FundingSource = TaskProgress.Completed,
+                ImplementationPlan = TaskProgress.Completed,
+                AssociatedServiceBilling = TaskProgress.Completed,
+                DataProcessingInformation = TaskProgress.Completed,
+                ReviewAndCompleteStatus = TaskProgress.NotStarted,
+            };
+
+            var model = new OrderTaskList();
+
+            var completedSections =
+                TaskListOrderSections.Description
+                | TaskListOrderSections.OrderingParty
+                | TaskListOrderSections.Supplier
+                | TaskListOrderSections.SupplierContact
+                | TaskListOrderSections.CommencementDate
+                | TaskListOrderSections.SolutionOrServiceInProgress
+                | TaskListOrderSections.SolutionOrService
+                | TaskListOrderSections.FundingSourceInProgress
+                | TaskListOrderSections.FundingSource
+                | TaskListOrderSections.ImplementationPlanInProgress
+                | TaskListOrderSections.ImplementationPlan
+                | TaskListOrderSections.AssociatedServiceBillingInProgress
+                | TaskListOrderSections.AssociatedServiceBilling
+                | TaskListOrderSections.DataProcessingInformationInProgress
+                | TaskListOrderSections.DataProcessingInformation;
 
             TaskListService.SetOrderTaskList(completedSections, model);
 


### PR DESCRIPTION
1. add descriptions to relevant sections
2. add Step 3
3. add task list statuses for step 3
4. mark Associated Services Billing as Not Applicable when no associated services exist on the order

The Task List Status enum is an ever growing list. We should find a better way of handling this.