### PR TITLE
Amend order review

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/EndDate.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/EndDate.cs
@@ -2,11 +2,9 @@
 
 namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
 {
-    public record EndDate(DateTime? CommencementDate, int? MaximumTerm, OrderTriageValue? TriageValue = null)
+    public record EndDate(DateTime? CommencementDate, int? MaximumTerm)
     {
-        public const int MaximumTermForOnOffCatalogueOrders = 48;
-
-        public DateTime? Value
+        public DateTime? DateTime
         {
             get
             {
@@ -14,46 +12,25 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
                     || MaximumTerm == null)
                     return null;
 
-                return TriageValue switch
-                {
-                    // direct Award
-                    null or OrderTriageValue.Under40K => CommencementDate?.AddMonths(MaximumTerm.Value).AddDays(-1),
-
-                    // on/off
-                    _ => (DateTime?)CommencementDate.Value.AddMonths(MaximumTermForOnOffCatalogueOrders).AddDays(-1),
-                };
+                return CommencementDate.Value.AddMonths(MaximumTerm.Value).AddDays(-1);
             }
         }
 
-        public string DisplayValue => Value.HasValue ? $"{Value:d MMMM yyyy}" : string.Empty;
+        public string DisplayValue => DateTime.HasValue ? $"{DateTime:d MMMM yyyy}" : string.Empty;
 
         public decimal RemainingTerm(DateTime plannedDelivery)
         {
-            if (!Value.HasValue)
+            if (!DateTime.HasValue)
             {
                 throw new InvalidOperationException("A known end date is required to calculate the remaining term");
             }
 
-            var remainingMonths = Math.Max(0, RemainingMonths(plannedDelivery));
-
-            return TriageValue switch
-            {
-                // direct Award
-                null or OrderTriageValue.Under40K => remainingMonths,
-
-                // on/off
-                _ => Math.Min(remainingMonths, MaximumTerm.Value),
-            };
+            return Math.Max(0, DifferenceInMonths(plannedDelivery, DateTime.Value.AddDays(1)));
         }
 
-        private decimal RemainingMonths(DateTime plannedDelivery)
+        private decimal DifferenceInMonths(DateTime plannedDelivery, DateTime endDate)
         {
-            if (!Value.HasValue)
-                return 0;
-
-            var endDate = Value?.AddDays(1);
-
-            return ((endDate?.Year - plannedDelivery.Year) * 12) + endDate?.Month - plannedDelivery.Month ?? 0;
+            return ((endDate.Year - plannedDelivery.Year) * 12) + (endDate.Month - plannedDelivery.Month);
         }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/EndDate.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/EndDate.cs
@@ -1,0 +1,59 @@
+﻿using System;
+
+namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
+{
+    public record EndDate(DateTime? CommencementDate, int? MaximumTerm, OrderTriageValue? TriageValue = null)
+    {
+        public const int MaximumTermForOnOffCatalogueOrders = 48;
+
+        public DateTime? Value
+        {
+            get
+            {
+                if (CommencementDate == null
+                    || MaximumTerm == null)
+                    return null;
+
+                return TriageValue switch
+                {
+                    // direct Award
+                    null or OrderTriageValue.Under40K => CommencementDate?.AddMonths(MaximumTerm.Value).AddDays(-1),
+
+                    // on/off
+                    _ => (DateTime?)CommencementDate.Value.AddMonths(MaximumTermForOnOffCatalogueOrders).AddDays(-1),
+                };
+            }
+        }
+
+        public string DisplayValue => Value.HasValue ? $"{Value:d MMMM yyyy}" : string.Empty;
+
+        public decimal RemainingTerm(DateTime plannedDelivery)
+        {
+            if (!Value.HasValue)
+            {
+                throw new InvalidOperationException("A known end date is required to calculate the remaining term");
+            }
+
+            var remainingMonths = Math.Max(0, RemainingMonths(plannedDelivery));
+
+            return TriageValue switch
+            {
+                // direct Award
+                null or OrderTriageValue.Under40K => remainingMonths,
+
+                // on/off
+                _ => Math.Min(remainingMonths, MaximumTerm.Value),
+            };
+        }
+
+        private decimal RemainingMonths(DateTime plannedDelivery)
+        {
+            if (!Value.HasValue)
+                return 0;
+
+            var endDate = Value?.AddDays(1);
+
+            return ((endDate?.Year - plannedDelivery.Year) * 12) + endDate?.Month - plannedDelivery.Month ?? 0;
+        }
+    }
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/Order.Custom.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/Order.Custom.cs
@@ -33,9 +33,9 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
             }
         }
 
-        public string EndDate => CommencementDate.HasValue && MaximumTerm.HasValue
-            ? $"{CommencementDate?.AddMonths(MaximumTerm.Value).AddDays(-1):d MMMM yyyy}"
-            : string.Empty;
+        public string EndDateDisplayValue => new EndDate(CommencementDate, MaximumTerm).DisplayValue;
+
+        public EndDate EndDate => new EndDate(CommencementDate, MaximumTerm, OrderTriageValue);
 
         public bool IsAmendment => CallOffId.IsAmendment;
 
@@ -228,6 +228,26 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
             var output = JsonConvert.DeserializeObject<Order>(serialised, outputSettings);
 
             return output;
+        }
+
+        public Order BuidAmendment(int newRevision)
+        {
+            return new Order
+            {
+                OrderNumber = OrderNumber,
+                Revision = newRevision,
+                AssociatedServicesOnly = AssociatedServicesOnly,
+                CommencementDate = CommencementDate,
+                Description = Description,
+                InitialPeriod = InitialPeriod,
+                MaximumTerm = MaximumTerm,
+                OrderingPartyId = OrderingPartyId,
+                OrderingPartyContact = OrderingPartyContact.Clone(),
+                OrderTriageValue = OrderTriageValue,
+                SelectedFrameworkId = SelectedFrameworkId,
+                SupplierId = SupplierId,
+                SupplierContact = SupplierContact.Clone(),
+            };
         }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/Order.Custom.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/Order.Custom.cs
@@ -33,9 +33,7 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
             }
         }
 
-        public string EndDateDisplayValue => new EndDate(CommencementDate, MaximumTerm).DisplayValue;
-
-        public EndDate EndDate => new EndDate(CommencementDate, MaximumTerm, OrderTriageValue);
+        public EndDate EndDate => new EndDate(CommencementDate, MaximumTerm);
 
         public bool IsAmendment => CallOffId.IsAmendment;
 

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/OrderItemPrice.Custom.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/OrderItemPrice.Custom.cs
@@ -35,6 +35,26 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
             }
         }
 
+        public OrderItemPrice(OrderItemPrice existingPrice)
+            : this()
+        {
+            CatalogueItemId = existingPrice.CatalogueItemId;
+            CataloguePriceId = existingPrice.CataloguePriceId;
+            ProvisioningType = existingPrice.ProvisioningType;
+            CataloguePriceType = existingPrice.CataloguePriceType;
+            CataloguePriceCalculationType = existingPrice.CataloguePriceCalculationType;
+            BillingPeriod = existingPrice.BillingPeriod;
+            CataloguePriceQuantityCalculationType = existingPrice.CataloguePriceQuantityCalculationType;
+            CurrencyCode = existingPrice.CurrencyCode;
+            Description = existingPrice.Description;
+            RangeDescription = existingPrice.RangeDescription;
+
+            foreach (var tier in existingPrice.OrderItemPriceTiers)
+            {
+                OrderItemPriceTiers.Add(new OrderItemPriceTier(this, tier));
+            }
+        }
+
         public ICollection<IPriceTier> PriceTiers => OrderItemPriceTiers.Cast<IPriceTier>().ToList();
 
         public string ToPriceUnitString()

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/OrderItemPriceTier.Custom.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/OrderItemPriceTier.Custom.cs
@@ -15,6 +15,17 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
             OrderItemPrice = price;
         }
 
+        public OrderItemPriceTier(OrderItemPrice price, OrderItemPriceTier tier)
+        {
+            OrderId = price.OrderId;
+            CatalogueItemId = price.CatalogueItemId;
+            Price = tier.Price;
+            ListPrice = tier.Price;
+            LowerRange = tier.LowerRange;
+            UpperRange = tier.UpperRange;
+            OrderItemPrice = price;
+        }
+
         public string GetRangeDescription()
         {
             var upperRange = UpperRange == null

--- a/src/NHSD.GPIT.BuyingCatalogue.Framework/Calculations/CataloguePriceCalculations.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Framework/Calculations/CataloguePriceCalculations.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Interfaces;
@@ -70,33 +71,68 @@ namespace NHSD.GPIT.BuyingCatalogue.Framework.Calculations
                 : CalculateCostPerMonth(price, quantity) * maxTerm;
         }
 
-        public static decimal TotalOneOffCost(this Order order)
+        public static decimal TotalOneOffCost(this Order order, bool roundResult = false)
         {
-            return order?.OrderItems.Sum(x => x.OrderItemPrice.CalculateOneOffCost(x.TotalQuantity)) ?? decimal.Zero;
+            var total = order?.OrderItems.Sum(x => x.OrderItemPrice.CalculateOneOffCost(x.TotalQuantity)) ?? decimal.Zero;
+
+            if (roundResult)
+            {
+                total = Math.Round(total, 2, MidpointRounding.AwayFromZero);
+            }
+
+            return total;
         }
 
-        public static decimal TotalMonthlyCost(this Order order)
+        public static decimal TotalMonthlyCost(this Order order, bool roundResult = false)
         {
-            return order?.OrderItems.Sum(x => x.OrderItemPrice.CalculateCostPerMonth(x.TotalQuantity)) ?? decimal.Zero;
+            var total = order?.OrderItems.Sum(x => x.OrderItemPrice.CalculateCostPerMonth(x.TotalQuantity)) ?? decimal.Zero;
+
+            if (roundResult)
+            {
+                total = Math.Round(total, 2, MidpointRounding.AwayFromZero);
+            }
+
+            return total;
         }
 
-        public static decimal TotalAnnualCost(this Order order)
+        public static decimal TotalAnnualCost(this Order order, bool roundResult = false)
         {
-            return order?.OrderItems.Sum(x => x.OrderItemPrice.CalculateCostPerYear(x.TotalQuantity)) ?? decimal.Zero;
+            var total = order?.OrderItems.Sum(x => x.OrderItemPrice.CalculateCostPerYear(x.TotalQuantity)) ?? decimal.Zero;
+
+            if (roundResult)
+            {
+                total = Math.Round(total, 2, MidpointRounding.AwayFromZero);
+            }
+
+            return total;
         }
 
-        public static decimal TotalCost(this Order order)
+        public static decimal TotalCost(this Order order, bool roundResult = false)
         {
             var maximumTerm = order?.MaximumTerm ?? 36;
 
-            return order.TotalOneOffCost()
+            var total = order.TotalOneOffCost()
                 + (order.TotalMonthlyCost() * maximumTerm);
+
+            if (roundResult)
+            {
+                total = Math.Round(total, 2, MidpointRounding.AwayFromZero);
+            }
+
+            return total;
         }
 
