### PR TITLE
Update NHSD.GPITBuyingCatalogue.Database.sqlproj

### DIFF
--- a/database/NHSD.GPITBuyingCatalogue.Database/NHSD.GPITBuyingCatalogue.Database.sqlproj
+++ b/database/NHSD.GPITBuyingCatalogue.Database/NHSD.GPITBuyingCatalogue.Database.sqlproj
@@ -257,7 +257,7 @@
     <Build Include="Ordering\TemporalTables\ImplementationPlanAcceptanceCriteria_History.sql" />
     <Build Include="Ordering\Tables\ContractFlags.sql" />
     <Build Include="Ordering\TemporalTables\ContractFlags_History.sql" />
-    <Build Include="PostDeployment\InsertOrderTriageValues.sql" />
+    <None Include="PostDeployment\InsertOrderTriageValues.sql" />
     <Build Include="Users\Tables\EmailDomains.sql" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
set InsertOrderTriageValues.sql to not build since it's a post deployment script and shouldn't build with the application