### PR TITLE
Update the task list contracts status logic

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,11 @@ variables:
   - group: dev-acr-secrets
 
 trigger:
-- feature/solution-selection
+- develop
 
 pr:
-- feature/solution-selection
+- develop
+- feature/*
 
 jobs:
 - job: version
@@ -33,11 +34,11 @@ jobs:
 - job: dockerBuildAndPush
   displayName: Run all tests and build & push docker containers to the ACR
   variables:
-    dacpacTag: dacpac-$[ dependencies.version.outputs['setVersionStep.semVer'] ] 
-    semVer: $[ dependencies.version.outputs['setVersionStep.semVer'] ]   
-    ${{ if eq(variables['Build.SourceBranchName'], 'main') }}: 
+    dacpacTag: dacpac-$[ dependencies.version.outputs['setVersionStep.semVer'] ]
+    semVer: $[ dependencies.version.outputs['setVersionStep.semVer'] ]
+    ${{ if eq(variables['Build.SourceBranchName'], 'main') }}:
       latestTag: latest
-    ${{ if ne(variables['Build.SourceBranchName'], 'main') }}: 
+    ${{ if ne(variables['Build.SourceBranchName'], 'main') }}:
       latestTag: latestbuild
 
   dependsOn: version
@@ -50,7 +51,7 @@ jobs:
     inputs:
       version: $(dotnetVersion)
       includePreviewVersions: false
-  
+
   - task: DotNetCoreCLI@2
     displayName: 'Run dotnet restore'
     inputs:
@@ -64,13 +65,13 @@ jobs:
     displayName: 'Install Node.js'
     inputs:
       versionSpec: '14.x'
- 
+
   - task: Npm@1
     displayName: 'Run npm install'
     inputs:
       command: 'install'
       workingDir: 'src/NHSD.GPIT.BuyingCatalogue.WebApp'
-      
+
   - task: DotNetCoreCLI@2
     displayName: 'Run dotnet build'
     inputs:
@@ -82,7 +83,7 @@ jobs:
     displayName: 'Run gulp min'
     inputs:
       gulpFile: 'src/NHSD.GPIT.BuyingCatalogue.WebApp/gulpfile.js'
-      targets: 'min'      
+      targets: 'min'
       workingDirectory: 'src/NHSD.GPIT.BuyingCatalogue.WebApp'
 
   - task: DotNetCoreCLI@2
@@ -120,7 +121,7 @@ jobs:
   - publish: $(build.artifactStagingDirectory)/screen-shots
     displayName: Publish screen shots
     condition: failed()
-    artifact: screen-shots 
+    artifact: screen-shots
 
   - task: DockerInstaller@0
     inputs:
@@ -146,17 +147,17 @@ jobs:
         $release = "$(semVer)"
         mkdir $(Build.ArtifactStagingDirectory)/code
         $release | Out-File $(Build.ArtifactStagingDirectory)/code/release.txt
-        
+
   - publish: $(build.artifactStagingDirectory)/code
     artifact: code-version
 
 - job: buildDatabaseDacpacs
   displayName: Build all Dacpacs and push
-  variables:    
-    semVer: $[ dependencies.version.outputs['setVersionStep.semVer'] ]   
-    ${{ if eq(variables['Build.SourceBranchName'], 'main') }}: 
+  variables:
+    semVer: $[ dependencies.version.outputs['setVersionStep.semVer'] ]
+    ${{ if eq(variables['Build.SourceBranchName'], 'main') }}:
       latestTag: latest
-    ${{ if ne(variables['Build.SourceBranchName'], 'main') }}: 
+    ${{ if ne(variables['Build.SourceBranchName'], 'main') }}:
       latestTag: latestbuild
 
   dependsOn: dockerBuildAndPush
@@ -187,12 +188,12 @@ jobs:
 
   - publish: $(build.artifactStagingDirectory)/dacpacs
     artifact: dacpacs
-  
+
 - job: createBuildArtifact
   displayName: Create Build Artifact
   pool:
-    vmImage: 'ubuntu-latest'  
-    
+    vmImage: 'ubuntu-latest'
+
   steps:
   - task: CopyFiles@2
     displayName: Build Artifact - Code
@@ -204,4 +205,4 @@ jobs:
       OverWrite: true
 
   - publish: $(build.artifactStagingDirectory)/terraform
-    artifact: build-artifact 
+    artifact: build-artifact

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Contracts/IContractsService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Contracts/IContractsService.cs
@@ -7,6 +7,10 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Contracts
     {
         Task<ContractFlags> GetContract(int orderId);
 
+        Task RemoveContract(int orderId);
+
+        Task RemoveBillingAndRequirements(int orderId);
+
         Task HasSpecificRequirements(int orderId, bool value);
 
         Task UseDefaultBilling(int orderId, bool value);

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Contracts/ContractsService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Contracts/ContractsService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.EntityFrameworkCore;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
@@ -35,6 +36,28 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Contracts
             await dbContext.SaveChangesAsync();
 
             return output;
+        }
+
+        public async Task RemoveContract(int orderId)
+        {
+            var contract = await GetContract(orderId);
+
+            contract.UseDefaultImplementationPlan = null;
+            contract.UseDefaultBilling = null;
+            contract.HasSpecificRequirements = null;
+            contract.UseDefaultDataProcessing = null;
+
+            await dbContext.SaveChangesAsync();
+        }
+
+        public async Task RemoveBillingAndRequirements(int orderId)
+        {
+            var contract = await GetContract(orderId);
+
+            contract.UseDefaultBilling = null;
+            contract.HasSpecificRequirements = null;
+
+            await dbContext.SaveChangesAsync();
         }
 
         public async Task HasSpecificRequirements(int orderId, bool value)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/SolutionSelection/AssociatedServicesController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/SolutionSelection/AssociatedServicesController.cs
@@ -8,6 +8,7 @@ using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.AssociatedServices;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Contracts;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Routing;
 using NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers;
@@ -28,17 +29,20 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers.SolutionSelec
         private readonly IOrderItemService orderItemService;
         private readonly IOrderService orderService;
         private readonly IRoutingService routingService;
+        private readonly IContractsService contractsService;
 
         public AssociatedServicesController(
             IAssociatedServicesService associatedServicesService,
             IOrderItemService orderItemService,
             IOrderService orderService,
-            IRoutingService routingService)
+            IRoutingService routingService,
+            IContractsService contractsService)
         {
             this.associatedServicesService = associatedServicesService ?? throw new ArgumentNullException(nameof(associatedServicesService));
             this.orderItemService = orderItemService ?? throw new ArgumentNullException(nameof(orderItemService));
             this.orderService = orderService ?? throw new ArgumentNullException(nameof(orderService));
             this.routingService = routingService ?? throw new ArgumentNullException(nameof(routingService));
+            this.contractsService = contractsService ?? throw new ArgumentNullException(nameof(contractsService));
         }
 
         [HttpGet("add")]
@@ -234,12 +238,24 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers.SolutionSelec
                     new { internalOrgId, callOffId });
             }
 
-            if (model.ToRemove?.Any() ?? false)
+            var removingServices = model.ToRemove?.Any() ?? false;
+            var addingServices = model.ToAdd?.Any() ?? false;
+
+            if (removingServices)
             {
                 await orderItemService.DeleteOrderItems(internalOrgId, callOffId, model.ToRemove.Select(x => x.CatalogueItemId));
             }
 
-            if (!(model.ToAdd?.Any() ?? false))
+            if (removingServices && !addingServices)
+            {
+                var order = await orderService.GetOrderWithOrderItems(callOffId, internalOrgId);
+                if (!order.HasAssociatedService())
+                {
+                    await contractsService.RemoveBillingAndRequirements(callOffId.Id);
+                }
+            }
+
+            if (!addingServices)
             {
                 return RedirectToAction(
                     nameof(TaskListController.TaskList),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/SolutionSelection/CatalogueSolutionsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Controllers/SolutionSelection/CatalogueSolutionsController.cs
@@ -8,6 +8,7 @@ using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.AdditionalServices;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Contracts;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Routing;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions;
@@ -26,17 +27,20 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers.SolutionSelec
         private readonly IOrderItemService orderItemService;
         private readonly IOrderService orderService;
         private readonly ISolutionsService solutionsService;
+        private readonly IContractsService contractsService;
 
         public CatalogueSolutionsController(
             IAdditionalServicesService additionalServicesService,
             IOrderItemService orderItemService,
             IOrderService orderService,
-            ISolutionsService solutionsService)
+            ISolutionsService solutionsService,
+            IContractsService contractsService)
         {
             this.additionalServicesService = additionalServicesService ?? throw new ArgumentNullException(nameof(additionalServicesService));
             this.orderItemService = orderItemService ?? throw new ArgumentNullException(nameof(orderItemService));
             this.orderService = orderService ?? throw new ArgumentNullException(nameof(orderService));
             this.solutionsService = solutionsService ?? throw new ArgumentNullException(nameof(solutionsService));
+            this.contractsService = contractsService ?? throw new ArgumentNullException(nameof(contractsService));
         }
 
         [HttpGet("select")]
@@ -293,6 +297,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers.SolutionSelec
                     new { internalOrgId, callOffId });
             }
 
+            await contractsService.RemoveContract(callOffId.Id);
             await orderItemService.DeleteOrderItems(internalOrgId, callOffId, model.ToRemove.Select(x => x.CatalogueItemId));
             await orderItemService.AddOrderItems(internalOrgId, callOffId, model.ToAdd.Select(x => x.CatalogueItemId));
 
@@ -372,6 +377,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Controllers.SolutionSelec
                     new { internalOrgId, callOffId });
             }
 
+            await contractsService.RemoveContract(callOffId.Id);
             await orderItemService.DeleteOrderItems(internalOrgId, callOffId, model.ToRemove.Select(x => x.CatalogueItemId));
             await orderService.SetSolutionId(internalOrgId, callOffId, model.ToAdd.First().CatalogueItemId);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/Order/OrderTaskList.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Order/Models/Order/OrderTaskList.cs
@@ -134,7 +134,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.Order
             }
 
             // Associated Services Billing
-            if (SolutionOrService is TaskProgress.InProgress
+            if ((SolutionOrService == TaskProgress.InProgress
+                    || ImplementationPlan == TaskProgress.InProgress)
                 && (order.ContractFlags?.HasSpecificRequirements != null
                     || order.ContractFlags?.UseDefaultBilling != null))
             {

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SolutionSelection/CatalogueSolutionsControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SolutionSelection/CatalogueSolutionsControllerTests.cs
@@ -15,6 +15,7 @@ using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.AdditionalServices;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Contracts;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Routing;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions;
@@ -877,6 +878,22 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Sol
 
         [Theory]
         [CommonAutoData]
+        public static async Task Post_ConfirmSolutionChanges_ClearsContract(
+            string internalOrgId,
+            CallOffId callOffId,
+            ConfirmServiceChangesModel model,
+            [Frozen] Mock<IContractsService> mockContractsService,
+            CatalogueSolutionsController controller)
+        {
+            model.ConfirmChanges = true;
+
+            var result = await controller.ConfirmSolutionChanges(internalOrgId, callOffId, model);
+
+            mockContractsService.Verify(s => s.RemoveContract(callOffId.Id), Times.Once());
+        }
+
+        [Theory]
+        [CommonAutoData]
         public static async Task Get_ConfirmSolutionChangesAssociatedServicesOnly_ReturnsExpectedResult(
             string internalOrgId,
             CallOffId callOffId,
@@ -992,6 +1009,22 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Sol
                 { "callOffId", callOffId },
                 { "source", RoutingSource.EditSolution },
             });
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static async Task Post_ConfirmSolutionChangesAssociatedServicesOnly_ClearsContract(
+            string internalOrgId,
+            CallOffId callOffId,
+            ConfirmServiceChangesModel model,
+            [Frozen] Mock<IContractsService> mockContractsService,
+            CatalogueSolutionsController controller)
+        {
+            model.ConfirmChanges = true;
+
+            var result = await controller.ConfirmSolutionChangesAssociatedServicesOnly(internalOrgId, callOffId, model);
+
+            mockContractsService.Verify(s => s.RemoveContract(callOffId.Id), Times.Once());
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/Order/OrderTaskListTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/Order/OrderTaskListTests.cs
@@ -56,6 +56,26 @@ public class OrderTaskListTests
 
     [Theory]
     [CommonAutoData]
+    public static void Construct_OrderingPartyNotCompleted(
+        string description)
+    {
+        var order = new EntityFramework.Ordering.Models.Order
+        {
+            Description = description, OrderingPartyContact = null,
+        };
+
+        var expectedModel = new OrderTaskList
+        {
+            DescriptionStatus = TaskProgress.Completed, OrderingPartyStatus = TaskProgress.NotStarted,
+        };
+
+        var model = new OrderTaskList(order);
+
+        model.Should().BeEquivalentTo(expectedModel);
+    }
+
+    [Theory]
+    [CommonAutoData]
     public static void Construct_Supplier_InProgress(
         string description,
         Contact orderingPartyContact,
@@ -315,6 +335,55 @@ public class OrderTaskListTests
 
     [Theory]
     [CommonAutoData]
+    public static void Construct_FundingSourceInProgress_WithImplementationPlan(
+        string description,
+        Contact orderingPartyContact,
+        EntityFramework.Catalogue.Models.Supplier supplier,
+        Contact supplierContact,
+        DateTime commencementDate,
+        OrderItem solutionOrderItem,
+        Solution solution,
+        OrderItem additionalServiceOrderItem,
+        AdditionalService additionalService)
+    {
+        var order = new EntityFramework.Ordering.Models.Order
+        {
+            Description = description,
+            OrderingPartyContact = orderingPartyContact,
+            Supplier = supplier,
+            SupplierContact = supplierContact,
+            CommencementDate = commencementDate,
+            ContractFlags = new()
+            {
+                UseDefaultImplementationPlan = true,
+            },
+        };
+
+        solutionOrderItem.CatalogueItem = solution.CatalogueItem;
+        additionalServiceOrderItem.CatalogueItem = additionalService.CatalogueItem;
+        additionalServiceOrderItem.OrderItemFunding = null;
+        order.OrderItems.Add(solutionOrderItem);
+        order.OrderItems.Add(additionalServiceOrderItem);
+
+        var expectedModel = new OrderTaskList
+        {
+            DescriptionStatus = TaskProgress.Completed,
+            OrderingPartyStatus = TaskProgress.Completed,
+            SupplierStatus = TaskProgress.Completed,
+            CommencementDateStatus = TaskProgress.Completed,
+            SolutionOrService = TaskProgress.Completed,
+            FundingSource = TaskProgress.InProgress,
+            ImplementationPlan = TaskProgress.InProgress,
+            AssociatedServiceBilling = TaskProgress.NotApplicable,
+        };
+
+        var model = new OrderTaskList(order);
+
+        model.Should().BeEquivalentTo(expectedModel);
+    }
+
+    [Theory]
+    [CommonAutoData]
     public static void Construct_ImplementationPlan_NoAssociatedServices(
         string description,
         Contact orderingPartyContact,
@@ -459,6 +528,150 @@ public class OrderTaskListTests
 
     [Theory]
     [CommonAutoData]
+    public static void Construct_OrderChanged_InProgressAssociatedServiceBilling(
+        string description,
+        Contact orderingPartyContact,
+        EntityFramework.Catalogue.Models.Supplier supplier,
+        Contact supplierContact,
+        DateTime commencementDate,
+        OrderItem solutionOrderItem,
+        Solution solution,
+        OrderItem associatedServiceOrderItem,
+        AssociatedService associatedService)
+    {
+        var order = new EntityFramework.Ordering.Models.Order
+        {
+            Description = description,
+            OrderingPartyContact = orderingPartyContact,
+            Supplier = supplier,
+            SupplierContact = supplierContact,
+            CommencementDate = commencementDate,
+            ContractFlags = new()
+            {
+                UseDefaultImplementationPlan = true,
+                UseDefaultBilling = true,
+                HasSpecificRequirements = false,
+            },
+        };
+
+        solutionOrderItem.CatalogueItem = solution.CatalogueItem;
+        associatedServiceOrderItem.CatalogueItem = associatedService.CatalogueItem;
+        associatedServiceOrderItem.OrderItemPrice = null;
+        order.OrderItems.Add(solutionOrderItem);
+        order.OrderItems.Add(associatedServiceOrderItem);
+
+        var expectedModel = new OrderTaskList
+        {
+            DescriptionStatus = TaskProgress.Completed,
+            OrderingPartyStatus = TaskProgress.Completed,
+            SupplierStatus = TaskProgress.Completed,
+            CommencementDateStatus = TaskProgress.Completed,
+            SolutionOrService = TaskProgress.InProgress,
+            FundingSource = TaskProgress.InProgress,
+            ImplementationPlan = TaskProgress.InProgress,
+            AssociatedServiceBilling = TaskProgress.InProgress,
+        };
+
+        var model = new OrderTaskList(order);
+
+        model.Should().BeEquivalentTo(expectedModel);
+    }
+
+    [Theory]
+    [CommonAutoData]
+    public static void Construct_AssociatedServiceBilling_ImplementationPlanNotCompleted(
+        string description,
+        Contact orderingPartyContact,
+        EntityFramework.Catalogue.Models.Supplier supplier,
+        Contact supplierContact,
+        DateTime commencementDate,
+        OrderItem solutionOrderItem,
+        Solution solution,
+        OrderItem associatedServiceOrderItem,
+        AssociatedService associatedService)
+    {
+        var order = new EntityFramework.Ordering.Models.Order
+        {
+            Description = description,
+            OrderingPartyContact = orderingPartyContact,
+            Supplier = supplier,
+            SupplierContact = supplierContact,
+            CommencementDate = commencementDate,
+        };
+
+        solutionOrderItem.CatalogueItem = solution.CatalogueItem;
+        associatedServiceOrderItem.CatalogueItem = associatedService.CatalogueItem;
+        order.OrderItems.Add(solutionOrderItem);
+        order.OrderItems.Add(associatedServiceOrderItem);
+
+        var expectedModel = new OrderTaskList
+        {
+            DescriptionStatus = TaskProgress.Completed,
+            OrderingPartyStatus = TaskProgress.Completed,
+            SupplierStatus = TaskProgress.Completed,
+            CommencementDateStatus = TaskProgress.Completed,
+            SolutionOrService = TaskProgress.Completed,
+            FundingSource = TaskProgress.Completed,
+            ImplementationPlan = TaskProgress.NotStarted,
+            AssociatedServiceBilling = TaskProgress.CannotStart,
+        };
+
+        var model = new OrderTaskList(order);
+
+        model.Should().BeEquivalentTo(expectedModel);
+    }
+
+    [Theory]
+    [CommonAutoData]
+    public static void Construct_AssociatedServiceBilling_InProgress(
+        string description,
+        Contact orderingPartyContact,
+        EntityFramework.Catalogue.Models.Supplier supplier,
+        Contact supplierContact,
+        DateTime commencementDate,
+        OrderItem solutionOrderItem,
+        Solution solution,
+        OrderItem associatedServiceOrderItem,
+        AssociatedService associatedService)
+    {
+        var order = new EntityFramework.Ordering.Models.Order
+        {
+            Description = description,
+            OrderingPartyContact = orderingPartyContact,
+            Supplier = supplier,
+            SupplierContact = supplierContact,
+            CommencementDate = commencementDate,
+            ContractFlags = new()
+            {
+                UseDefaultImplementationPlan = true,
+                UseDefaultBilling = true,
+            },
+        };
+
+        solutionOrderItem.CatalogueItem = solution.CatalogueItem;
+        associatedServiceOrderItem.CatalogueItem = associatedService.CatalogueItem;
+        order.OrderItems.Add(solutionOrderItem);
+        order.OrderItems.Add(associatedServiceOrderItem);
+
+        var expectedModel = new OrderTaskList
+        {
+            DescriptionStatus = TaskProgress.Completed,
+            OrderingPartyStatus = TaskProgress.Completed,
+            SupplierStatus = TaskProgress.Completed,
+            CommencementDateStatus = TaskProgress.Completed,
+            SolutionOrService = TaskProgress.Completed,
+            FundingSource = TaskProgress.Completed,
+            ImplementationPlan = TaskProgress.Completed,
+            AssociatedServiceBilling = TaskProgress.InProgress,
+        };
+
+        var model = new OrderTaskList(order);
+
+        model.Should().BeEquivalentTo(expectedModel);
+    }
+
+    [Theory]
+    [CommonAutoData]
     public static void Construct_DataProcessingPlan(
         string description,
         Contact orderingPartyContact,
@@ -497,6 +710,57 @@ public class OrderTaskListTests
             AssociatedServiceBilling = TaskProgress.NotApplicable,
             DataProcessingInformation = TaskProgress.Completed,
             ReviewAndCompleteStatus = TaskProgress.NotStarted,
+        };
+
+        var model = new OrderTaskList(order);
+
+        model.Should().BeEquivalentTo(expectedModel);
+    }
+
+    [Theory]
+    [CommonAutoData]
+    public static void Construct_DataProcessingPlan_InProgress(
+        string description,
+        Contact orderingPartyContact,
+        EntityFramework.Catalogue.Models.Supplier supplier,
+        Contact supplierContact,
+        DateTime commencementDate,
+        OrderItem solutionOrderItem,
+        Solution solution,
+        OrderItem additionalServiceOrderItem,
+        AdditionalService additionalService)
+    {
+        var order = new EntityFramework.Ordering.Models.Order
+        {
+            Description = description,
+            OrderingPartyContact = orderingPartyContact,
+            Supplier = supplier,
+            SupplierContact = supplierContact,
+            CommencementDate = commencementDate,
+            ContractFlags = new()
+            {
+                UseDefaultImplementationPlan = true,
+                UseDefaultDataProcessing = true,
+            },
+        };
+
+        solutionOrderItem.CatalogueItem = solution.CatalogueItem;
+        additionalServiceOrderItem.CatalogueItem = additionalService.CatalogueItem;
+        additionalServiceOrderItem.OrderItemFunding = null;
+        order.OrderItems.Add(solutionOrderItem);
+        order.OrderItems.Add(additionalServiceOrderItem);
+
+        var expectedModel = new OrderTaskList
+        {
+            DescriptionStatus = TaskProgress.Completed,
+            OrderingPartyStatus = TaskProgress.Completed,
+            SupplierStatus = TaskProgress.Completed,
+            CommencementDateStatus = TaskProgress.Completed,
+            SolutionOrService = TaskProgress.Completed,
+            FundingSource = TaskProgress.InProgress,
+            ImplementationPlan = TaskProgress.InProgress,
+            AssociatedServiceBilling = TaskProgress.NotApplicable,
+            DataProcessingInformation = TaskProgress.InProgress,
         };
 
         var model = new OrderTaskList(order);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/Order/OrderTaskListTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/Order/OrderTaskListTests.cs
@@ -4,6 +4,7 @@ using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
 using NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.AutoFixtureCustomisations;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Order.Models.Order;
 using Xunit;
 
@@ -567,6 +568,61 @@ public class OrderTaskListTests
             SupplierStatus = TaskProgress.Completed,
             CommencementDateStatus = TaskProgress.Completed,
             SolutionOrService = TaskProgress.InProgress,
+            FundingSource = TaskProgress.InProgress,
+            ImplementationPlan = TaskProgress.InProgress,
+            AssociatedServiceBilling = TaskProgress.InProgress,
+        };
+
+        var model = new OrderTaskList(order);
+
+        model.Should().BeEquivalentTo(expectedModel);
+    }
+
+    [Theory]
+    [CommonAutoData]
+    public static void Construct_AssociatedServiceBilling_FundingSourceInnProgress(
+        string description,
+        Contact orderingPartyContact,
+        EntityFramework.Catalogue.Models.Supplier supplier,
+        Contact supplierContact,
+        DateTime commencementDate,
+        OrderItem solutionOrderItem,
+        Solution solution,
+        OrderItem associatedServiceOrderItem,
+        AssociatedService associatedService,
+        OrderItem additionalServiceOrderItem,
+        AdditionalService additionalService)
+    {
+        var order = new EntityFramework.Ordering.Models.Order
+        {
+            Description = description,
+            OrderingPartyContact = orderingPartyContact,
+            Supplier = supplier,
+            SupplierContact = supplierContact,
+            CommencementDate = commencementDate,
+            ContractFlags = new()
+            {
+                UseDefaultImplementationPlan = true,
+                UseDefaultBilling = true,
+                HasSpecificRequirements = false,
+            },
+        };
+
+        solutionOrderItem.CatalogueItem = solution.CatalogueItem;
+        associatedServiceOrderItem.CatalogueItem = associatedService.CatalogueItem;
+        additionalServiceOrderItem.CatalogueItem = additionalService.CatalogueItem;
+        additionalServiceOrderItem.OrderItemFunding = null;
+        order.OrderItems.Add(solutionOrderItem);
+        order.OrderItems.Add(associatedServiceOrderItem);
+        order.OrderItems.Add(additionalServiceOrderItem);
+
+        var expectedModel = new OrderTaskList
+        {
+            DescriptionStatus = TaskProgress.Completed,
+            OrderingPartyStatus = TaskProgress.Completed,
+            SupplierStatus = TaskProgress.Completed,
+            CommencementDateStatus = TaskProgress.Completed,
+            SolutionOrService = TaskProgress.Completed,
             FundingSource = TaskProgress.InProgress,
             ImplementationPlan = TaskProgress.InProgress,
             AssociatedServiceBilling = TaskProgress.InProgress,


### PR DESCRIPTION
Amend the contracts and status logic so that

1. When a solution is changed, the contract is wiped
2. When the last associated service is removed, the associated service contract information is wiped
3. The steps in section 3 are set to In Progress if they have previously been populated and the preceding sections become "In Progress"