### PR TITLE
Add Framework to PDF, CSV & admin dashboard

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Frameworks/IFrameworkService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Frameworks/IFrameworkService.cs
@@ -5,8 +5,6 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Frameworks
 {
     public interface IFrameworkService
     {
-        Task<Framework> GetFramework(int orderId);
-
         public Task<Framework> GetFramework(string frameworkId);
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Csv/CsvService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Csv/CsvService.cs
@@ -21,19 +21,15 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Csv
     public class CsvService : ICsvService
     {
         private readonly BuyingCatalogueDbContext dbContext;
-        private readonly IFrameworkService frameworkService;
 
-        public CsvService(BuyingCatalogueDbContext dbContext, IFrameworkService frameworkService)
+        public CsvService(BuyingCatalogueDbContext dbContext)
         {
             this.dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
-            this.frameworkService = frameworkService ?? throw new ArgumentNullException(nameof(frameworkService));
         }
 
         public async Task CreateFullOrderCsvAsync(int orderId, MemoryStream stream)
         {
             var billingPeriods = await GetBillingPeriods(orderId);
-            var framework = await frameworkService.GetFramework(orderId);
-            var frameworkId = framework?.Id ?? string.Empty;
             var fundingType = await GetFundingType(orderId);
             var prices = await GetPrices(orderId);
             var (supplierId, supplierName) = await GetSupplierDetails(orderId);
@@ -65,7 +61,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Csv
                     OrderType = (int)oir.OrderItem.OrderItemPrice.ProvisioningType,
                     M1Planned = oir.OrderItem.Order.CommencementDate,
                     FundingType = fundingType,
-                    Framework = frameworkId,
+                    Framework = oir.OrderItem.Order.SelectedFrameworkId,
                     InitialTerm = oir.OrderItem.Order.InitialPeriod,
                     MaximumTerm = oir.OrderItem.Order.MaximumTerm,
                 })
@@ -82,8 +78,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Csv
 
         public async Task<int> CreatePatientNumberCsvAsync(int orderId, MemoryStream stream)
         {
-            var framework = await frameworkService.GetFramework(orderId);
-            var frameworkId = framework?.Id ?? string.Empty;
             var fundingType = await GetFundingType(orderId);
             var prices = await GetPrices(orderId);
             var (supplierId, supplierName) = await GetSupplierDetails(orderId);
@@ -112,7 +106,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Csv
                     Price = prices[oir.OrderItem.CatalogueItemId],
                     FundingType = fundingType,
                     M1Planned = oir.OrderItem.Order.CommencementDate,
-                    Framework = frameworkId,
+                    Framework = oir.OrderItem.Order.SelectedFrameworkId,
                     InitialTerm = oir.OrderItem.Order.InitialPeriod,
                     MaximumTerm = oir.OrderItem.Order.MaximumTerm,
                 }).ToListAsync();

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Framework/FrameworkService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Framework/FrameworkService.cs
@@ -8,8 +8,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Framework
 {
     public class FrameworkService : IFrameworkService
     {
-        public const string CovidFrameworkId = "COVID";
-
         private readonly BuyingCatalogueDbContext dbContext;
 
         public FrameworkService(BuyingCatalogueDbContext dbContext)
@@ -18,30 +16,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Framework
         }
 
         public async Task<EntityFramework.Catalogue.Models.Framework> GetFramework(string frameworkId) =>
-            await dbContext.Frameworks.SingleOrDefaultAsync(f => f.Id == frameworkId);
-
-        public async Task<EntityFramework.Catalogue.Models.Framework> GetFramework(int orderId)
-        {
-            var order = await dbContext.Orders
-                .Include(x => x.OrderItems)
-                .ThenInclude(x => x.CatalogueItem)
-                .AsNoTracking()
-                .SingleOrDefaultAsync(x => x.Id == orderId);
-
-            var solutionId = order?.GetSolutionId();
-
-            if (solutionId == null)
-            {
-                return null;
-            }
-
-            var solution = await dbContext.FrameworkSolutions
-                .Include(x => x.Framework)
-                .AsNoTracking()
-                .FirstOrDefaultAsync(x => x.SolutionId == solutionId
-                    && x.FrameworkId != CovidFrameworkId);
-
-            return solution?.Framework;
-        }
+            await dbContext.Frameworks.FirstOrDefaultAsync(f => f.Id == frameworkId);
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/OrderAdminService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/OrderAdminService.cs
@@ -32,6 +32,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
                 .Include(o => o.LastUpdatedByUser)
                 .Include(o => o.OrderingParty)
                 .Include(o => o.Supplier)
+                .Include(o => o.SelectedFramework)
                 .Include(o => o.OrderItems).ThenInclude(oi => oi.CatalogueItem)
                 .Include(o => o.OrderItems).ThenInclude(oi => oi.OrderItemFunding)
                 .Include(o => o.OrderItems).ThenInclude(oi => oi.OrderItemPrice).ThenInclude(oip => oip.OrderItemPriceTiers)

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/OrderService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/OrderService.cs
@@ -140,6 +140,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
                 .Include(o => o.Supplier)
                 .Include(o => o.SupplierContact)
                 .Include(o => o.LastUpdatedByUser)
+                .Include(o => o.SelectedFramework)
                 .Include(o => o.OrderItems)
                     .ThenInclude(i => i.CatalogueItem)
                     .ThenInclude(ci => ci.Solution)

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsAddress/NhsAddressViewComponent.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsAddress/NhsAddressViewComponent.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 
-namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.Address
+namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsAddress
 {
     public sealed class NhsAddressViewComponent : ViewComponent
     {
@@ -16,31 +16,27 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.Addres
             if (address is null)
                 throw new ArgumentNullException(nameof(address));
 
-            return new HtmlString(ProcessAdressBreakRowSeperatedString(address));
+            return new HtmlString(ProcessAddressBreakRowSeperatedString(address));
         }
 
-        private static string ProcessAdressBreakRowSeperatedString(EntityFramework.Addresses.Models.Address address)
+        private static string ProcessAddressBreakRowSeperatedString(EntityFramework.Addresses.Models.Address address)
         {
             var addressProperties = address.GetType().GetProperties().Where(a => a.PropertyType == typeof(string));
 
-            List<string> values = new List<string>();
+            var values = addressProperties.Select(property => property.GetValue(address)?.ToString()).Where(propertyValue => !string.IsNullOrWhiteSpace(propertyValue)).ToList();
 
-            foreach (var property in addressProperties)
-            {
-                var propertyValue = property.GetValue(address)?.ToString();
-
-                if (!string.IsNullOrWhiteSpace(propertyValue))
-                    values.Add(propertyValue);
-            }
-
-            var builder = new TagBuilder("p");
+            var builder = new TagBuilder("span");
 
             var breakRow = new TagBuilder("br") { TagRenderMode = TagRenderMode.SelfClosing };
 
-            foreach (string value in values)
+            for (var i = 0; i < values.Count; i++)
             {
-                builder.InnerHtml.Append(value);
-                builder.InnerHtml.AppendHtml(breakRow);
+                var value = values[i];
+                builder.InnerHtml.Append(value!);
+                if (i < (values.Count - 1))
+                {
+                    builder.InnerHtml.AppendHtml(breakRow);
+                }
             }
 
             using var writer = new System.IO.StringWriter();

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/ManageOrdersController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/ManageOrdersController.cs
@@ -25,20 +25,17 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
     [Route("admin/manage-orders")]
     public class ManageOrdersController : Controller
     {
-        private readonly IFrameworkService frameworkService;
         private readonly IOrderAdminService orderAdminService;
         private readonly ICsvService csvService;
         private readonly IPdfService pdfService;
         private readonly PdfSettings pdfSettings;
 
         public ManageOrdersController(
-            IFrameworkService frameworkService,
             IOrderAdminService orderAdminService,
             ICsvService csvService,
             IPdfService pdfService,
             PdfSettings pdfSettings)
         {
-            this.frameworkService = frameworkService ?? throw new ArgumentNullException(nameof(frameworkService));
             this.orderAdminService = orderAdminService ?? throw new ArgumentNullException(nameof(orderAdminService));
             this.csvService = csvService ?? throw new ArgumentNullException(nameof(csvService));
             this.pdfService = pdfService ?? throw new ArgumentNullException(nameof(pdfService));
@@ -85,9 +82,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
         public async Task<IActionResult> ViewOrder(CallOffId callOffId, string returnUrl = null)
         {
             var order = await orderAdminService.GetOrder(callOffId);
-            var framework = await frameworkService.GetFramework(order?.Id ?? 0);
 
-            var model = new ViewOrderModel(order, framework)
+            var model = new ViewOrderModel(order)
             {
                 BackLink = returnUrl ?? Url.Action(nameof(Index)),
             };

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ManageOrders/AdminViewOrderItem.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ManageOrders/AdminViewOrderItem.cs
@@ -9,8 +9,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ManageOrders
 
         public CatalogueItemType Type { get; set; }
 
-        public string Framework { get; set; }
-
         public OrderItemFundingType SelectedFundingType { get; set; }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ManageOrders/ViewOrderModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ManageOrders/ViewOrderModel.cs
@@ -17,7 +17,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ManageOrders
             OrganisationInternalIdentifier = order.OrderingParty.InternalIdentifier;
             SupplierName = order.Supplier?.Name;
             OrderStatus = order.OrderStatus;
-            SelectedFrameworkName = order.SelectedFramework?.Name;
+            SelectedFrameworkName = order.SelectedFramework?.ShortName;
             OrderItems = order.OrderItems?.Select(oi => new AdminViewOrderItem
             {
                 Name = oi.CatalogueItem.Name,

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ManageOrders/ViewOrderModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ManageOrders/ViewOrderModel.cs
@@ -7,7 +7,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ManageOrders
 {
     public class ViewOrderModel : NavBaseModel
     {
-        public ViewOrderModel(EntityFramework.Ordering.Models.Order order, EntityFramework.Catalogue.Models.Framework framework)
+        public ViewOrderModel(EntityFramework.Ordering.Models.Order order)
         {
             CallOffId = order.CallOffId;
             Description = order.Description;
@@ -17,18 +17,20 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ManageOrders
             OrganisationInternalIdentifier = order.OrderingParty.InternalIdentifier;
             SupplierName = order.Supplier?.Name;
             OrderStatus = order.OrderStatus;
+            SelectedFrameworkName = order.SelectedFramework?.Name;
             OrderItems = order.OrderItems?.Select(oi => new AdminViewOrderItem
             {
                 Name = oi.CatalogueItem.Name,
                 Type = oi.CatalogueItem.CatalogueItemType,
                 SelectedFundingType = oi.FundingType,
-                Framework = framework?.ShortName ?? string.Empty,
             });
         }
 
         public CallOffId CallOffId { get; set; }
 
         public string OrganisationName { get; set; }
+
+        public string SelectedFrameworkName { get; set; }
 
         public string OrganisationInternalIdentifier { get; set; }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ManageOrders/ViewOrder.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ManageOrders/ViewOrder.cshtml
@@ -11,6 +11,13 @@
                     caption="@Model.CallOffId"
                     advice="View information about this order." />
     <nhs-summary-list>
+        @if (Model.SelectedFrameworkName is not null) {
+            <nhs-summary-list-row label-text="Framework">
+                <p data-test-id="view-order-framework">
+                    @Model.SelectedFrameworkName
+                </p>
+            </nhs-summary-list-row>
+        }
         <nhs-summary-list-row label-text="Organisation">
             <p data-test-id="view-order-organisation">
                 @Model.OrganisationName
@@ -72,9 +79,6 @@
                     Type of solution or service
                 </nhs-table-column>
                 <nhs-table-column>
-                    Solution framework
-                </nhs-table-column>
-                <nhs-table-column>
                     Funding type
                 </nhs-table-column>
                 @foreach (var orderItem in Model.OrderItems)
@@ -85,9 +89,6 @@
                         </nhs-table-cell>
                         <nhs-table-cell>
                             @orderItem.Type.AsString(EnumFormat.DisplayName)
-                        </nhs-table-cell>
-                        <nhs-table-cell>
-                            @orderItem.Framework
                         </nhs-table-cell>
                         <nhs-table-cell>
                             <span data-test-id="funding-type">@orderItem.SelectedFundingType.Description()</span>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
@@ -168,6 +168,13 @@
         @Model.Order.CallOffId
     </pdf-summary-list-row>
 
+    @if (Model.Order.SelectedFramework is not null)
+    {
+        <pdf-summary-list-row label-text="Framework">
+            @Model.Order.SelectedFramework.Name
+        </pdf-summary-list-row>
+    }
+
     <pdf-summary-list-row label-text="Description">
         @Model.Order.Description
     </pdf-summary-list-row>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
@@ -171,7 +171,7 @@
     @if (Model.Order.SelectedFramework is not null)
     {
         <pdf-summary-list-row label-text="Framework">
-            @Model.Order.SelectedFramework.Name
+            @Model.Order.SelectedFramework.ShortName
         </pdf-summary-list-row>
     }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
@@ -152,6 +152,10 @@
             font-weight: 600;
             width: 30%;
         }
+
+        .nhsuk-main-wrapper {
+            padding-top: 5px;
+        }
     </style>
 </head>
 <body class="nhsuk-bc-print">
@@ -160,8 +164,7 @@
 <div class="nhsuk-grid-row">
 <div class="nhsuk-grid-column-full">
 <nhs-page-title title="Order summary"
-                caption="@Model.Order.CallOffId"
-                advice="This is the information that has been added to this order." />
+                caption="Order @Model.Order.CallOffId"/>
 
 <pdf-summary-list>
     <pdf-summary-list-row label-text="Order ID">

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageOrders/ViewOrder.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageOrders/ViewOrder.cs
@@ -40,6 +40,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageOrders
             CommonActions.GoBackLinkDisplayed().Should().BeTrue();
             CommonActions.ContinueButtonDisplayed().Should().BeTrue();
 
+            CommonActions.ElementIsDisplayed(ViewOrderObjects.FrameworkSection).Should().BeTrue();
             CommonActions.ElementIsDisplayed(ViewOrderObjects.OrganisationSection).Should().BeTrue();
             CommonActions.ElementIsDisplayed(ViewOrderObjects.DescriptionSection).Should().BeTrue();
             CommonActions.ElementIsDisplayed(ViewOrderObjects.LastUpdatedBySection).Should().BeTrue();
@@ -52,6 +53,25 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageOrders
 
             CommonActions.ElementIsDisplayed(ViewOrderObjects.OrdersItemsTable).Should().BeTrue();
             CommonActions.ElementIsDisplayed(ViewOrderObjects.NoOrderItems).Should().BeFalse();
+        }
+
+        [Fact]
+        public void NoFramework()
+        {
+            var context = GetEndToEndDbContext();
+            var order = context.Orders.Include(o => o.SelectedFramework).First(o => o.Id == CallOffId.Id);
+            var frameworkId = order.SelectedFrameworkId;
+
+            order.SelectedFramework = null;
+
+            context.SaveChanges();
+
+            Driver.Navigate().Refresh();
+
+            CommonActions.ElementIsDisplayed(ViewOrderObjects.FrameworkSection).Should().BeFalse();
+
+            order.SelectedFrameworkId = frameworkId;
+            context.SaveChanges();
         }
 
         [Fact]

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/OrderSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/OrderSeedData.cs
@@ -1464,6 +1464,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
                     Email = "bat.man@Gotham.Fake",
                     Phone = "123456789",
                 },
+                SelectedFrameworkId = DFOCVC,
                 CommencementDate = timeNow.AddDays(1),
             };
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Objects/Admin/ManageOrders/ViewOrderObjects.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Objects/Admin/ManageOrders/ViewOrderObjects.cs
@@ -5,6 +5,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.Admin.ManageOrder
 {
     public static class ViewOrderObjects
     {
+        public static By FrameworkSection => ByExtensions.DataTestId("view-order-framework");
+
         public static By OrganisationSection => ByExtensions.DataTestId("view-order-organisation");
 
         public static By DescriptionSection => ByExtensions.DataTestId("view-order-description");

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Frameworks/FrameworkServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Frameworks/FrameworkServiceTests.cs
@@ -29,153 +29,15 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Frameworks
 
         [Theory]
         [InMemoryDbAutoData]
-        public static async Task GetFramework_NoOrderFound_ReturnsNull(FrameworkService service)
-        {
-            var result = await service.GetFramework(0);
-
-            result.Should().BeNull();
-        }
-
-        [Theory]
-        [InMemoryDbAutoData]
-        public static async Task GetFramework_NoSolutionId_ReturnsNull(
-            Order order,
-            [Frozen] BuyingCatalogueDbContext dbContext,
-            FrameworkService service)
-        {
-            order.AssociatedServicesOnly = false;
-            order.OrderItems.ForEach(x => x.CatalogueItem.CatalogueItemType = CatalogueItemType.AdditionalService);
-
-            dbContext.Orders.Add(order);
-
-            await dbContext.SaveChangesAsync();
-
-            var result = await service.GetFramework(order.Id);
-
-            result.Should().BeNull();
-        }
-
-        [Theory]
-        [InMemoryDbAutoData]
-        public static async Task GetFramework_NoSolutionId_AssociatedServicesOnly_ReturnsNull(
-            Order order,
-            [Frozen] BuyingCatalogueDbContext dbContext,
-            FrameworkService service)
-        {
-            order.AssociatedServicesOnly = true;
-            order.SolutionId = null;
-            order.OrderItems.ForEach(x => x.CatalogueItem.CatalogueItemType = CatalogueItemType.AssociatedService);
-
-            dbContext.Orders.Add(order);
-
-            await dbContext.SaveChangesAsync();
-
-            var result = await service.GetFramework(order.Id);
-
-            result.Should().BeNull();
-        }
-
-        [Theory]
-        [InMemoryDbAutoData]
-        public static async Task GetFramework_SolutionExists_CovidFrameworkOnly_ReturnsNull(
-            Order order,
-            [Frozen] BuyingCatalogueDbContext dbContext,
-            FrameworkService service)
-        {
-            order.AssociatedServicesOnly = false;
-            order.OrderItems.ForEach(x => x.CatalogueItem.CatalogueItemType = CatalogueItemType.AdditionalService);
-            order.OrderItems.First().CatalogueItem.CatalogueItemType = CatalogueItemType.Solution;
-
-            dbContext.Orders.Add(order);
-            dbContext.FrameworkSolutions.Add(new FrameworkSolution
-            {
-                SolutionId = order.OrderItems.First().CatalogueItemId,
-                FrameworkId = FrameworkService.CovidFrameworkId,
-            });
-
-            await dbContext.SaveChangesAsync();
-
-            var result = await service.GetFramework(order.Id);
-
-            result.Should().BeNull();
-        }
-
-        [Theory]
-        [InMemoryDbAutoData]
-        public static async Task GetFramework_SolutionExists_CovidFrameworkOnly_AssociatedServicesOnly_ReturnsNull(
-            Order order,
-            CatalogueItemId solutionId,
-            [Frozen] BuyingCatalogueDbContext dbContext,
-            FrameworkService service)
-        {
-            order.AssociatedServicesOnly = true;
-            order.OrderItems.ForEach(x => x.CatalogueItem.CatalogueItemType = CatalogueItemType.AssociatedService);
-            order.SolutionId = solutionId;
-
-            dbContext.Orders.Add(order);
-            dbContext.FrameworkSolutions.Add(new FrameworkSolution
-            {
-                SolutionId = solutionId,
-                FrameworkId = FrameworkService.CovidFrameworkId,
-            });
-
-            await dbContext.SaveChangesAsync();
-
-            var result = await service.GetFramework(order.Id);
-
-            result.Should().BeNull();
-        }
-
-        [Theory]
-        [InMemoryDbAutoData]
-        public static async Task GetFramework_SolutionExists_ReturnsExpectedResult(
-            Order order,
+        public static async Task GetFramework_ReturnsExpected(
             EntityFramework.Catalogue.Models.Framework framework,
             [Frozen] BuyingCatalogueDbContext dbContext,
             FrameworkService service)
         {
-            order.AssociatedServicesOnly = false;
-            order.OrderItems.ForEach(x => x.CatalogueItem.CatalogueItemType = CatalogueItemType.AdditionalService);
-            order.OrderItems.First().CatalogueItem.CatalogueItemType = CatalogueItemType.Solution;
-
-            dbContext.Orders.Add(order);
             dbContext.Frameworks.Add(framework);
-            dbContext.FrameworkSolutions.Add(new FrameworkSolution
-            {
-                SolutionId = order.OrderItems.First().CatalogueItemId,
-                FrameworkId = framework.Id,
-            });
-
             await dbContext.SaveChangesAsync();
 
-            var result = await service.GetFramework(order.Id);
-
-            result.Should().BeEquivalentTo(framework);
-        }
-
-        [Theory]
-        [InMemoryDbAutoData]
-        public static async Task GetFramework_SolutionExists_AssociatedServicesOnly_ReturnsExpectedResult(
-            Order order,
-            EntityFramework.Catalogue.Models.Framework framework,
-            [Frozen] BuyingCatalogueDbContext dbContext,
-            FrameworkService service)
-        {
-            order.AssociatedServicesOnly = true;
-            order.OrderItems.ForEach(x => x.CatalogueItem.CatalogueItemType = CatalogueItemType.AssociatedService);
-            order.SolutionId = order.Solution.Id;
-
-            dbContext.Orders.Add(order);
-            dbContext.Frameworks.Add(framework);
-            dbContext.FrameworkSolutions.Add(new FrameworkSolution
-            {
-                SolutionId = order.SolutionId.Value,
-                FrameworkId = framework.Id,
-            });
-
-            await dbContext.SaveChangesAsync();
-
-            var result = await service.GetFramework(order.Id);
+            var result = await service.GetFramework(framework.Id);
 
             result.Should().BeEquivalentTo(framework);
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.UI.Components.UnitTests/View Components/AddressComponentTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.UI.Components.UnitTests/View Components/AddressComponentTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Microsoft.AspNetCore.Html;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Addresses.Models;
-using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.Address;
+using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsAddress;
 using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.UI.Components.UnitTests.View_Components
@@ -16,7 +16,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.UnitTests.View_Components
                 ViewComponentContext = ViewComponentContextSetup.GetViewComponentContext(),
             };
 
-            const string expectedResult = "<p>1 John Street<br />Test Area<br />TestingTon<br />County Test<br />T3ST 3ST<br />United Kingdom<br /></p>";
+            const string expectedResult = "<span>1 John Street<br />Test Area<br />TestingTon<br />County Test<br />T3ST 3ST<br />United Kingdom</span>";
 
             var model = new Address
             {
@@ -45,7 +45,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.UnitTests.View_Components
                 ViewComponentContext = ViewComponentContextSetup.GetViewComponentContext(),
             };
 
-            const string expectedResult = "<p></p>";
+            const string expectedResult = "<span></span>";
 
             var model = new Address();
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/ManageOrdersControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/ManageOrdersControllerTests.cs
@@ -70,7 +70,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             EntityFramework.Ordering.Models.Order order,
             EntityFramework.Catalogue.Models.Framework framework,
             [Frozen] Mock<IOrderAdminService> orderAdminService,
-            [Frozen] Mock<IFrameworkService> mockFrameworkService,
             ManageOrdersController controller)
         {
             solution.FrameworkSolutions = frameworkSolutions;
@@ -82,17 +81,14 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             order.OrderingParty = organisation;
             order.LastUpdatedByUser = user;
             order.Supplier = supplier;
+            order.SelectedFramework = framework;
 
             orderAdminService.Setup(s => s.GetOrder(order.CallOffId))
                 .ReturnsAsync(order);
 
-            mockFrameworkService
-                .Setup(x => x.GetFramework(order.Id))
-                .ReturnsAsync(framework);
-
             var result = (await controller.ViewOrder(order.CallOffId)).As<ViewResult>();
 
-            var expected = new ViewOrderModel(order, framework);
+            var expected = new ViewOrderModel(order);
 
             result.Should().NotBeNull();
             result.Model.Should().BeEquivalentTo(expected, opt => opt.Excluding(m => m.BackLink));

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/ManageOrders/ViewOrderModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/ManageOrders/ViewOrderModelTests.cs
@@ -37,7 +37,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.ManageOr
             model.OrganisationInternalIdentifier.Should().Be(order.OrderingParty.InternalIdentifier);
             model.SupplierName.Should().Be(order.Supplier.Name);
             model.OrderStatus.Should().Be(order.OrderStatus);
-            model.SelectedFrameworkName.Should().Be(order.SelectedFramework.Name);
+            model.SelectedFrameworkName.Should().Be(order.SelectedFramework.ShortName);
             model.OrderItems.Should().HaveCount(orderItems.Count);
         }
     }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/ManageOrders/ViewOrderModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/ManageOrders/ViewOrderModelTests.cs
@@ -14,59 +14,31 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.ManageOr
     {
         [Theory]
         [CommonAutoData]
-        public static void Construct_WithOrderItems_DerivesFrameworkFromSolution(
-            AspNetUser user,
-            Organisation orderingParty,
+        public static void Construct_MapsCorrectly(
+            Organisation organisation,
+            AspNetUser lastUpdatedBy,
             Supplier supplier,
-            Solution solution,
-            AssociatedService associatedService,
-            AdditionalService additionalService,
             EntityFramework.Catalogue.Models.Framework framework,
+            List<OrderItem> orderItems,
             EntityFramework.Ordering.Models.Order order)
         {
-            var orderItems = new List<OrderItem>
-            {
-                new() { CatalogueItem = solution.CatalogueItem },
-                new() { CatalogueItem = associatedService.CatalogueItem },
-                new() { CatalogueItem = additionalService.CatalogueItem },
-            };
-
-            orderItems.ForEach(oi => order.OrderItems.Add(oi));
-
-            order.LastUpdatedByUser = user;
-            order.OrderingParty = orderingParty;
+            order.LastUpdatedByUser = lastUpdatedBy;
+            order.OrderingParty = organisation;
             order.Supplier = supplier;
+            order.SelectedFramework = framework;
+            order.OrderItems = orderItems;
+            var model = new ViewOrderModel(order);
 
-            var model = new ViewOrderModel(order, framework);
-
-            model.OrderItems.Should().AllSatisfy(oi => oi.Framework.Should().Be(framework.ShortName));
-        }
-
-        [Theory]
-        [CommonAutoData]
-        public static void Construct_WithNoSolution_EmptyFrameworkName(
-            AspNetUser user,
-            Organisation orderingParty,
-            Supplier supplier,
-            AssociatedService associatedService,
-            AdditionalService additionalService,
-            EntityFramework.Ordering.Models.Order order)
-        {
-            var orderItems = new List<OrderItem>
-            {
-                new() { CatalogueItem = associatedService.CatalogueItem },
-                new() { CatalogueItem = additionalService.CatalogueItem },
-            };
-
-            orderItems.ForEach(oi => order.OrderItems.Add(oi));
-
-            order.LastUpdatedByUser = user;
-            order.OrderingParty = orderingParty;
-            order.Supplier = supplier;
-
-            var model = new ViewOrderModel(order, null);
-
-            model.OrderItems.Should().AllSatisfy(oi => oi.Framework.Should().Be(string.Empty));
+            model.CallOffId.Should().Be(order.CallOffId);
+            model.Description.Should().Be(order.Description);
+            model.LastUpdatedBy.Should().Be(order.LastUpdatedByUser.FullName);
+            model.OrganisationName.Should().Be(order.OrderingParty.Name);
+            model.OrganisationExternalIdentifier.Should().Be(order.OrderingParty.ExternalIdentifier);
+            model.OrganisationInternalIdentifier.Should().Be(order.OrderingParty.InternalIdentifier);
+            model.SupplierName.Should().Be(order.Supplier.Name);
+            model.OrderStatus.Should().Be(order.OrderStatus);
+            model.SelectedFrameworkName.Should().Be(order.SelectedFramework.Name);
+            model.OrderItems.Should().HaveCount(orderItems.Count);
         }
     }
 }


### PR DESCRIPTION
Adds the Selected Framework to the PDF, CSV & the admin View Order page.

I've also removed the `GetFramework` method as it was no longer necessary, and added some tests that were missing from #913 