-        public static decimal TotalCost(this OrderWrapper orderWrapper)
+        public static decimal TotalCost(this OrderWrapper orderWrapper, bool roundResult = false)
         {
-            return (orderWrapper?.Previous?.TotalCost() ?? 0)
+            var total = (orderWrapper?.Previous?.TotalCost() ?? 0)
                 + (orderWrapper?.Order?.TotalCostForAmendment() ?? 0);
+
+            if (roundResult)
+            {
+                total = Math.Round(total, 2, MidpointRounding.AwayFromZero);
+            }
+
+            return total;
         }
 
         public static decimal TotalCost(this OrderItem orderItem)

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/OrderService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/OrderService.cs
@@ -315,22 +315,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
         {
             var order = (await GetOrderForSummary(callOffId, internalOrgId)).Order;
 
-            var amendment = new Order
-            {
-                OrderNumber = order.OrderNumber,
-                Revision = await dbContext.NextRevision(order.OrderNumber),
-                AssociatedServicesOnly = order.AssociatedServicesOnly,
-                CommencementDate = order.CommencementDate,
-                Description = order.Description,
-                InitialPeriod = order.InitialPeriod,
-                MaximumTerm = order.MaximumTerm,
-                OrderingPartyId = order.OrderingPartyId,
-                OrderingPartyContact = order.OrderingPartyContact.Clone(),
-                OrderTriageValue = order.OrderTriageValue,
-                SelectedFrameworkId = order.SelectedFrameworkId,
-                SupplierId = order.SupplierId,
-                SupplierContact = order.SupplierContact.Clone(),
-            };
+            var amendment = order.BuidAmendment(await dbContext.NextRevision(order.OrderNumber));
 
             dbContext.Add(amendment);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/DetailsAndExpander/DetailsAndExpanderTagHelperBuilders.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/DetailsAndExpander/DetailsAndExpanderTagHelperBuilders.cs
@@ -14,6 +14,9 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Detail
         private const string DetailsSummaryTextLetterClass = "nhsuk-details__summary-text__letter";
         private const string DetailsTextClass = "nhsuk-details__text";
         private const string SummaryTextSecondaryClass = "nhsuk-details__summary-text_secondary";
+        private const string TagTopLevelClass = "bc-c-task-list__task-status";
+        private const string TagClass = "nhsuk-tag";
+        private const string TagColourClass = "nhsuk-tag--blue";
         private const string VisuallyHidden = "nhsuk-u-visually-hidden";
 
         public static TagBuilder GetTextItem()
@@ -24,7 +27,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Detail
             return builder;
         }
 
-        public static TagBuilder GetSummaryLabelBuilder(string headingText, string labelText, bool bold)
+        public static TagBuilder GetSummaryLabelBuilder(string headingText, string labelText, bool bold, bool addedSticker = false)
         {
             var summaryBuilder = new TagBuilder("summary");
             summaryBuilder.AddCssClass(DetailsSummaryClass);
@@ -52,16 +55,26 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Detail
             var spanBuilder = new TagBuilder(TagHelperConstants.Span);
             spanBuilder.AddCssClass(DetailsSummaryTextClass);
 
+            if (addedSticker)
+            {
+                spanBuilder.InnerHtml.AppendHtml(GetAddedStickerBuilder());
+            }
+
             if (bold)
             {
                 var boldBuilder = new TagBuilder("b");
+
                 boldBuilder.InnerHtml.Append(labelText);
+                boldBuilder.InnerHtml.AppendHtml("&nbsp");
+                boldBuilder.InnerHtml.AppendHtml("&nbsp");
 
                 spanBuilder.InnerHtml.AppendHtml(boldBuilder);
             }
             else
             {
                 spanBuilder.InnerHtml.Append(labelText);
+                spanBuilder.InnerHtml.AppendHtml("&nbsp");
+                spanBuilder.InnerHtml.AppendHtml("&nbsp");
             }
 
             if (!string.IsNullOrWhiteSpace(headingText))
@@ -78,7 +91,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Detail
             return summaryBuilder;
         }
 
-        public static TagBuilder GetSummaryLabelBuilderWithSecondaryInformation(string labelText, string secondaryTextTite, string secondaryText, bool bold)
+        public static TagBuilder GetSummaryLabelBuilderWithSecondaryInformation(string labelText, string secondaryTextTitle, string secondaryText, bool bold, bool addedSticker = false)
         {
             var summaryBuilder = new TagBuilder("summary");
             summaryBuilder.AddCssClass(DetailsSummaryClass);
@@ -86,23 +99,33 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Detail
             var labelSpanBuilder = new TagBuilder(TagHelperConstants.Span);
             labelSpanBuilder.AddCssClass(DetailsSummaryTextClass);
 
+            if (addedSticker)
+            {
+                labelSpanBuilder.InnerHtml.AppendHtml(GetAddedStickerBuilder());
+            }
+
             if (bold)
             {
                 var boldBuilder = new TagBuilder("b");
+
                 boldBuilder.InnerHtml.Append(labelText);
+                boldBuilder.InnerHtml.AppendHtml("&nbsp");
+                boldBuilder.InnerHtml.AppendHtml("&nbsp");
 
                 labelSpanBuilder.InnerHtml.AppendHtml(boldBuilder);
             }
             else
             {
                 labelSpanBuilder.InnerHtml.Append(labelText);
+                labelSpanBuilder.InnerHtml.AppendHtml("&nbsp");
+                labelSpanBuilder.InnerHtml.AppendHtml("&nbsp");
             }
 
             var secondarySpanBuilder = new TagBuilder(TagHelperConstants.Span);
             secondarySpanBuilder.AddCssClass(SummaryTextSecondaryClass);
 
             var secondaryTitleBuilder = new TagBuilder("b");
-            secondaryTitleBuilder.InnerHtml.Append(secondaryTextTite);
+            secondaryTitleBuilder.InnerHtml.Append(secondaryTextTitle);
 
             secondarySpanBuilder.InnerHtml
                 .AppendHtml(secondaryTitleBuilder)
@@ -113,6 +136,23 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Detail
                 .AppendHtml(secondarySpanBuilder);
 
             return summaryBuilder;
+        }
+
+        private static TagBuilder GetAddedStickerBuilder()
+        {
+            var output = new TagBuilder(TagHelperConstants.Div);
+
+            output.AddCssClass(TagTopLevelClass);
+
+            var inner = new TagBuilder(TagHelperConstants.Strong);
+
+            inner.AddCssClass(TagClass);
+            inner.AddCssClass(TagColourClass);
+            inner.InnerHtml.Append("Added");
+
+            output.InnerHtml.AppendHtml(inner);
+
+            return output;
         }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/DetailsAndExpander/ExpanderTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/DetailsAndExpander/ExpanderTagHelper.cs
@@ -9,6 +9,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Detail
     public sealed class ExpanderTagHelper : TagHelper
     {
         public const string TagHelperName = "nhs-expander";
+        public const string AddedStickerName = "added-sticker";
         public const string ColourModeName = "colour-mode";
         public const string SecondaryTextTitleName = "secondary-text-title";
         public const string SecondaryTextName = "secondary-text";
@@ -29,6 +30,9 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Detail
 
         [HtmlAttributeName(TagHelperConstants.LabelTextName)]
         public string LabelText { get; set; }
+
+        [HtmlAttributeName(AddedStickerName)]
+        public bool AddedSticker { get; set; }
 
         [HtmlAttributeName(ColourModeName)]
         public ExpanderColourMode ColourMode { get; set; }
@@ -60,8 +64,8 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Detail
             output.TagMode = TagMode.StartTagAndEndTag;
 
             var summary = string.IsNullOrWhiteSpace(SecondaryTextTitle)
-                ? DetailsAndExpanderTagHelperBuilders.GetSummaryLabelBuilder(HeadingText, LabelText, BoldTitle)
-                : DetailsAndExpanderTagHelperBuilders.GetSummaryLabelBuilderWithSecondaryInformation(LabelText, SecondaryTextTitle, SecondaryText, BoldTitle);
+                ? DetailsAndExpanderTagHelperBuilders.GetSummaryLabelBuilder(HeadingText, LabelText, BoldTitle, AddedSticker)
+                : DetailsAndExpanderTagHelperBuilders.GetSummaryLabelBuilderWithSecondaryInformation(LabelText, SecondaryTextTitle, SecondaryText, BoldTitle, AddedSticker);
 
             var textItem = DetailsAndExpanderTagHelperBuilders.GetTextItem();
 

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Helpers/TagHelperConstants.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Helpers/TagHelperConstants.cs
@@ -21,6 +21,7 @@
         internal const string Input = "input";
         internal const string Nav = "nav";
         internal const string Script = "script";
+        internal const string Strong = "strong";
 
         /* Attributes*/
         internal const string For = "asp-for";

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Table/TableCellTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Table/TableCellTagHelper.cs
@@ -13,7 +13,12 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Table
 
         private const string CellRole = "cell";
         private const string CellClass = "nhsuk-table__cell";
+        private const string CellClassNumeric = "nhsuk-table__cell--numeric";
         private const string HeadingClass = "nhsuk-table-responsive__heading";
+        private const string NumericName = "numeric";
+
+        [HtmlAttributeName(NumericName)]
+        public bool Numeric { get; set; }
 
         public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
@@ -21,7 +26,14 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Table
             output.TagMode = TagMode.StartTagAndEndTag;
 
             output.Attributes.Add(new TagHelperAttribute(TagHelperConstants.Role, CellRole));
-            output.Attributes.Add(new TagHelperAttribute(TagHelperConstants.Class, CellClass));
+            if (Numeric)
+            {
+                output.Attributes.Add(new TagHelperAttribute(TagHelperConstants.Class, CellClassNumeric));
+            }
+            else
+            {
+                output.Attributes.Add(new TagHelperAttribute(TagHelperConstants.Class, CellClass));
+            }
 
             var heading = GetHeadingBuilder(context);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Table/TableColumnTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Table/TableColumnTagHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers;
 
@@ -10,16 +11,21 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Table
     {
         public const string TagHelperName = "nhs-table-column";
 
+        private const string NumericName = "numeric";
+
+        [HtmlAttributeName(NumericName)]
+        public bool Numeric { get; set; }
+
         public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             output.SuppressOutput();
 
             var childContent = await output.GetChildContentAsync();
 
-            if (context.Items[TagHelperConstants.ColumnNameContextName] is not List<TagHelperContent> columnNames)
+            if (context.Items[TagHelperConstants.ColumnNameContextName] is not List<(TagHelperContent, bool)> columns)
                 return;
 
-            columnNames.Add(childContent);
+            columns.Add((childContent, Numeric));
         }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Table/TableContainerTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Table/TableContainerTagHelper.cs
@@ -26,6 +26,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Table
         private const string HeaderRowRole = "row";
         private const string HeaderRowColumnRole = "columnheader";
         private const string HeaderRowColumnScope = "col";
+        private const string HeadingClassNumeric = "nhsuk-table__header--numeric";
 
         private ParentChildContext parentChildContext;
 
@@ -41,8 +42,6 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Table
         [HtmlAttributeName(CatchErrorsName)]
         public bool CatchesErrors { get; set; } = true;
 
-        private List<TagHelperContent> ColumnNames { get; set; }
-
         public override void Init(TagHelperContext context)
         {
             if (CatchesErrors)
@@ -51,9 +50,9 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Table
                 context.Items.Add(typeof(ParentChildContext), parentChildContext);
             }
 
-            ColumnNames = new List<TagHelperContent>();
+            var columns = new List<(TagHelperContent, bool)>();
 
-            context.Items.Add(TagHelperConstants.ColumnNameContextName, ColumnNames);
+            context.Items.Add(TagHelperConstants.ColumnNameContextName, columns);
         }
 
         public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
@@ -161,12 +160,12 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Table
             if (DisableHeader)
                 return null;
 
-            if (!context.Items.TryGetValue(TagHelperConstants.ColumnNameContextName, out object columnNames))
+            if (!context.Items.TryGetValue(TagHelperConstants.ColumnNameContextName, out object columns))
                 return null;
 
-            var columnNamesConverted = (List<TagHelperContent>)columnNames;
+            var columnsConverted = (List<(TagHelperContent Content, bool Numeric)>)columns;
 
