### PR TITLE
Downgrade terraform and azurerm versions

### DIFF
--- a/terraform/webapp/main.tf
+++ b/terraform/webapp/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.3.9"
+  required_version = ">= 1.3.1"
 
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.46.0"
+      version = "3.18.0"
     }
   }
   backend "azurerm" {


### PR DESCRIPTION
Downgrading versions again as Terraform is a bit too brittle.

The latest versions cause an error with the `azurerm_mssql_failover_group` resource and the `timeouts` object. Documentation for this is quite poor so for now a rollback is a suitable option.