### PR TITLE
Hardcode dotnet version to 7.0.1xx

### DIFF
--- a/NHSD.GPIT.BuyingCatalogue.sln
+++ b/NHSD.GPIT.BuyingCatalogue.sln
@@ -15,6 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		NHSD.GPIT.BuyingCatalogue.sln.DotSettings = NHSD.GPIT.BuyingCatalogue.sln.DotSettings
 		NuGet.config = NuGet.config
 		README.md = README.md
+		global.json = global.json
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{885B7CFA-DB1B-4D95-9943-CDDDDCBED5A3}"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ variables:
   - name: dockerVersion
     value: '19.03.5'
   - name: dotnetVersion
-    value: '7.0.x'
+    value: '7.0.102'
   - name: MSBUILDSINGLELOADCONTEXT
     value: '1'
   - name: buildConfiguration

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "7.0.0",
-    "rollForward": "latestMinor",
+    "version": "7.0.102",
+    "rollForward": "latestPatch",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
.NET version 7.0.200 has a bug, or a breaking change, whereby the backlink component doesn't function correctly.

For now this is hardcoded to 7.0.1xx. In the meantime we'll investigate why 7.0.200 is causing problems and determine whether we should skip that version.