-            if (columnNamesConverted.Count == 0)
+            if (columnsConverted.Count == 0)
                 return null;
 
             var headerBuilder = new TagBuilder("thead");
@@ -177,9 +176,15 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Table
             var headerRowBuilder = new TagBuilder("tr");
             headerRowBuilder.MergeAttribute(TagHelperConstants.Role, HeaderRowRole);
 
-            foreach (var columnName in columnNamesConverted)
+            foreach (var columnDetails in columnsConverted)
             {
-                var column = GetHeaderColumnBuilder(columnName);
+                var column = GetHeaderColumnBuilder(columnDetails.Content);
+
+                if (columnDetails.Numeric)
+                {
+                    column.MergeAttribute(TagHelperConstants.Class, HeadingClassNumeric);
+                }
+
                 headerRowBuilder.InnerHtml.AppendHtml(column);
             }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Table/TableRowContainerTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Table/TableRowContainerTagHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers;
@@ -13,21 +14,19 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Table
         private const string TableRowClass = "nhsuk-table__row";
         private const string TableRowRole = "row";
 
-        private Queue<TagHelperContent> CellColumnNames { get; set; }
-
         public override void Init(TagHelperContext context)
         {
             if (!context.Items.TryGetValue(TagHelperConstants.ColumnNameContextName, out object columnNames))
                 return;
 
-            var columnNamesConverted = (List<TagHelperContent>)columnNames;
+            var columnNamesConverted = (List<(TagHelperContent Content, bool Numeric)>)columnNames;
 
             if (columnNamesConverted.Count == 0)
                 return;
 
-            CellColumnNames = new Queue<TagHelperContent>(columnNamesConverted);
+            var cellColumnNames = new Queue<TagHelperContent>(columnNamesConverted.Select(c => c.Content).ToList());
 
-            context.Items.Add(TagHelperConstants.CellColumnContextName, CellColumnNames);
+            context.Items.Add(TagHelperConstants.CellColumnContextName, cellColumnNames);
         }
 
         public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/SolutionSelection/ReviewSolutionsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/SolutionSelection/ReviewSolutionsController.cs
@@ -24,9 +24,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.SolutionSele
         [HttpGet]
         public async Task<IActionResult> ReviewSolutions(string internalOrgId, CallOffId callOffId)
         {
-            var order = (await orderService.GetOrderWithOrderItems(callOffId, internalOrgId)).Order;
+            var wrapper = await orderService.GetOrderWithOrderItems(callOffId, internalOrgId);
 
-            var model = new ReviewSolutionsModel(order, internalOrgId)
+            var model = new ReviewSolutionsModel(wrapper, internalOrgId)
             {
                 BackLink = Url.Action(
                     nameof(OrderController.Order),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/Contracts/DeliveryDates/AmendDateModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/Contracts/DeliveryDates/AmendDateModel.cs
@@ -67,13 +67,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.Contracts.Deliver
         {
             get
             {
-                if (TriageValue == null)
-                {
-                    return null;
-                }
-
-                var endDate = new EndDate(CommencementDate, MaximumTerm, TriageValue);
-                return endDate.Value;
+                var endDate = new EndDate(CommencementDate, MaximumTerm);
+                return endDate.DateTime;
             }
         }
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/Contracts/DeliveryDates/AmendDateModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/Contracts/DeliveryDates/AmendDateModel.cs
@@ -9,7 +9,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.Contracts.Deliver
     {
         public const string AdviceText = "Enter the date you expect this item to start being used by the Service Recipients.";
         public const string TitleText = "Planned delivery date";
-        public const int MaximumTermForOnOffCatalogueOrders = 48;
 
         public AmendDateModel()
         {
@@ -68,16 +67,13 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.Contracts.Deliver
         {
             get
             {
-                if (CommencementDate == null
-                    || MaximumTerm == null
-                    || TriageValue == null)
+                if (TriageValue == null)
                 {
                     return null;
                 }
 
-                return TriageValue == OrderTriageValue.Under40K
-                    ? CommencementDate.Value.AddMonths(MaximumTerm.Value).AddDays(-1)
-                    : CommencementDate.Value.AddMonths(MaximumTermForOnOffCatalogueOrders).AddDays(-1);
+                var endDate = new EndDate(CommencementDate, MaximumTerm, TriageValue);
+                return endDate.Value;
             }
         }
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/SolutionSelection/Review/ReviewExpanderModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/SolutionSelection/Review/ReviewExpanderModel.cs
@@ -5,15 +5,12 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection
 {
     public class ReviewExpanderModel
     {
-        private readonly OrderItem previous;
-
         public ReviewExpanderModel(OrderItem orderItem, OrderItem previous, bool isAmendment = false)
         {
             IsAmendment = isAmendment;
             IsOrderItemAdded = orderItem != null && previous == null;
             OrderItem = orderItem;
-
-            this.previous = previous;
+            Previous = previous;
         }
 
         public bool IsAmendment { get; }
@@ -22,8 +19,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection
 
         public OrderItem OrderItem { get; }
 
+        public OrderItem Previous { get; }
+
         public bool IsServiceRecipientAdded(string odsCode) =>
             OrderItem?.OrderItemRecipients?.FirstOrDefault(x => x.OdsCode == odsCode) != null
-            && previous?.OrderItemRecipients?.FirstOrDefault(x => x.OdsCode == odsCode) == null;
+            && Previous?.OrderItemRecipients?.FirstOrDefault(x => x.OdsCode == odsCode) == null;
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/SolutionSelection/Review/ReviewExpanderModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/SolutionSelection/Review/ReviewExpanderModel.cs
@@ -1,0 +1,29 @@
+﻿using System.Linq;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.Review
+{
+    public class ReviewExpanderModel
+    {
+        private readonly OrderItem previous;
+
+        public ReviewExpanderModel(OrderItem orderItem, OrderItem previous, bool isAmendment = false)
+        {
+            IsAmendment = isAmendment;
+            IsOrderItemAdded = orderItem != null && previous == null;
+            OrderItem = orderItem;
+
+            this.previous = previous;
+        }
+
+        public bool IsAmendment { get; }
+
+        public bool IsOrderItemAdded { get; }
+
+        public OrderItem OrderItem { get; }
+
+        public bool IsServiceRecipientAdded(string odsCode) =>
+            OrderItem?.OrderItemRecipients?.FirstOrDefault(x => x.OdsCode == odsCode) != null
+            && previous?.OrderItemRecipients?.FirstOrDefault(x => x.OdsCode == odsCode) == null;
+    }
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/SolutionSelection/Review/ReviewSolutionsModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/SolutionSelection/Review/ReviewSolutionsModel.cs
@@ -8,47 +8,34 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection
 {
     public class ReviewSolutionsModel : NavBaseModel
     {
-        public ReviewSolutionsModel()
-        {
-        }
-
         public ReviewSolutionsModel(OrderWrapper wrapper, string internalOrgId)
         {
-            var order = wrapper.Order;
-
-            CallOffId = order.CallOffId;
+            OrderWrapper = wrapper;
             InternalOrgId = internalOrgId;
-            Order = order;
-            Previous = wrapper.Previous;
-            RolledUp = wrapper.RolledUp;
-            AllOrderItems = order.OrderItems;
-            CatalogueSolutions = RolledUp.GetSolutions().ToList();
-            AdditionalServices = RolledUp.GetAdditionalServices().ToList();
-            AssociatedServices = RolledUp.GetAssociatedServices().ToList();
-            ContractLength = order.MaximumTerm ?? 0;
-            AssociatedServicesOnly = order.AssociatedServicesOnly;
         }
 
-        public CallOffId CallOffId { get; set; }
+        public OrderWrapper OrderWrapper { get; }
 
-        public Order Order { get; set; }
+        public CallOffId CallOffId => OrderWrapper.Order.CallOffId;
 
-        public Order Previous { get; set; }
+        public Order Order => OrderWrapper.Order;
 
-        public Order RolledUp { get; set; }
+        public Order Previous => OrderWrapper.Previous;
 
-        public List<OrderItem> CatalogueSolutions { get; set; }
+        public Order RolledUp => OrderWrapper.RolledUp;
 
-        public List<OrderItem> AdditionalServices { get; set; }
+        public List<OrderItem> CatalogueSolutions => RolledUp.GetSolutions().ToList();
 
-        public List<OrderItem> AssociatedServices { get; set; }
+        public List<OrderItem> AdditionalServices => RolledUp.GetAdditionalServices().ToList();
 
-        public ICollection<OrderItem> AllOrderItems { get; set; }
+        public List<OrderItem> AssociatedServices => RolledUp.GetAssociatedServices().ToList();
 
-        public int ContractLength { get; set; }
+        public ICollection<OrderItem> AllOrderItems => OrderWrapper.Order.OrderItems;
+
+        public int ContractLength => OrderWrapper.Order.MaximumTerm ?? 0;
 
         public string InternalOrgId { get; set; }
 
-        public bool AssociatedServicesOnly { get; set; }
+        public bool AssociatedServicesOnly => OrderWrapper.Order.AssociatedServicesOnly;
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/SolutionSelection/Review/ReviewSolutionsModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/SolutionSelection/Review/ReviewSolutionsModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Models;
 
 namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.Review
@@ -11,15 +12,19 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection
         {
         }
 
-        public ReviewSolutionsModel(Order order, string internalOrgId)
+        public ReviewSolutionsModel(OrderWrapper wrapper, string internalOrgId)
         {
+            var order = wrapper.Order;
+
             CallOffId = order.CallOffId;
             InternalOrgId = internalOrgId;
             Order = order;
+            Previous = wrapper.Previous;
+            RolledUp = wrapper.RolledUp;
             AllOrderItems = order.OrderItems;
-            CatalogueSolutions = order.GetSolutions().ToList();
-            AdditionalServices = order.GetAdditionalServices().ToList();
-            AssociatedServices = order.GetAssociatedServices().ToList();
+            CatalogueSolutions = RolledUp.GetSolutions().ToList();
+            AdditionalServices = RolledUp.GetAdditionalServices().ToList();
+            AssociatedServices = RolledUp.GetAssociatedServices().ToList();
             ContractLength = order.MaximumTerm ?? 0;
             AssociatedServicesOnly = order.AssociatedServicesOnly;
         }
@@ -27,6 +32,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection
         public CallOffId CallOffId { get; set; }
 
         public Order Order { get; set; }
+
+        public Order Previous { get; set; }
+
+        public Order RolledUp { get; set; }
 
         public List<OrderItem> CatalogueSolutions { get; set; }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/Summary.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/Summary.cshtml
@@ -102,7 +102,7 @@
                 && Model.Order.MaximumTerm.HasValue)
             {
                 <nhs-summary-list-row label-text="End date" data-test-id="end-date-summary">
-                    @Model.Order.EndDate
+                    @Model.Order.EndDateDisplayValue
                 </nhs-summary-list-row>
             }
         </nhs-summary-list>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/Summary.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/Summary.cshtml
@@ -102,7 +102,7 @@
                 && Model.Order.MaximumTerm.HasValue)
             {
                 <nhs-summary-list-row label-text="End date" data-test-id="end-date-summary">
-                    @Model.Order.EndDateDisplayValue
+                    @Model.Order.EndDate.DisplayValue
                 </nhs-summary-list-row>
             }
         </nhs-summary-list>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/_OrderItemSummary.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/_OrderItemSummary.cshtml
@@ -6,14 +6,11 @@
 
 @{
     var totalCost = Model.TotalCost();
-	var subTotalDescription = $"£{totalCost:N2} {Model.OrderItemPrice?.BillingPeriod?.Description() ?? string.Empty}";
     var hasServiceRecipientQuantities = Model.OrderItemPrice?.IsPerServiceRecipient() ?? false;
 }
 
 <nhs-expander colour-mode="BlackAndWhite"
               label-text="@Model.CatalogueItem.Name"
-              secondary-text-title="Subtotal: "
-              secondary-text="@subTotalDescription"
 			  open="true"
 			  bold-title="true">
     @if (Model.OrderItemRecipients.Any())

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/ReviewSolutions/ReviewSolutions.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/ReviewSolutions/ReviewSolutions.cshtml
@@ -1,6 +1,12 @@
 ﻿@using System.Linq;
+@using Microsoft.AspNetCore.Mvc.TagHelpers
+@using NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
+@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.ActionLink
+@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSecondaryButton
+@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.SummaryList
 @using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers
 @using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.SolutionSelection
+@using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.Review
 
 @model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.Review.ReviewSolutionsModel
 @{
@@ -39,7 +45,7 @@
 		    <h2 id="catalogue-solutions-title">@solutionsTitle</h2>
 		    @foreach (var solution in Model.CatalogueSolutions)
 		    {
-		        <partial name="_ReviewExpander" model="solution" />
+                <partial name="_ReviewExpander" model="new ReviewExpanderModel(solution, Model.Previous?.OrderItem(solution.CatalogueItemId), Model.Order.IsAmendment)" />
 		    }
 		}
 
@@ -48,7 +54,7 @@
 			<h2 id="additional-services-title">Additional Services</h2>
 			@foreach (var service in Model.AdditionalServices)
 			{
-				<partial name="_ReviewExpander" model="service" />
+                <partial name="_ReviewExpander" model="new ReviewExpanderModel(service, Model.Previous?.OrderItem(service.CatalogueItemId), Model.Order.IsAmendment)" />
 			}
 		}
 
@@ -57,7 +63,7 @@
 			<h2 id="associated-services-title">Associated Services</h2>
 			@foreach (var service in Model.AssociatedServices)
 			{
-				<partial name="_ReviewExpander" model="service" />
+                <partial name="_ReviewExpander" model="new ReviewExpanderModel(service, Model.Previous?.OrderItem(service.CatalogueItemId), Model.Order.IsAmendment)" />
 			}
 		}
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/ReviewSolutions/ReviewSolutions.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/ReviewSolutions/ReviewSolutions.cshtml
@@ -75,16 +75,20 @@
              <nhs-table id="review-solutions-amended-indicative-costs" label-text="Indicative costs">
                  <nhs-table-column>Cost type</nhs-table-column>
                  <nhs-table-column numeric="true">Previous cost</nhs-table-column>
+                 <nhs-table-column numeric="true">Difference</nhs-table-column>
                  <nhs-table-column numeric="true">New cost</nhs-table-column>
                  <nhs-table-row-container>
                     <nhs-table-cell>
                         <strong>Total one-off cost:</strong>
                     </nhs-table-cell>
                     <nhs-table-cell numeric="true">
-                        £@($"{Model.Previous.TotalOneOffCost():N2}")
+                        £@($"{Model.Previous.TotalOneOffCost(true):N2}")
                     </nhs-table-cell>
                     <nhs-table-cell numeric="true">
-                        £@($"{Model.RolledUp.TotalOneOffCost():N2}")
+                        £@($"{Model.RolledUp.TotalOneOffCost(true)-Model.Previous.TotalOneOffCost(true):N2}")
+                    </nhs-table-cell>
+                    <nhs-table-cell numeric="true">
+                        £@($"{Model.RolledUp.TotalOneOffCost(true):N2}")
                     </nhs-table-cell>
                  </nhs-table-row-container>
                  <nhs-table-row-container>
@@ -92,10 +96,13 @@
                         <strong>Total monthly cost:</strong>
                     </nhs-table-cell>
                     <nhs-table-cell numeric="true">
-                        £@($"{Model.Previous.TotalMonthlyCost():N2}")
+                        £@($"{Model.Previous.TotalMonthlyCost(true):N2}")
                     </nhs-table-cell>
                     <nhs-table-cell numeric="true">
-                        £@($"{Model.RolledUp.TotalMonthlyCost():N2}")
+                        £@($"{Model.RolledUp.TotalMonthlyCost(true)-Model.Previous.TotalMonthlyCost(true):N2}")
+                    </nhs-table-cell>
+                    <nhs-table-cell numeric="true">
+                        £@($"{Model.RolledUp.TotalMonthlyCost(true):N2}")
                     </nhs-table-cell>
                  </nhs-table-row-container>
                  <nhs-table-row-container>
@@ -103,10 +110,13 @@
                         <strong>Total cost for one year:</strong>
                     </nhs-table-cell>
                     <nhs-table-cell numeric="true">
-                        £@($"{Model.Previous.TotalAnnualCost():N2}")
+                        £@($"{Model.Previous.TotalAnnualCost(true):N2}")
                     </nhs-table-cell>
                     <nhs-table-cell numeric="true">
-                        £@($"{Model.RolledUp.TotalAnnualCost():N2}")
+                        £@($"{Model.RolledUp.TotalAnnualCost(true)-Model.Previous.TotalAnnualCost(true):N2}")
+                    </nhs-table-cell>
+                    <nhs-table-cell numeric="true">
+                        £@($"{Model.RolledUp.TotalAnnualCost(true):N2}")
                     </nhs-table-cell>
                  </nhs-table-row-container>
                  <nhs-table-row-container>
@@ -114,10 +124,13 @@
                         <strong>Total cost of contract:</strong>
                     </nhs-table-cell>
                     <nhs-table-cell numeric="true">
-                        £@($"{Model.Previous.TotalCost():N2}")
+                        £@($"{Model.Previous.TotalCost(true):N2}")
                     </nhs-table-cell>
                     <nhs-table-cell numeric="true">
-                        £@($"{Model.OrderWrapper.TotalCost():N2}")
+                        £@($"{Model.OrderWrapper.TotalCost(true)-Model.Previous.TotalCost(true):N2}")
+                    </nhs-table-cell>
+                    <nhs-table-cell numeric="true">
+                        £@($"{Model.OrderWrapper.TotalCost(true):N2}")
                     </nhs-table-cell>
                  </nhs-table-row-container>
              </nhs-table>
@@ -127,19 +140,19 @@
              <h2 id="review-solutions-indicative-costs">Indicative costs</h2>
              <nhs-summary-list>
                  <nhs-summary-list-row label-text="Total one-off cost:">
-                     £@($"{Model.Order.TotalOneOffCost():N2}")
+                     £@($"{Model.Order.TotalOneOffCost(true):N2}")
                  </nhs-summary-list-row>
 
                  <nhs-summary-list-row label-text="Total monthly cost:">
-                     £@($"{Model.Order.TotalMonthlyCost():N2}")
+                     £@($"{Model.Order.TotalMonthlyCost(true):N2}")
                  </nhs-summary-list-row>
 
                  <nhs-summary-list-row label-text="Total cost for one year:">
-                     £@($"{Model.Order.TotalAnnualCost():N2}")
+                     £@($"{Model.Order.TotalAnnualCost(true):N2}")
                  </nhs-summary-list-row>
 
                  <nhs-summary-list-row label-text="Total cost of contract (@Model.ContractLength months):">
-                     £@($"{Model.Order.TotalCost():N2}")
+                     £@($"{Model.Order.TotalCost(true):N2}")
                  </nhs-summary-list-row>
              </nhs-summary-list>
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/ReviewSolutions/ReviewSolutions.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/ReviewSolutions/ReviewSolutions.cshtml
@@ -4,15 +4,16 @@
 @using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.ActionLink
 @using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSecondaryButton
 @using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.SummaryList
+@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Table
 @using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers
 @using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.SolutionSelection
 @using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.Review
 
 @model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.Review.ReviewSolutionsModel
 @{
-	ViewBag.Title = Model.AssociatedServicesOnly
+    ViewBag.Title = Model.AssociatedServicesOnly
         ? "Associated Services"
-	    : "Catalogue Solution and services";
+        : "Catalogue Solution and services";
 
     var advice = Model.AssociatedServicesOnly
         ? "Review the Associated Services that you've added to this order. You can edit the items that you've added at any time."
@@ -30,63 +31,118 @@
 <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
         <nhs-page-title title="@ViewBag.Title"
-						caption="Order @Model.CallOffId"
-						advice="@advice"/>
+                        caption="Order @Model.CallOffId"
+                        advice="@advice"/>
 
         <vc:nhs-action-link text="@editLinkTitle"
                             url="@Url.Action(
                                      nameof(TaskListController.TaskList),
                                      typeof(TaskListController).ControllerName(),
                                      new { Model.InternalOrgId, Model.CallOffId })" />
-		<hr />
+        <hr />
 
-		@if (Model.CatalogueSolutions.Any())
-		{
-		    <h2 id="catalogue-solutions-title">@solutionsTitle</h2>
-		    @foreach (var solution in Model.CatalogueSolutions)
-		    {
+        @if (Model.CatalogueSolutions.Any())
+        {
+            <h2 id="catalogue-solutions-title">@solutionsTitle</h2>
+            @foreach (var solution in Model.CatalogueSolutions)
+            {
                 <partial name="_ReviewExpander" model="new ReviewExpanderModel(solution, Model.Previous?.OrderItem(solution.CatalogueItemId), Model.Order.IsAmendment)" />
-		    }
-		}
+            }
+        }
 
-		@if (Model.AdditionalServices.Any())
-		{
-			<h2 id="additional-services-title">Additional Services</h2>
-			@foreach (var service in Model.AdditionalServices)
-			{
+        @if (Model.AdditionalServices.Any())
+        {
+            <h2 id="additional-services-title">Additional Services</h2>
+            @foreach (var service in Model.AdditionalServices)
+            {
                 <partial name="_ReviewExpander" model="new ReviewExpanderModel(service, Model.Previous?.OrderItem(service.CatalogueItemId), Model.Order.IsAmendment)" />
-			}
-		}
+            }
+        }
 
-		@if (Model.AssociatedServices.Any())
-		{
-			<h2 id="associated-services-title">Associated Services</h2>
-			@foreach (var service in Model.AssociatedServices)
-			{
-                <partial name="_ReviewExpander" model="new ReviewExpanderModel(service, Model.Previous?.OrderItem(service.CatalogueItemId), Model.Order.IsAmendment)" />
-			}
-		}
+        @if (Model.AssociatedServices.Any())
+        {
+            <h2 id="associated-services-title">Associated Services</h2>
+            @foreach (var service in Model.AssociatedServices)
+            {
+                 <partial name="_ReviewExpander" model="new ReviewExpanderModel(service, Model.Previous?.OrderItem(service.CatalogueItemId), Model.Order.IsAmendment)" />
+            }
+        }
 
         <br/>
 
-        <h2>Indicative costs</h2>
-        <nhs-summary-list>
-            <nhs-summary-list-row label-text="Total one-off cost:">
-                £@($"{Model.Order.TotalOneOffCost():N2}")
-            </nhs-summary-list-row>
+        @if (Model.Order.IsAmendment)
+        {
+             <nhs-table id="review-solutions-amended-indicative-costs" label-text="Indicative costs">
+                 <nhs-table-column>Cost type</nhs-table-column>
+                 <nhs-table-column numeric="true">Previous cost</nhs-table-column>
+                 <nhs-table-column numeric="true">New cost</nhs-table-column>
+                 <nhs-table-row-container>
+                    <nhs-table-cell>
+                        <strong>Total one-off cost:</strong>
+                    </nhs-table-cell>
+                    <nhs-table-cell numeric="true">
+                        £@($"{Model.Previous.TotalOneOffCost():N2}")
+                    </nhs-table-cell>
+                    <nhs-table-cell numeric="true">
+                        £@($"{Model.RolledUp.TotalOneOffCost():N2}")
+                    </nhs-table-cell>
+                 </nhs-table-row-container>
+                 <nhs-table-row-container>
+                    <nhs-table-cell>
+                        <strong>Total monthly cost:</strong>
+                    </nhs-table-cell>
+                    <nhs-table-cell numeric="true">
+                        £@($"{Model.Previous.TotalMonthlyCost():N2}")
+                    </nhs-table-cell>
+                    <nhs-table-cell numeric="true">
+                        £@($"{Model.RolledUp.TotalMonthlyCost():N2}")
+                    </nhs-table-cell>
+                 </nhs-table-row-container>
+                 <nhs-table-row-container>
+                    <nhs-table-cell>
+                        <strong>Total cost for one year:</strong>
+                    </nhs-table-cell>
+                    <nhs-table-cell numeric="true">
+                        £@($"{Model.Previous.TotalAnnualCost():N2}")
+                    </nhs-table-cell>
+                    <nhs-table-cell numeric="true">
+                        £@($"{Model.RolledUp.TotalAnnualCost():N2}")
+                    </nhs-table-cell>
+                 </nhs-table-row-container>
+                 <nhs-table-row-container>
+                    <nhs-table-cell>
+                        <strong>Total cost of contract:</strong>
+                    </nhs-table-cell>
+                    <nhs-table-cell numeric="true">
+                        £@($"{Model.Previous.TotalCost():N2}")
+                    </nhs-table-cell>
+                    <nhs-table-cell numeric="true">
+                        £@($"{Model.OrderWrapper.TotalCost():N2}")
+                    </nhs-table-cell>
+                 </nhs-table-row-container>
+             </nhs-table>
+        }
+        else
+        {
+             <h2 id="review-solutions-indicative-costs">Indicative costs</h2>
+             <nhs-summary-list>
+                 <nhs-summary-list-row label-text="Total one-off cost:">
+                     £@($"{Model.Order.TotalOneOffCost():N2}")
+                 </nhs-summary-list-row>
 
-            <nhs-summary-list-row label-text="Total monthly cost:">
-                £@($"{Model.Order.TotalMonthlyCost():N2}")
-            </nhs-summary-list-row>
+                 <nhs-summary-list-row label-text="Total monthly cost:">
+                     £@($"{Model.Order.TotalMonthlyCost():N2}")
+                 </nhs-summary-list-row>
 
-            <nhs-summary-list-row label-text="Total cost for one year:">
-                £@($"{Model.Order.TotalAnnualCost():N2}")
-            </nhs-summary-list-row>
+                 <nhs-summary-list-row label-text="Total cost for one year:">
+                     £@($"{Model.Order.TotalAnnualCost():N2}")
+                 </nhs-summary-list-row>
 
-            <nhs-summary-list-row label-text="Total cost of contract (@Model.ContractLength months):">
-                £@($"{Model.Order.TotalCost():N2}")
-            </nhs-summary-list-row>
-		</nhs-summary-list>
+                 <nhs-summary-list-row label-text="Total cost of contract (@Model.ContractLength months):">
+                     £@($"{Model.Order.TotalCost():N2}")
+                 </nhs-summary-list-row>
+             </nhs-summary-list>
+        }
         <p><b>All prices exclude VAT.</b></p>
 
         <vc:nhs-secondary-button text="Continue"
@@ -95,6 +151,6 @@
                                           nameof(OrderController.Order),
                                           typeof(OrderController).ControllerName(),
                                           new { Model.InternalOrgId, Model.CallOffId })"/>
-	</div>
+    </div>
 </div>
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/ReviewSolutions/_ReviewExpander.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/ReviewSolutions/_ReviewExpander.cshtml
@@ -3,28 +3,44 @@
 @using NHSD.GPIT.BuyingCatalogue.EntityFramework.Extensions;
 @using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.DetailsAndExpander
 @using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Table
-@model NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models.OrderItem
+@model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.Review.ReviewExpanderModel
 @{
-	var totalCosts = Model.OrderItemPrice.CalculateTotalCostPerTier(Model.TotalQuantity);
+	var totalCosts = Model.OrderItem.OrderItemPrice.CalculateTotalCostPerTier(Model.OrderItem.TotalQuantity);
     var totalCost = totalCosts.Sum(tc => tc.Cost);
-    var billingPeriod = Model.OrderItemPrice?.BillingPeriod?.Description() ?? string.Empty;
-    var hasTieredPricing = Model.OrderItemPrice?.CataloguePriceType is CataloguePriceType.Tiered;
-    var hasServiceRecipientQuantities = Model.OrderItemPrice?.IsPerServiceRecipient() ?? false;
+    var billingPeriod = Model.OrderItem.OrderItemPrice?.BillingPeriod?.Description() ?? string.Empty;
+    var hasTieredPricing = Model.OrderItem.OrderItemPrice?.CataloguePriceType is CataloguePriceType.Tiered;
+    var hasServiceRecipientQuantities = Model.OrderItem.OrderItemPrice?.IsPerServiceRecipient() ?? false;
 }
 
-<nhs-expander label-text="@Model.CatalogueItem.Name"
+<nhs-expander label-text="@Model.OrderItem.CatalogueItem.Name"
+              added-sticker="@Model.IsAmendment && @Model.IsOrderItemAdded"
 			  colour-mode="BlackAndWhite"
 			  secondary-text-title="Subtotal: "
 			  secondary-text="£@($"{totalCost:N2} {billingPeriod}")"
 			  open="true"
 			  bold-title="true">
 	<br/>
-	<nhs-table label-text="Service Recipients">
-		<nhs-table-column>Recipient</nhs-table-column>
-		<nhs-table-column>Quantity</nhs-table-column>
-		@foreach(var recipient in Model.OrderItemRecipients)
-		{
-			<nhs-table-row-container>
+    <nhs-table label-text="Service Recipients">
+        @if (Model.IsAmendment)
+        {
+            <nhs-table-column>Status</nhs-table-column>
+        }
+        <nhs-table-column>Recipient</nhs-table-column>
+        <nhs-table-column>Quantity</nhs-table-column>
+        @foreach (var recipient in Model.OrderItem.OrderItemRecipients)
+        {
+            <nhs-table-row-container>
+                @if (Model.IsAmendment)
+                {
+                    <nhs-table-cell style="width: 50px;">
+                        @if (Model.IsServiceRecipientAdded(recipient.OdsCode))
+                        {
+                            <div class="bc-c-task-list__task-status">
+                                <strong class="nhsuk-tag nhsuk-tag--blue">Added</strong>
+                            </div>
+                        }
+                    </nhs-table-cell>
+                }
                 <nhs-table-cell>
                     @recipient.Recipient.Name
                 </nhs-table-cell>
@@ -38,9 +54,9 @@
                         @("N/A")
                     }
                 </nhs-table-cell>
-			</nhs-table-row-container>
-		}
-	</nhs-table>
+            </nhs-table-row-container>
+        }
+    </nhs-table>
 
     <nhs-table label-text="Pricing">
         @if (hasTieredPricing)
@@ -52,7 +68,7 @@
 
         @for (var i = 0; i < totalCosts.Count; i++)
         {
-            var price = Model.OrderItemPrice.OrderItemPriceTiers.ElementAt(i).Price;
+            var price = Model.OrderItem.OrderItemPrice.OrderItemPriceTiers.ElementAt(i).Price;
 
             <nhs-table-row-container>
                 @if (hasTieredPricing)
@@ -62,7 +78,7 @@
                     </nhs-table-cell>
                 }
                 <nhs-table-cell>
-                    £@($"{price:#,###,##0.00##}") @Model.OrderItemPrice.ToPriceUnitString()
+                    £@($"{price:#,###,##0.00##}") @Model.OrderItem.OrderItemPrice.ToPriceUnitString()
                 </nhs-table-cell>
                 <nhs-table-cell>
                     @($"{totalCosts[i].Quantity:N0}")

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/ReviewSolutions/_ReviewExpander.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/ReviewSolutions/_ReviewExpander.cshtml
@@ -5,18 +5,18 @@
 @using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Table
 @model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.Review.ReviewExpanderModel
 @{
-	var totalCosts = Model.OrderItem.OrderItemPrice.CalculateTotalCostPerTier(Model.OrderItem.TotalQuantity);
-    var totalCost = totalCosts.Sum(tc => tc.Cost);
-    var billingPeriod = Model.OrderItem.OrderItemPrice?.BillingPeriod?.Description() ?? string.Empty;
+    var totalCostsRolledUp = Model.OrderItem.OrderItemPrice.CalculateTotalCostPerTier(Model.OrderItem.TotalQuantity);
+    var totalCostsPrevious = Model.IsAmendment && Model.Previous is not null
+        ? Model.Previous.OrderItemPrice.CalculateTotalCostPerTier(Model.Previous.TotalQuantity)
+        : Model.OrderItem.OrderItemPrice.CalculateTotalCostPerTier(0);
     var hasTieredPricing = Model.OrderItem.OrderItemPrice?.CataloguePriceType is CataloguePriceType.Tiered;
     var hasServiceRecipientQuantities = Model.OrderItem.OrderItemPrice?.IsPerServiceRecipient() ?? false;
+    var tableText = Model.IsAmendment ? "Pricing and total quantities" : "Pricing";
 }
 
 <nhs-expander label-text="@Model.OrderItem.CatalogueItem.Name"
               added-sticker="@Model.IsAmendment && @Model.IsOrderItemAdded"
 			  colour-mode="BlackAndWhite"
-			  secondary-text-title="Subtotal: "
-			  secondary-text="£@($"{totalCost:N2} {billingPeriod}")"
 			  open="true"
 			  bold-title="true">
 	<br/>
@@ -38,6 +38,10 @@
                             <div class="bc-c-task-list__task-status">
                                 <strong class="nhsuk-tag nhsuk-tag--blue">Added</strong>
                             </div>
+                        } 
+                        else
+                        {
+                            <span aria-label="Existing"></span>
                         }
                     </nhs-table-cell>
                 }
@@ -58,15 +62,21 @@
         }
     </nhs-table>
 
-    <nhs-table label-text="Pricing">
+    <nhs-table label-text="@tableText">
         @if (hasTieredPricing)
         {
             <nhs-table-column>Pricing Tier</nhs-table-column>
         }
         <nhs-table-column>Price per unit</nhs-table-column>
-        <nhs-table-column>Quantity</nhs-table-column>
-
-        @for (var i = 0; i < totalCosts.Count; i++)
+        @if (Model.IsAmendment) {
+            <nhs-table-column>Old quantity</nhs-table-column>
+            <nhs-table-column>New quantity</nhs-table-column>
+            <nhs-table-column>Old price</nhs-table-column>
+            <nhs-table-column>New price</nhs-table-column>
+        } else {
+            <nhs-table-column>Quantity</nhs-table-column>
+        }
+        @for (var i = 0; i < totalCostsRolledUp.Count; i++)
         {
             var price = Model.OrderItem.OrderItemPrice.OrderItemPriceTiers.ElementAt(i).Price;
 
@@ -74,15 +84,38 @@
                 @if (hasTieredPricing)
                 {
                     <nhs-table-cell>
-                        Tier @totalCosts[i].Id
+                        Tier @totalCostsRolledUp[i].Id
                     </nhs-table-cell>
                 }
                 <nhs-table-cell>
                     £@($"{price:#,###,##0.00##}") @Model.OrderItem.OrderItemPrice.ToPriceUnitString()
                 </nhs-table-cell>
+                @if (Model.IsAmendment)
+                {
+                    <nhs-table-cell>
+                        @(
+                            totalCostsPrevious[i].Quantity == 0
+                              ? "N/A"
+                              : $"{totalCostsPrevious[i].Quantity:N0}"
+                        )
+                    </nhs-table-cell>
+                }
                 <nhs-table-cell>
-                    @($"{totalCosts[i].Quantity:N0}")
+                    @($"{totalCostsRolledUp[i].Quantity:N0}")
                 </nhs-table-cell>
+                @if (Model.IsAmendment)
+                {
+                    <nhs-table-cell>
+                        @(
+                            totalCostsPrevious[i].Cost == 0
+                              ? "N/A"
+                              : $"£{totalCostsPrevious[i].Cost:N2}"
+                        )
+                    </nhs-table-cell>
+                    <nhs-table-cell>
+                        £@($"{totalCostsRolledUp[i].Cost:N2}")
+                    </nhs-table-cell>
+                }
             </nhs-table-row-container>
         }
     </nhs-table>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
@@ -236,7 +236,7 @@
         if (Model.Order.CommencementDate != null)
         {
             <pdf-summary-list-row label-text="End date">
-                @Model.Order.EndDateDisplayValue
+                @Model.Order.EndDate.DisplayValue
             </pdf-summary-list-row>
         }
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
@@ -236,7 +236,7 @@
         if (Model.Order.CommencementDate != null)
         {
             <pdf-summary-list-row label-text="End date">
-                @Model.Order.EndDate
+                @Model.Order.EndDateDisplayValue
             </pdf-summary-list-row>
         }
     }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/DeliveryDates/AmendDate.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/DeliveryDates/AmendDate.cs
@@ -276,7 +276,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Contracts.DeliveryDa
 
             context.SaveChanges();
 
-            var date = order.CommencementDate!.Value.AddMonths(AmendDateModel.MaximumTermForOnOffCatalogueOrders);
+            var date = order.CommencementDate!.Value.AddMonths(EndDate.MaximumTermForOnOffCatalogueOrders);
 
             Driver.Navigate().Refresh();
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Review/ReviewSolutionsAmendment.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Review/ReviewSolutionsAmendment.cs
@@ -11,12 +11,12 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Review
 {
-    public class ReviewSolutions : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    public class ReviewSolutionsAmendment : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
     {
+        private const int OrderId = 90032;
         private const string InternalOrgId = "CG-03F";
-        private const int OrderId = 90013;
 
-        private static readonly CallOffId CallOffId = new(OrderId, 1);
+        private static readonly CallOffId CallOffId = new(OrderId, 2);
 
         private static readonly Dictionary<string, string> Parameters = new()
         {
@@ -24,7 +24,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Re
             { nameof(CallOffId), $"{CallOffId}" },
         };
 
-        public ReviewSolutions(LocalWebApplicationFactory factory)
+        public ReviewSolutionsAmendment(LocalWebApplicationFactory factory)
             : base(
                   factory,
                   typeof(ReviewSolutionsController),
@@ -34,7 +34,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Re
         }
 
         [Fact]
-        public void ReviewSolutions_AllSectionsDisplayed()
+        public void ReviewSolutionsAmendment_AllSectionsDisplayed()
         {
             CommonActions.PageTitle().Should().BeEquivalentTo($"Catalogue Solution and services - Order {CallOffId}".FormatForComparison());
             CommonActions.GoBackLinkDisplayed().Should().BeTrue();
@@ -42,15 +42,15 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Re
             CommonActions.ElementIsDisplayed(ReviewSolutionsObjects.CatalogueSolutionSectionTitle).Should().BeTrue();
             CommonActions.ElementIsDisplayed(ReviewSolutionsObjects.AdditionalServicesSectionTitle).Should().BeTrue();
             CommonActions.ElementIsDisplayed(ReviewSolutionsObjects.AssociatedServicesSectionTitle).Should().BeTrue();
-            CommonActions.ElementIsDisplayed(ReviewSolutionsObjects.IndicativeCostsAmendment).Should().BeFalse();
-            CommonActions.ElementIsDisplayed(ReviewSolutionsObjects.IndicativeCosts).Should().BeTrue();
-            CommonActions.ElementIsDisplayed(ReviewSolutionsObjects.AddedStickers).Should().BeFalse();
-            CommonActions.ElementExists(ReviewSolutionsObjects.SreenReaderExisting).Should().BeFalse();
+            CommonActions.ElementIsDisplayed(ReviewSolutionsObjects.IndicativeCostsAmendment).Should().BeTrue();
+            CommonActions.ElementIsDisplayed(ReviewSolutionsObjects.IndicativeCosts).Should().BeFalse();
+            CommonActions.ElementIsDisplayed(ReviewSolutionsObjects.AddedStickers).Should().BeTrue();
+            CommonActions.ElementExists(ReviewSolutionsObjects.SreenReaderExisting).Should().BeTrue();
             CommonActions.ElementIsDisplayed(ReviewSolutionsObjects.ContinueButton).Should().BeTrue();
         }
 
         [Fact]
-        public void ReviewSolutions_ClickGoBackLink_ExpectedResult()
+        public void ReviewSolutionsAmendment_ClickGoBackLink_ExpectedResult()
         {
             CommonActions.ClickGoBackLink();
 
@@ -60,7 +60,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Re
         }
 
         [Fact]
-        public void ReviewSolutions_ClickContinueButton_ExpectedResult()
+        public void ReviewSolutionsAmendment_ClickContinueButton_ExpectedResult()
         {
             CommonActions.ClickLinkElement(ReviewSolutionsObjects.ContinueButton);
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/NHSD.GPIT.BuyingCatalogue.IntegrationTests.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/NHSD.GPIT.BuyingCatalogue.IntegrationTests.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="Selenium.Support" Version="4.2.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.2.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="109.0.5414.7400" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="111.0.5563.6400" />
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Browsers/BrowserFactory.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Browsers/BrowserFactory.cs
@@ -63,7 +63,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Browsers
 
             if (headless)
             {
-                options.AddArguments("headless", "window-size=1920,1080", "no-sandbox", "ignore-certificate-errors", "log-level=3");
+                options.AddArguments("headless=new", "window-size=1920,1080", "no-sandbox", "ignore-certificate-errors", "log-level=3");
             }
             else
             {

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Objects/Ordering/SolutionSelection/ReviewSolutionsObjects.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Objects/Ordering/SolutionSelection/ReviewSolutionsObjects.cs
@@ -4,6 +4,14 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.Ordering.Solution
 {
     public static class ReviewSolutionsObjects
     {
+        public static By AddedStickers => By.XPath("//*[contains(@class, 'nhsuk-tag') and text()='Added']");
+
+        public static By SreenReaderExisting => By.XPath("//span[@aria-label='Existing']");
+
+        public static By IndicativeCosts => By.Id("review-solutions-indicative-costs");
+
+        public static By IndicativeCostsAmendment => By.Id("review-solutions-amended-indicative-costs");
+
         public static By CatalogueSolutionSectionTitle => By.Id("catalogue-solutions-title");
 
         public static By AdditionalServicesSectionTitle => By.Id("additional-services-title");

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Utils/Files/FileHelper.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Utils/Files/FileHelper.cs
@@ -23,11 +23,13 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Utils.Files
             {
                 if (FileExists(filePath))
                 {
-                    break;
+                    return;
                 }
 
                 Thread.Sleep(1000);
             }
+
+            throw new TimeoutException($"Timeout waiting for download file {filePath}");
         }
 
         public static void ValidateIsPdf(string filePath)

--- a/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/Models/Ordering/EndDateTest.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/Models/Ordering/EndDateTest.cs
@@ -14,7 +14,7 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests.Models.Ordering
             var maximumTerm = 36;
             var commencementDate = (DateTime?)null;
             var endDate = new EndDate(commencementDate, maximumTerm);
-            endDate.Value.Should().BeNull();
+            endDate.DateTime.Should().BeNull();
             endDate.DisplayValue.Should().BeEmpty();
         }
 
@@ -30,31 +30,13 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests.Models.Ordering
         }
 
         [Fact]
-        public static void With_No_OrderTriageValue_Has_EndDate_Value_To_MaximumTerm()
+        public static void EndDate_Uses_MaximumTerm()
         {
             var maximumTerm = 36;
             var commencementDate = new DateTime(2000, 2, 2);
             var endDate = new EndDate(commencementDate, maximumTerm);
-            endDate.Value.Should().Be(new DateTime(2003, 2, 1));
+            endDate.DateTime.Should().Be(new DateTime(2003, 2, 1));
             endDate.DisplayValue.Should().Be("1 February 2003");
-        }
-
-        [Fact]
-        public static void With_OrderTriageValue_Under40K_Has_EndDate_Value_To_MaximumTerm()
-        {
-            var maximumTerm = 36;
-            var commencementDate = new DateTime(2000, 2, 24);
-            var endDate = new EndDate(commencementDate, maximumTerm, OrderTriageValue.Under40K);
-            endDate.Value.Should().Be(new DateTime(2003, 2, 23));
-        }
-
-        [Fact]
-        public static void With_OrderTriageValue_Between40KTo250k_Has_EndDate_Value_To_MaximumTermForOnOffCatalogueOrders()
-        {
-            var maximumTerm = 36;
-            var commencementDate = new DateTime(2000, 2, 24);
-            var endDate = new EndDate(commencementDate, maximumTerm, OrderTriageValue.Between40KTo250K);
-            endDate.Value.Should().Be(new DateTime(2004, 2, 23));
         }
 
         [Theory]
@@ -68,7 +50,7 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests.Models.Ordering
         [InlineAutoData(2001, 2, 1, 0)]
         [InlineAutoData(2001, 2, 23, 0)]
         [InlineAutoData(2001, 2, 24, 0)]
-        public static void DirectAward_RemainingTerm_Starting_Mid_Month(int year, int month, int day, int remainingTerm)
+        public static void RemainingTerm_Starting_Mid_Month(int year, int month, int day, int remainingTerm)
         {
             var maximumTerm = 12;
             var commencementDate = new DateTime(2000, 2, 24);
@@ -84,32 +66,11 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests.Models.Ordering
         [InlineAutoData(2000, 7, 1, 6)]
         [InlineAutoData(2000, 7, 30, 6)]
         [InlineAutoData(2001, 1, 1, 0)]
-        public static void DirectAward_RemainingTerm_Start_Of_Month(int year, int month, int day, int remainingTerm)
+        public static void RemainingTerm_Start_Of_Month(int year, int month, int day, int remainingTerm)
         {
             var maximumTerm = 12;
             var commencementDate = new DateTime(2000, 1, 1);
             var endDate = new EndDate(commencementDate, maximumTerm);
-
-            endDate.RemainingTerm(new DateTime(year, month, day)).Should().Be(remainingTerm);
-        }
-
-        [Theory]
-        [InlineAutoData(2000, 2, 24, 12)]
-        [InlineAutoData(2000, 2, 25, 12)]
-        [InlineAutoData(2000, 2, 28, 12)]
-        [InlineAutoData(2000, 3, 1, 12)]
-        [InlineAutoData(2000, 3, 24, 12)]
-        [InlineAutoData(2000, 3, 25, 12)]
-        [InlineAutoData(2004, 1, 1, 1)]
-        [InlineAutoData(2004, 1, 24, 1)]
-        [InlineAutoData(2004, 1, 30, 1)]
-        [InlineAutoData(2004, 2, 24, 0)]
-        [InlineAutoData(2004, 2, 24, 0)]
-        public static void OnOff_RemainingTerm(int year, int month, int day, int remainingTerm)
-        {
-            var maximumTerm = 12;
-            var commencementDate = new DateTime(2000, 2, 24);
-            var endDate = new EndDate(commencementDate, maximumTerm, OrderTriageValue.Between40KTo250K);
 
             endDate.RemainingTerm(new DateTime(year, month, day)).Should().Be(remainingTerm);
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/Models/Ordering/EndDateTest.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/Models/Ordering/EndDateTest.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using AutoFixture.Xunit2;
+using FluentAssertions;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests.Models.Ordering
+{
+    public static class EndDateTest
+    {
+        [Fact]
+        public static void With_Null_CommencementDate_Has_EndDate_Value_Null()
+        {
+            var maximumTerm = 36;
+            var commencementDate = (DateTime?)null;
+            var endDate = new EndDate(commencementDate, maximumTerm);
+            endDate.Value.Should().BeNull();
+            endDate.DisplayValue.Should().BeEmpty();
+        }
+
+        [Fact]
+        public static void EndDate_Required_For_RemainingTerm()
+        {
+            var maximumTerm = 36;
+            var commencementDate = (DateTime?)null;
+            var endDate = new EndDate(commencementDate, maximumTerm);
+            endDate.Invoking(e => e.RemainingTerm(DateTime.Now))
+                .Should()
+                .Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public static void With_No_OrderTriageValue_Has_EndDate_Value_To_MaximumTerm()
+        {
+            var maximumTerm = 36;
+            var commencementDate = new DateTime(2000, 2, 2);
+            var endDate = new EndDate(commencementDate, maximumTerm);
+            endDate.Value.Should().Be(new DateTime(2003, 2, 1));
+            endDate.DisplayValue.Should().Be("1 February 2003");
+        }
+
+        [Fact]
+        public static void With_OrderTriageValue_Under40K_Has_EndDate_Value_To_MaximumTerm()
+        {
+            var maximumTerm = 36;
+            var commencementDate = new DateTime(2000, 2, 24);
+            var endDate = new EndDate(commencementDate, maximumTerm, OrderTriageValue.Under40K);
+            endDate.Value.Should().Be(new DateTime(2003, 2, 23));
+        }
+
+        [Fact]
+        public static void With_OrderTriageValue_Between40KTo250k_Has_EndDate_Value_To_MaximumTermForOnOffCatalogueOrders()
+        {
+            var maximumTerm = 36;
+            var commencementDate = new DateTime(2000, 2, 24);
+            var endDate = new EndDate(commencementDate, maximumTerm, OrderTriageValue.Between40KTo250K);
+            endDate.Value.Should().Be(new DateTime(2004, 2, 23));
+        }
+
+        [Theory]
+        [InlineAutoData(2000, 2, 24, 12)]
+        [InlineAutoData(2000, 2, 25, 12)]
+        [InlineAutoData(2000, 2, 28, 12)]
+        [InlineAutoData(2000, 3, 1, 11)]
+        [InlineAutoData(2000, 3, 24, 11)]
+        [InlineAutoData(2000, 3, 25, 11)]
+        [InlineAutoData(2001, 1, 30, 1)]
+        [InlineAutoData(2001, 2, 1, 0)]
+        [InlineAutoData(2001, 2, 23, 0)]
+        [InlineAutoData(2001, 2, 24, 0)]
+        public static void DirectAward_RemainingTerm_Starting_Mid_Month(int year, int month, int day, int remainingTerm)
+        {
+            var maximumTerm = 12;
+            var commencementDate = new DateTime(2000, 2, 24);
+            var endDate = new EndDate(commencementDate, maximumTerm);
+
+            endDate.RemainingTerm(new DateTime(year, month, day)).Should().Be(remainingTerm);
+        }
+
+        [Theory]
+        [InlineAutoData(2000, 1, 1, 12)]
+        [InlineAutoData(2000, 12, 1, 1)]
+        [InlineAutoData(2000, 12, 31, 1)]
+        [InlineAutoData(2000, 7, 1, 6)]
+        [InlineAutoData(2000, 7, 30, 6)]
+        [InlineAutoData(2001, 1, 1, 0)]
+        public static void DirectAward_RemainingTerm_Start_Of_Month(int year, int month, int day, int remainingTerm)
+        {
+            var maximumTerm = 12;
+            var commencementDate = new DateTime(2000, 1, 1);
+            var endDate = new EndDate(commencementDate, maximumTerm);
+
+            endDate.RemainingTerm(new DateTime(year, month, day)).Should().Be(remainingTerm);
+        }
+
+        [Theory]
+        [InlineAutoData(2000, 2, 24, 12)]
+        [InlineAutoData(2000, 2, 25, 12)]
+        [InlineAutoData(2000, 2, 28, 12)]
+        [InlineAutoData(2000, 3, 1, 12)]
+        [InlineAutoData(2000, 3, 24, 12)]
+        [InlineAutoData(2000, 3, 25, 12)]
+        [InlineAutoData(2004, 1, 1, 1)]
+        [InlineAutoData(2004, 1, 24, 1)]
+        [InlineAutoData(2004, 1, 30, 1)]
+        [InlineAutoData(2004, 2, 24, 0)]
+        [InlineAutoData(2004, 2, 24, 0)]
+        public static void OnOff_RemainingTerm(int year, int month, int day, int remainingTerm)
+        {
+            var maximumTerm = 12;
+            var commencementDate = new DateTime(2000, 2, 24);
+            var endDate = new EndDate(commencementDate, maximumTerm, OrderTriageValue.Between40KTo250K);
+
+            endDate.RemainingTerm(new DateTime(year, month, day)).Should().Be(remainingTerm);
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.Framework.UnitTests/Calculations/CataloguePriceCalculationsTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Framework.UnitTests/Calculations/CataloguePriceCalculationsTests.cs
@@ -263,13 +263,13 @@ namespace NHSD.GPIT.BuyingCatalogue.Framework.UnitTests.Calculations
         }
 
         [Theory]
-        [CommonInlineAutoData(TimeUnit.PerMonth, 0, 12, 12 * 12)]
-        [CommonInlineAutoData(TimeUnit.PerYear, 0, 1, 12)]
-        [CommonInlineAutoData(null, 12, 0, 0)]
-        public static void Order_Totals_Using_BillingPeriod(TimeUnit? billingPeriod, decimal oneOff, decimal monthly, decimal annual, IFixture fixture)
+        [CommonInlineAutoData(TimeUnit.PerMonth, 12, 0, 12, 12 * 12)]
+        [CommonInlineAutoData(TimeUnit.PerYear, 12, 0, 1, 12)]
+        [CommonInlineAutoData(TimeUnit.PerYear, 12.666, 0, 1.0555, 12.666)]
+        [CommonInlineAutoData(null, 12, 12, 0, 0)]
+        [CommonInlineAutoData(null, 12.666, 12.666, 0, 0)]
+        public static void Order_Totals_Using_BillingPeriod(TimeUnit? billingPeriod, decimal price, decimal oneOff, decimal monthly, decimal annual, IFixture fixture)
         {
-            var price = 12M;
-
             (decimal Price, int LowerRange, int? UpperRange) tier = (price, 1, null);
 
             OrderItem orderItem = BuildOrderItem(fixture, 1, new[] { tier }, CataloguePriceCalculationType.SingleFixed);
@@ -280,18 +280,22 @@ namespace NHSD.GPIT.BuyingCatalogue.Framework.UnitTests.Calculations
                 .Create();
 
             order.TotalOneOffCost().Should().Be(oneOff);
+            order.TotalOneOffCost(true).Should().Be(Math.Round(oneOff, 2, MidpointRounding.AwayFromZero));
             order.TotalMonthlyCost().Should().Be(monthly);
+            order.TotalMonthlyCost(true).Should().Be(Math.Round(monthly, 2, MidpointRounding.AwayFromZero));
             order.TotalAnnualCost().Should().Be(annual);
+            order.TotalAnnualCost(true).Should().Be(Math.Round(annual, 2, MidpointRounding.AwayFromZero));
         }
 
         [Theory]
-        [CommonInlineAutoData(TimeUnit.PerMonth, 12 * 24)]
-        [CommonInlineAutoData(TimeUnit.PerYear, 1 * 24)]
-        [CommonInlineAutoData(null, 12)]
-        public static void Order_TotalCost_PerMonth_And_PerYear_Use_MaximumTerm_But_OneOff_Costs_Dont(TimeUnit? billingPeriod, decimal total, IFixture fixture)
+        [CommonInlineAutoData(TimeUnit.PerMonth, 12, 12 * 24)]
+        [CommonInlineAutoData(TimeUnit.PerYear, 12, 1 * 24)]
+        [CommonInlineAutoData(TimeUnit.PerYear, 12.666, 25.332)]
+        [CommonInlineAutoData(null, 12, 12)]
+        [CommonInlineAutoData(null, 12.666, 12.666)]
+        public static void Order_TotalCost_PerMonth_And_PerYear_Use_MaximumTerm_But_OneOff_Costs_Dont(TimeUnit? billingPeriod, decimal price, decimal total, IFixture fixture)
         {
             var maximumTerm = 24;
-            var price = 12M;
 
             (decimal Price, int LowerRange, int? UpperRange) tier = (price, 1, null);
 
@@ -304,6 +308,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Framework.UnitTests.Calculations
                 .Create();
 
             order.TotalCost().Should().Be(total);
+            order.TotalCost(true).Should().Be(Math.Round(total, 2, MidpointRounding.AwayFromZero));
         }
 
         [Theory]

--- a/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/NHSD.GPIT.BuyingCatalogue.RegressionTests.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/NHSD.GPIT.BuyingCatalogue.RegressionTests.csproj
@@ -17,7 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="107.0.5304.6200" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="111.0.5563.6400" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SolutionSelection/ReviewSolutionsControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SolutionSelection/ReviewSolutionsControllerTests.cs
@@ -54,7 +54,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Sol
 
             var actualResult = result.Should().BeOfType<ViewResult>().Subject;
 
-            var expected = new ReviewSolutionsModel(order, internalOrgId);
+            var expected = new ReviewSolutionsModel(new OrderWrapper(order), internalOrgId);
 
             actualResult.Model.Should().BeEquivalentTo(expected, x => x.Excluding(o => o.BackLink));
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/Contracts/DeliveryDates/AmendDateModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/Contracts/DeliveryDates/AmendDateModelTests.cs
@@ -90,45 +90,13 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Contract
             model.MaximumTerm = null;
 
             model.ContractEndDate.Should().BeNull();
-
-            model.MaximumTerm = order.MaximumTerm;
-            model.TriageValue = null;
-
-            model.ContractEndDate.Should().BeNull();
-
-            model.TriageValue = order.OrderTriageValue;
-
-            model.ContractEndDate.Should().NotBeNull();
         }
 
         [Theory]
-        [CommonAutoData]
-        public static void ContractEndDate_DirectAward_ExpectedResult(
-            string internalOrgId,
-            CallOffId callOffId,
-            EntityFramework.Ordering.Models.Order order,
-            DateTime date,
-            RoutingSource source)
-        {
-            var orderItem = order.OrderItems.First();
-
-            var model = new AmendDateModel(internalOrgId, callOffId, orderItem.CatalogueItemId, order, date)
-            {
-                Source = source,
-                TriageValue = OrderTriageValue.Under40K,
-            };
-
-            var expected = order.CommencementDate!.Value
-                .AddMonths(order.MaximumTerm!.Value)
-                .AddDays(-1);
-
-            model.ContractEndDate.Should().Be(expected);
-        }
-
-        [Theory]
+        [CommonInlineAutoData(OrderTriageValue.Under40K)]
         [CommonInlineAutoData(OrderTriageValue.Between40KTo250K)]
         [CommonInlineAutoData(OrderTriageValue.Over250K)]
-        public static void ContractEndDate_OnOffCatalogueOrder_ExpectedResult(
+        public static void ContractEndDate_ExpectedResult(
             OrderTriageValue triageValue,
             string internalOrgId,
             CallOffId callOffId,
@@ -145,7 +113,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Contract
             };
 
             var expected = order.CommencementDate!.Value
-                .AddMonths(EndDate.MaximumTermForOnOffCatalogueOrders)
+                .AddMonths(order.MaximumTerm!.Value)
                 .AddDays(-1);
 
             model.ContractEndDate.Should().Be(expected);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/Contracts/DeliveryDates/AmendDateModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/Contracts/DeliveryDates/AmendDateModelTests.cs
@@ -145,7 +145,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Contract
             };
 
             var expected = order.CommencementDate!.Value
-                .AddMonths(AmendDateModel.MaximumTermForOnOffCatalogueOrders)
+                .AddMonths(EndDate.MaximumTermForOnOffCatalogueOrders)
                 .AddDays(-1);
 
             model.ContractEndDate.Should().Be(expected);

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/SolutionSelection/Review/ReviewExpanderModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/SolutionSelection/Review/ReviewExpanderModelTests.cs
@@ -1,0 +1,39 @@
+﻿using FluentAssertions;
+using MoreLinq;
+using NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.AutoFixtureCustomisations;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.Review;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.SolutionSelection.Review
+{
+    public static class ReviewExpanderModelTests
+    {
+        [Theory]
+        [CommonAutoData]
+        public static void WithValidArguments_PropertiesSetCorrectly(
+            EntityFramework.Ordering.Models.OrderItem orderItem)
+        {
+            var model = new ReviewExpanderModel(orderItem, null, isAmendment: false);
+
+            model.IsAmendment.Should().BeFalse();
+            model.IsOrderItemAdded.Should().BeTrue();
+            model.OrderItem.Should().Be(orderItem);
+
+            orderItem.OrderItemRecipients.ForEach(x => model.IsServiceRecipientAdded(x.OdsCode).Should().BeTrue());
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static void WithValidArguments_AndPreviousVersion_PropertiesSetCorrectly(
+            EntityFramework.Ordering.Models.OrderItem orderItem)
+        {
+            var model = new ReviewExpanderModel(orderItem, orderItem, isAmendment: true);
+
+            model.IsAmendment.Should().BeTrue();
+            model.IsOrderItemAdded.Should().BeFalse();
+            model.OrderItem.Should().Be(orderItem);
+
+            orderItem.OrderItemRecipients.ForEach(x => model.IsServiceRecipientAdded(x.OdsCode).Should().BeFalse());
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/SolutionSelection/Review/ReviewSolutionsModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/SolutionSelection/Review/ReviewSolutionsModelTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using FluentAssertions;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders;
 using NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.AutoFixtureCustomisations;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.Review;
 using Xunit;
@@ -18,8 +19,12 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Solution
             order.OrderItems.First().CatalogueItem.CatalogueItemType = CatalogueItemType.Solution;
             order.OrderItems = order.OrderItems.Where(oi => oi.CatalogueItem.CatalogueItemType == CatalogueItemType.Solution).ToList();
 
-            var model = new ReviewSolutionsModel(order, internalOrgId);
+            var wrapper = new OrderWrapper(order);
+            var model = new ReviewSolutionsModel(wrapper, internalOrgId);
 
+            model.Order.Should().Be(order);
+            model.Previous.Should().BeNull();
+            model.RolledUp.Should().BeEquivalentTo(wrapper.RolledUp);
             model.CallOffId.Should().BeEquivalentTo(order.CallOffId);
             model.CatalogueSolutions.Should().BeEquivalentTo(order.OrderItems);
             model.AdditionalServices.Should().BeEmpty();
@@ -27,6 +32,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Solution
             model.AllOrderItems.Should().HaveCount(1);
             model.ContractLength.Should().Be(order.MaximumTerm);
             model.InternalOrgId.Should().BeEquivalentTo(internalOrgId);
+            model.AssociatedServicesOnly.Should().Be(order.AssociatedServicesOnly);
         }
 
         [Theory]
@@ -39,8 +45,12 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Solution
             order.OrderItems.Last().CatalogueItem.CatalogueItemType = CatalogueItemType.AdditionalService;
             order.OrderItems = order.OrderItems.Where(oi => oi.CatalogueItem.CatalogueItemType != 0).ToList();
 
-            var model = new ReviewSolutionsModel(order, internalOrgId);
+            var wrapper = new OrderWrapper(order);
+            var model = new ReviewSolutionsModel(wrapper, internalOrgId);
 
+            model.Order.Should().Be(order);
+            model.Previous.Should().BeNull();
+            model.RolledUp.Should().BeEquivalentTo(wrapper.RolledUp);
             model.CallOffId.Should().BeEquivalentTo(order.CallOffId);
             model.CatalogueSolutions.Should().HaveCount(1);
             model.AdditionalServices.Should().HaveCount(1);
@@ -48,6 +58,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Solution
             model.AllOrderItems.Should().HaveCount(2);
             model.ContractLength.Should().Be(order.MaximumTerm);
             model.InternalOrgId.Should().BeEquivalentTo(internalOrgId);
+            model.AssociatedServicesOnly.Should().Be(order.AssociatedServicesOnly);
         }
 
         [Theory]
@@ -60,8 +71,12 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Solution
             order.OrderItems.Last().CatalogueItem.CatalogueItemType = CatalogueItemType.AssociatedService;
             order.OrderItems = order.OrderItems.Where(oi => oi.CatalogueItem.CatalogueItemType != 0).ToList();
 
-            var model = new ReviewSolutionsModel(order, internalOrgId);
+            var wrapper = new OrderWrapper(order);
+            var model = new ReviewSolutionsModel(wrapper, internalOrgId);
 
+            model.Order.Should().Be(order);
+            model.Previous.Should().BeNull();
+            model.RolledUp.Should().BeEquivalentTo(wrapper.RolledUp);
             model.CallOffId.Should().BeEquivalentTo(order.CallOffId);
             model.CatalogueSolutions.Should().HaveCount(1);
             model.AdditionalServices.Should().BeEmpty();
@@ -69,6 +84,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Solution
             model.AllOrderItems.Should().HaveCount(2);
             model.ContractLength.Should().Be(order.MaximumTerm);
             model.InternalOrgId.Should().BeEquivalentTo(internalOrgId);
+            model.AssociatedServicesOnly.Should().Be(order.AssociatedServicesOnly);
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/Contracts/DeliveryDates/AmendDateModelValidatorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/Contracts/DeliveryDates/AmendDateModelValidatorTests.cs
@@ -54,47 +54,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Validators.Cont
         }
 
         [Theory]
-        [CommonAutoData]
-        public static void Validate_DateAfterContractEndDate_DirectAward_ThrowsValidationError(
-            AmendDateModel model,
-            AmendDateModelValidator validator)
-        {
-            model.CommencementDate = DateTime.UtcNow.AddDays(-1).Date;
-            model.MaximumTerm = 1;
-            model.TriageValue = OrderTriageValue.Under40K;
-
-            var contractEndDate = model.CommencementDate.Value
-                .AddMonths(model.MaximumTerm.Value)
-                .AddDays(-1);
-
-            var invalidDate = model.CommencementDate.Value
-                .AddMonths(model.MaximumTerm.Value);
-
-            model.Day = $"{invalidDate.Day}";
-            model.Month = $"{invalidDate.Month}";
-            model.Year = $"{invalidDate.Year}";
-
-            var result = validator.TestValidate(model);
-
-            var errorMessage = string.Format(
-                AmendDateModelValidator.DeliveryDateAfterContractEndDateErrorMessage,
-                $"{contractEndDate:d MMMM yyyy}");
-
-            result.ShouldHaveValidationErrorFor(x => x.Day).WithErrorMessage(errorMessage);
-
-            model.Day = $"{contractEndDate.Day}";
-            model.Month = $"{contractEndDate.Month}";
-            model.Year = $"{contractEndDate.Year}";
-
-            result = validator.TestValidate(model);
-
-            result.ShouldNotHaveAnyValidationErrors();
-        }
-
-        [Theory]
+        [CommonInlineAutoData(OrderTriageValue.Under40K)]
         [CommonInlineAutoData(OrderTriageValue.Between40KTo250K)]
         [CommonInlineAutoData(OrderTriageValue.Over250K)]
-        public static void Validate_DateAfterContractEndDate_CatalogueAward_ThrowsValidationError(
+        public static void Validate_DateAfterContractEndDate_ThrowsValidationError(
             OrderTriageValue triageValue,
             AmendDateModel model,
             AmendDateModelValidator validator)
@@ -103,12 +66,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Validators.Cont
             model.MaximumTerm = 1;
             model.TriageValue = triageValue;
 
-            var contractEndDate = model.CommencementDate.Value
-                .AddMonths(EndDate.MaximumTermForOnOffCatalogueOrders)
-                .AddDays(-1);
-
-            var invalidDate = model.CommencementDate.Value
-                .AddMonths(EndDate.MaximumTermForOnOffCatalogueOrders);
+            var contractEndDate = new EndDate(model.CommencementDate, model.MaximumTerm).DateTime.Value;
+            var invalidDate = contractEndDate
+                .AddMonths(model.MaximumTerm.Value);
 
             model.Day = $"{invalidDate.Day}";
             model.Month = $"{invalidDate.Month}";

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/Contracts/DeliveryDates/AmendDateModelValidatorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/Contracts/DeliveryDates/AmendDateModelValidatorTests.cs
@@ -104,11 +104,11 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Validators.Cont
             model.TriageValue = triageValue;
 
             var contractEndDate = model.CommencementDate.Value
-                .AddMonths(AmendDateModel.MaximumTermForOnOffCatalogueOrders)
+                .AddMonths(EndDate.MaximumTermForOnOffCatalogueOrders)
                 .AddDays(-1);
 
             var invalidDate = model.CommencementDate.Value
-                .AddMonths(AmendDateModel.MaximumTermForOnOffCatalogueOrders);
+                .AddMonths(EndDate.MaximumTermForOnOffCatalogueOrders);
 
             model.Day = $"{invalidDate.Day}";
             model.Month = $"{invalidDate.Month}";


### PR DESCRIPTION
The main change covered by the PR is to update the review screen (`ReviewSolutions.cshtml`, `_ReviewExpaander.cshtml`) to make it `IsAmendment` aware. So when the page is used to view an amended order it shows a comparison between the old and new costs. 

- The cost calculation needs to take into account the planned delivery date of the service recipients that have been added. `TotalCost()` for an `OrderWrapper` was added to `CataloguePriceCalculations` as the value needs to be the sum of the previous and the amended order.
- The cost calculation needs to take into account the end date. `EndDate` class was added for the `RemainingTerm(...)` logic and to bring together existing/duplicated "End Date" logic in `Order.EndDate` and `AmendDateModel.ContractEndDate`.
- The amend planned delivery date validation for on off catalogue awards was changed to no longer use the 48 term window.
- The Table TagHelpers were updated to support right aligning of columns and cells identified as numeric.
- `OrderItermService.CopyOrderItemPrice(...)` was changed so that it copies the existing price and tier structure rather that just the price value. To support this change, new constructors were added to `OrderItemPrice` and `OrderItemPriceTier`
- Moved some logic related to creating an amended order from `OrderService.AmendOrder()` to the model `Order.BuildAmendment(...)`. This made it more readily available in tests and allowed removing further duplicaton from `OrderSeedData`


