### PR TITLE
Amending order - Funding source

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/EndDate.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/EndDate.cs
@@ -18,7 +18,7 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
 
         public string DisplayValue => DateTime.HasValue ? $"{DateTime:d MMMM yyyy}" : string.Empty;
 
-        public decimal RemainingTerm(DateTime plannedDelivery)
+        public int RemainingTerm(DateTime plannedDelivery)
         {
             if (!DateTime.HasValue)
             {
@@ -28,7 +28,7 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
             return Math.Max(0, DifferenceInMonths(plannedDelivery, DateTime.Value.AddDays(1)));
         }
 
-        private decimal DifferenceInMonths(DateTime plannedDelivery, DateTime endDate)
+        private int DifferenceInMonths(DateTime plannedDelivery, DateTime endDate)
         {
             return ((endDate.Year - plannedDelivery.Year) * 12) + (endDate.Month - plannedDelivery.Month);
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.Framework/Calculations/PriceCalculationModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Framework/Calculations/PriceCalculationModel.cs
@@ -6,16 +6,19 @@
         {
         }
 
-        public PriceCalculationModel(int id, int quantity, decimal cost)
+        public PriceCalculationModel(int id, int quantity, decimal price, decimal cost)
         {
             Id = id;
             Quantity = quantity;
+            Price = price;
             Cost = cost;
         }
 
         public int Id { get; set; }
 
         public int Quantity { get; set; }
+
+        public decimal Price { get; set; }
 
         public decimal Cost { get; set; }
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/FundingSourceStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/FundingSourceStatusProvider.cs
@@ -25,8 +25,13 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
             }
 
             return AllFundingSourcesEntered(order)
-                ? TaskProgress.Completed
+                ? CompletedOrAmended(order.IsAmendment)
                 : (anyFundingSourcesEntered ? TaskProgress.InProgress : TaskProgress.NotStarted);
+        }
+
+        private static TaskProgress CompletedOrAmended(bool isAmendment)
+        {
+            return isAmendment ? TaskProgress.Amended : TaskProgress.Completed;
         }
 
         private static bool AllFundingSourcesEntered(EntityFramework.Ordering.Models.Order order)

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/ImplementationPlanStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/ImplementationPlanStatusProvider.cs
@@ -1,4 +1,5 @@
-﻿using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
+﻿using System.Linq;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.TaskList;
 
@@ -16,7 +17,9 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
 
             var order = wrapper.Order;
 
-            if (state.FundingSource != TaskProgress.Completed)
+            var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
+
+            if (!okToProgress.Contains(state.FundingSource))
             {
                 return order.ContractFlags?.UseDefaultImplementationPlan != null
                     ? TaskProgress.InProgress

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/SolutionOrServiceStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/SolutionOrServiceStatusProvider.cs
@@ -40,12 +40,19 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
 
         private static bool SolutionsSelected(EntityFramework.Ordering.Models.Order order)
         {
-            if (order.AssociatedServicesOnly)
+            if (!order.IsAmendment)
             {
-                return order.SolutionId != null;
-            }
+              if (order.AssociatedServicesOnly)
+              {
+                  return order.SolutionId != null;
+              }
 
-            return order.OrderItems.Any(x => x.CatalogueItem.CatalogueItemType == CatalogueItemType.Solution);
+              return order.OrderItems.Any(x => x.CatalogueItem.CatalogueItemType == CatalogueItemType.Solution);
+            }
+            else
+            {
+                return order.OrderItems.Any();
+            }
         }
 
         private static bool SolutionsCompleted(EntityFramework.Ordering.Models.Order order)

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/SolutionOrServiceStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/SolutionOrServiceStatusProvider.cs
@@ -29,8 +29,13 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
             }
 
             return SolutionsCompleted(order)
-                ? TaskProgress.Completed
+                ? CompletedOrAmended(order.IsAmendment)
                 : TaskProgress.InProgress;
+        }
+
+        private static TaskProgress CompletedOrAmended(bool isAmendment)
+        {
+            return isAmendment ? TaskProgress.Amended : TaskProgress.Completed;
         }
 
         private static bool SolutionsSelected(EntityFramework.Ordering.Models.Order order)

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Tags/NhsTagsTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Tags/NhsTagsTagHelper.cs
@@ -126,14 +126,14 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Tags
 
             var tagText = progress switch
             {
-                TaskProgress.NotApplicable => "Not applicable",
-                TaskProgress.NotStarted => "Not started",
-                TaskProgress.CannotStart => "Cannot start yet",
+                TaskProgress.NotApplicable => "Not&nbsp;applicable",
+                TaskProgress.NotStarted => "Not&nbsp;started",
+                TaskProgress.CannotStart => "Cannot&nbsp;start&nbsp;yet",
                 TaskProgress.Optional => "Optional",
-                TaskProgress.InProgress => "In progress",
+                TaskProgress.InProgress => "In&nbsp;progress",
                 TaskProgress.Completed => "Completed",
                 TaskProgress.Amended => "Amended",
-                _ => "Not started",
+                _ => "Not&nbsp;started",
             };
 
             return (selectedColourClass, tagText);

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/FundingSource/FundingSourceController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/FundingSource/FundingSourceController.cs
@@ -155,7 +155,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.FundingSourc
         }
 
         [HttpPost]
-        public async Task<IActionResult> FundingSources(FundingSources model, string internalOrgId, CallOffId callOffId)
+        public async Task<IActionResult> FundingSourcesContinue(string internalOrgId, CallOffId callOffId)
         {
             await orderService.SetFundingSourceForForceFundedItems(internalOrgId, callOffId);
 
@@ -168,7 +168,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.FundingSourc
         [HttpGet("{catalogueItemId}/funding-source")]
         public async Task<IActionResult> FundingSource(string internalOrgId, CallOffId callOffId, CatalogueItemId catalogueItemId)
         {
-            var order = (await orderService.GetOrderThin(callOffId, internalOrgId)).Order;
+            var order = (await orderService.GetOrderWithOrderItemsForFunding(callOffId, internalOrgId)).Order;
 
             var item = await orderItemService.GetOrderItem(callOffId, internalOrgId, catalogueItemId);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/FundingSources/FundingSource.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/FundingSources/FundingSource.cs
@@ -17,7 +17,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.FundingSources
             CallOffId = callOffId;
             CatalogueItemName = orderItem.CatalogueItem.Name;
             SelectedFundingType = orderItem.FundingType;
-            TotalCost = orderItem.OrderItemPrice.CalculateTotalCostForContractLength(orderItem.TotalQuantity, order.MaximumTerm!.Value);
+            TotalCost = order.TotalCostForOrderItem(orderItem.CatalogueItem.Id);
         }
 
         public string CatalogueItemName { get; set; }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/FundingSources/FundingSources.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/FundingSources/FundingSources.cs
@@ -13,12 +13,13 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.FundingSources
 
         public FundingSources(string internalOrgId, CallOffId callOffId, Order order, int countOfOrderFrameworks)
         {
+            Order = order;
             Title = "Funding sources";
             InternalOrgId = internalOrgId;
             CallOffId = callOffId;
             Caption = $"Order {CallOffId}";
-            MaximumTerm = order.MaximumTerm!.Value;
             CountOfOrderFrameworks = countOfOrderFrameworks;
+
             SelectedFramework = order.SelectedFramework;
 
             var completedOrderItems = order.OrderItems.Where(oi => oi.AllQuantitiesEntered).ToList();
@@ -35,6 +36,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.FundingSources
             OrderItemsNoFundingRequired = completedOrderItems.Where(oi => oi.OrderItemPrice.CalculateTotalCost(oi.TotalQuantity) == 0).ToList();
         }
 
+        public Order Order { get; set; }
+
         public CallOffId CallOffId { get; set; }
 
         public List<OrderItem> OrderItemsSelectable { get; set; }
@@ -46,7 +49,5 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.FundingSources
         public EntityFramework.Catalogue.Models.Framework SelectedFramework { get; set; }
 
         public int CountOfOrderFrameworks { get; set; }
-
-        public int MaximumTerm { get; set; }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/SolutionSelection/Review/ReviewExpanderModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/SolutionSelection/Review/ReviewExpanderModel.cs
@@ -1,11 +1,13 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 
 namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.Review
 {
     public class ReviewExpanderModel
     {
-        public ReviewExpanderModel(OrderItem orderItem, OrderItem previous, bool isAmendment = false)
+        public ReviewExpanderModel(OrderItem orderItem, OrderItem previous, bool isAmendment)
         {
             IsAmendment = isAmendment;
             IsOrderItemAdded = orderItem != null && previous == null;
@@ -17,9 +19,19 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection
 
         public bool IsOrderItemAdded { get; }
 
-        public OrderItem OrderItem { get; }
+        public OrderItemPrice OrderItemPrice => OrderItem.OrderItemPrice;
 
-        public OrderItem Previous { get; }
+        public CatalogueItem CatalogueItem => OrderItem.CatalogueItem;
+
+        public ICollection<OrderItemRecipient> OrderItemRecipients => OrderItem.OrderItemRecipients;
+
+        public int RolledUpTotalQuantity => OrderItem.TotalQuantity;
+
+        public int PreviousTotalQuantity => Previous?.TotalQuantity ?? 0;
+
+        private OrderItem OrderItem { get; }
+
+        private OrderItem Previous { get; }
 
         public bool IsServiceRecipientAdded(string odsCode) =>
             OrderItem?.OrderItemRecipients?.FirstOrDefault(x => x.OdsCode == odsCode) != null

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/FundingSource/FundingSources.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/FundingSource/FundingSources.cshtml
@@ -1,23 +1,28 @@
 ﻿@using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
 @using NHSD.GPIT.BuyingCatalogue.EntityFramework.Extensions;
+@using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
 @using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.FundingSource
 @using static NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Tags.NhsTagsTagHelper
 @model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.FundingSources.FundingSources
 @{
-	ViewBag.Title = Model.Title;
+    ViewBag.Title = Model.Title;
+
+    var advice = Model.Order.IsAmendment
+        ? "Provide information on how you'll be paying for the amendments you've made to the previous order."
+        : "Provide information on how you'll be paying for this order.";
 }
 
 <partial name="Partials/_BackLink" model="Model" />
 <div class="nhsuk-grid-row">
-	<div class="nhsuk-grid-column-two-thirds">
-		<nhs-validation-summary />
-		<nhs-page-title title="@ViewBag.Title"
-						advice="Provide information on how you'll be paying for this order."
-						caption="@Model.Caption" />
+    <div class="nhsuk-grid-column-two-thirds">
+        <nhs-validation-summary />
+        <nhs-page-title title="@ViewBag.Title"
+                        advice="@advice"
+                        caption="@Model.Caption" />
 
-        @if (Model.CountOfOrderFrameworks > 1)
+        @if (Model.Order.IsAmendment == false && Model.CountOfOrderFrameworks > 1)
         {
-            <nhs-inset-text>
+            <nhs-inset-text data-test-id="funding-sources-multiple-frameworks-change">
                 <p>
                     These items are available from more than one framework. You’re procuring them from the @(Model.SelectedFramework.ShortName) framework.
                     <a href="@Url.Action(
@@ -34,114 +39,108 @@
             </nhs-inset-text>
         }
 
-		@if (Model.OrderItemsSelectable != null && Model.OrderItemsSelectable.Any())
-		{
-			<nhs-details label-text="What is central, local and mixed funding?">
-				<h2 class="nhsuk-heading-m">Central funding</h2>
-				<p>Central funding means you're using your centrally held allocation to pay for the order. Any solutions or services you order will be paid for by either NHS England or NHS Digital. The supplier will invoice the relevant organisation directly.</p>
-				<p>You should make sure you have enough of your central allocation available to pay for your order before placing it.</p>
-				<h2 class="nhsuk-heading-m">Local funding</h2>
-				<p>Local funding means your organisation will be paying for the order. The supplier will invoice you directly.</p>
-				<h2 class="nhsuk-heading-m">Mixed funding</h2>
-				<p>Mixed funding means your organisation will start paying with central funding, and when your allocation runs out, will move over to local funding.</p>
-			</nhs-details>
+        @if (Model.OrderItemsSelectable != null && Model.OrderItemsSelectable.Any())
+        {
+            <nhs-details label-text="What is central, local and mixed funding?">
+                <h2 class="nhsuk-heading-m">Central funding</h2>
+                <p>Central funding means you're using your centrally held allocation to pay for the order. Any solutions or services you order will be paid for by either NHS England or NHS Digital. The supplier will invoice the relevant organisation directly.</p>
+                <p>You should make sure you have enough of your central allocation available to pay for your order before placing it.</p>
+                <h2 class="nhsuk-heading-m">Local funding</h2>
+                <p>Local funding means your organisation will be paying for the order. The supplier will invoice you directly.</p>
+                <h2 class="nhsuk-heading-m">Mixed funding</h2>
+                <p>Mixed funding means your organisation will start paying with central funding, and when your allocation runs out, will move over to local funding.</p>
+            </nhs-details>
 
-			<nhs-table data-test-id="funding-sources-items-editable" 
-					   label-text="Allocate funding"
-					   label-hint="Allocate the funding sources you want to use to pay for the following solutions or services.">
-				<nhs-table-column>Solution or service</nhs-table-column>
-				<nhs-table-column>Total cost</nhs-table-column>
-				<nhs-table-column>Funding type</nhs-table-column>
-				<nhs-table-column>Status</nhs-table-column>
-				<nhs-table-column>Action</nhs-table-column>
-				@foreach (var item in Model.OrderItemsSelectable)
-				{
-				<nhs-table-row-container>
-					<nhs-table-cell>@item.CatalogueItem.Name</nhs-table-cell>
-					<nhs-table-cell>@($"£{CalculateTotalCost(item).ToString("N2")}")</nhs-table-cell>
-					<nhs-table-cell>@item.FundingType.Description()</nhs-table-cell>
-					<nhs-table-cell><nhs-tag text="@FormatFundingType(item.FundingType)" colour="@FormatFundingTypeColour(item.FundingType)"></nhs-tag></nhs-table-cell>
-					<nhs-table-cell>
-						<a data-test-id="@item.CatalogueItem.Name.Trim().Replace(' ', '-')" asp-controller="@typeof(FundingSourceController).ControllerName()"
-							asp-action="@nameof(FundingSourceController.FundingSource)"
-							asp-route-internalOrgId="@Model.InternalOrgId"
-							asp-route-callOffId="@Model.CallOffId"
-							asp-route-catalogueItemId="@item.CatalogueItemId">Edit</a>
-					</nhs-table-cell>						
-				</nhs-table-row-container>
-				}           
-				<nhs-table-row-container>
-					<nhs-table-cell><b>Total</b></nhs-table-cell>
-					<nhs-table-cell>@($"£{Model.OrderItemsSelectable.Sum(oi => CalculateTotalCost(oi)).ToString("N2")}")</nhs-table-cell>
-					<nhs-table-cell></nhs-table-cell>
-					<nhs-table-cell></nhs-table-cell>
-				</nhs-table-row-container>
-			</nhs-table>
-                <p><b>All prices exclude VAT.</b></p>
-			<br/>
-		}
-		@if (Model.OrderItemsLocalOnly != null && Model.OrderItemsLocalOnly.Any())
-		{
-			<nhs-table data-test-id="funding-sources-items-local-only"
-					   label-text="Local funding only"
-			           label-hint="You can only pay for the following solutions or services with local funding due to the framework they're available from.">
-				<nhs-table-column>Solution or service</nhs-table-column>
-				<nhs-table-column>Total cost</nhs-table-column>
-				<nhs-table-column></nhs-table-column>
-				<nhs-table-column></nhs-table-column>
-				@foreach (var item in Model.OrderItemsLocalOnly)
-				{
-				<nhs-table-row-container>
-					<nhs-table-cell>@item.CatalogueItem.Name</nhs-table-cell>
-					<nhs-table-cell>@($"£{CalculateTotalCost(item).ToString("N2")}")</nhs-table-cell>
-					<nhs-table-cell></nhs-table-cell>
-					<nhs-table-cell></nhs-table-cell>
-				</nhs-table-row-container>
-				}           
-				<nhs-table-row-container>
+            <nhs-table data-test-id="funding-sources-items-editable"
+                   label-text="Allocate funding"
+                   label-hint="Allocate the funding sources you want to use to pay for the following solutions or services.">
+                <nhs-table-column>Solution or service</nhs-table-column>
+                <nhs-table-column>Total cost</nhs-table-column>
+                <nhs-table-column>Funding type</nhs-table-column>
+                <nhs-table-column>Status</nhs-table-column>
+                <nhs-table-column>Action</nhs-table-column>
+                @foreach (var item in Model.OrderItemsSelectable)
+                {
+                    <nhs-table-row-container>
+                        <nhs-table-cell>@item.CatalogueItem.Name</nhs-table-cell>
+                        <nhs-table-cell>@($"£{CalculateTotalCost(item).ToString("N2")}")</nhs-table-cell>
+                        <nhs-table-cell>@item.FundingType.Description()</nhs-table-cell>
+                        <nhs-table-cell><nhs-tag status-enum="@GetStatus(item)"></nhs-tag></nhs-table-cell>
+                        <nhs-table-cell>
+                            <a data-test-id="@item.CatalogueItem.Name.Trim().Replace(' ', '-')" asp-controller="@typeof(FundingSourceController).ControllerName()"
+                                asp-action="@nameof(FundingSourceController.FundingSource)"
+                                asp-route-internalOrgId="@Model.InternalOrgId"
+                                asp-route-callOffId="@Model.CallOffId"
+                                asp-route-catalogueItemId="@item.CatalogueItem.Id">Edit</a>
+                        </nhs-table-cell>
+                    </nhs-table-row-container>
+                }
+                <nhs-table-row-container>
                     <nhs-table-cell><b>Total</b></nhs-table-cell>
-					<nhs-table-cell>@($"£{Model.OrderItemsLocalOnly.Sum(oi => CalculateTotalCost(oi)).ToString("N2")}")</nhs-table-cell>
-				</nhs-table-row-container>
-			</nhs-table>
-                <p><b>All prices exclude VAT.</b></p>
-			<br/>
-		}
-		@if (Model.OrderItemsNoFundingRequired != null && Model.OrderItemsNoFundingRequired.Any())
-		{
-			<nhs-table data-test-id="funding-sources-items-no-funding-required"
-					   label-text="No funding required"
-			           label-hint="You do not need to pay for the following solutions or services as they’re available free of charge.">
-				<nhs-table-column>Solution or service</nhs-table-column>
-				<nhs-table-column>Total cost</nhs-table-column>
-				<nhs-table-column></nhs-table-column>
-				<nhs-table-column></nhs-table-column>
-				@foreach (var item in Model.OrderItemsNoFundingRequired)
-				{
-				<nhs-table-row-container>
-					<nhs-table-cell>@item.CatalogueItem.Name</nhs-table-cell>
-					<nhs-table-cell>@($"£{CalculateTotalCost(item).ToString("N2")}")</nhs-table-cell>
-					<nhs-table-cell></nhs-table-cell>
-					<nhs-table-cell></nhs-table-cell>	
-				</nhs-table-row-container>
-				}
-			</nhs-table>
-			<br/>
-		}
-		<form method="post" >
-			<nhs-submit-button text="Continue"/>
-		</form>
-	</div>
+                    <nhs-table-cell>@($"£{Model.OrderItemsSelectable.Sum(oi => CalculateTotalCost(oi)).ToString("N2")}")</nhs-table-cell>
+                    <nhs-table-cell></nhs-table-cell>
+                    <nhs-table-cell></nhs-table-cell>
+                </nhs-table-row-container>
+            </nhs-table>
+            <p><b>All prices exclude VAT.</b></p>
+            <br />
+        }
+        @if (Model.OrderItemsLocalOnly != null && Model.OrderItemsLocalOnly.Any())
+        {
+            <nhs-table data-test-id="funding-sources-items-local-only"
+                   label-text="Local funding only"
+                   label-hint="You can only pay for the following solutions or services with local funding due to the framework they're available from.">
+                <nhs-table-column>Solution or service</nhs-table-column>
+                <nhs-table-column>Total cost</nhs-table-column>
+                <nhs-table-column></nhs-table-column>
+                <nhs-table-column></nhs-table-column>
+                @foreach (var item in Model.OrderItemsLocalOnly)
+                {
+                    <nhs-table-row-container>
+                        <nhs-table-cell>@item.CatalogueItem.Name</nhs-table-cell>
+                        <nhs-table-cell>@($"£{CalculateTotalCost(item).ToString("N2")}")</nhs-table-cell>
+                        <nhs-table-cell></nhs-table-cell>
+                        <nhs-table-cell></nhs-table-cell>
+                    </nhs-table-row-container>
+                }
+                <nhs-table-row-container>
+                    <nhs-table-cell><b>Total</b></nhs-table-cell>
+                    <nhs-table-cell>@($"£{Model.OrderItemsLocalOnly.Sum(oi => CalculateTotalCost(oi)).ToString("N2")}")</nhs-table-cell>
+                </nhs-table-row-container>
+            </nhs-table>
+            <p><b>All prices exclude VAT.</b></p>
+            <br />
+        }
+        @if (Model.OrderItemsNoFundingRequired != null && Model.OrderItemsNoFundingRequired.Any())
+        {
+            <nhs-table data-test-id="funding-sources-items-no-funding-required"
+                   label-text="No funding required"
+                   label-hint="You do not need to pay for the following solutions or services as they’re available free of charge.">
+                <nhs-table-column>Solution or service</nhs-table-column>
+                <nhs-table-column>Total cost</nhs-table-column>
+                <nhs-table-column></nhs-table-column>
+                <nhs-table-column></nhs-table-column>
+                @foreach (var item in Model.OrderItemsNoFundingRequired)
+                {
+                    <nhs-table-row-container>
+                        <nhs-table-cell>@item.CatalogueItem.Name</nhs-table-cell>
+                        <nhs-table-cell>@($"£{CalculateTotalCost(item).ToString("N2")}")</nhs-table-cell>
+                        <nhs-table-cell></nhs-table-cell>
+                        <nhs-table-cell></nhs-table-cell>
+                    </nhs-table-row-container>
+                }
+            </nhs-table>
+            <br />
+        }
+        <form method="post">
+            <nhs-submit-button text="Continue" />
+        </form>
+    </div>
 </div>
 
 @{
-	string FormatFundingType(OrderItemFundingType fundingType) =>
-	fundingType == OrderItemFundingType.None ? "Not&nbsp;Started" : "Completed";
+    TaskProgress GetStatus(OrderItem item) => item.FundingType == OrderItemFundingType.None ? TaskProgress.NotStarted : TaskProgress.Completed;
 
-	TagColour FormatFundingTypeColour(OrderItemFundingType fundingType) => 
-	fundingType == OrderItemFundingType.None ? TagColour.Grey : TagColour.Green;
-
-	decimal CalculateTotalCost(OrderItem item) => item.OrderItemPrice.CalculateTotalCostForContractLength(item.TotalQuantity, Model.MaximumTerm);
-
-
+    decimal CalculateTotalCost(OrderItem item) => Model.Order.TotalCostForOrderItem(item.CatalogueItem.Id);
 }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/ReviewSolutions/_ReviewExpander.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/ReviewSolutions/_ReviewExpander.cshtml
@@ -5,16 +5,14 @@
 @using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Table
 @model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.Review.ReviewExpanderModel
 @{
-    var totalCostsRolledUp = Model.OrderItem.OrderItemPrice.CalculateTotalCostPerTier(Model.OrderItem.TotalQuantity);
-    var totalCostsPrevious = Model.IsAmendment && Model.Previous is not null
-        ? Model.Previous.OrderItemPrice.CalculateTotalCostPerTier(Model.Previous.TotalQuantity)
-        : Model.OrderItem.OrderItemPrice.CalculateTotalCostPerTier(0);
-    var hasTieredPricing = Model.OrderItem.OrderItemPrice?.CataloguePriceType is CataloguePriceType.Tiered;
-    var hasServiceRecipientQuantities = Model.OrderItem.OrderItemPrice?.IsPerServiceRecipient() ?? false;
+    var totalCostsRolledUp = Model.OrderItemPrice.CalculateTotalCostPerTier(Model.RolledUpTotalQuantity);
+    var totalCostsPrevious = Model.OrderItemPrice.CalculateTotalCostPerTier(Model.PreviousTotalQuantity);
+    var hasTieredPricing = Model.OrderItemPrice.CataloguePriceType is CataloguePriceType.Tiered;
+    var hasServiceRecipientQuantities = Model.OrderItemPrice.IsPerServiceRecipient();
     var tableText = Model.IsAmendment ? "Pricing and total quantities" : "Pricing";
 }
 
-<nhs-expander label-text="@Model.OrderItem.CatalogueItem.Name"
+<nhs-expander label-text="@Model.CatalogueItem.Name"
               added-sticker="@Model.IsAmendment && @Model.IsOrderItemAdded"
 			  colour-mode="BlackAndWhite"
 			  open="true"
@@ -27,7 +25,7 @@
         }
         <nhs-table-column>Recipient</nhs-table-column>
         <nhs-table-column>Quantity</nhs-table-column>
-        @foreach (var recipient in Model.OrderItem.OrderItemRecipients)
+        @foreach (var recipient in Model.OrderItemRecipients)
         {
             <nhs-table-row-container>
                 @if (Model.IsAmendment)
@@ -78,8 +76,6 @@
         }
         @for (var i = 0; i < totalCostsRolledUp.Count; i++)
         {
-            var price = Model.OrderItem.OrderItemPrice.OrderItemPriceTiers.ElementAt(i).Price;
-
             <nhs-table-row-container>
                 @if (hasTieredPricing)
                 {
@@ -88,7 +84,7 @@
                     </nhs-table-cell>
                 }
                 <nhs-table-cell>
-                    £@($"{price:#,###,##0.00##}") @Model.OrderItem.OrderItemPrice.ToPriceUnitString()
+                    £@($"{totalCostsRolledUp[i].Price:#,###,##0.00##}") @Model.OrderItemPrice.ToPriceUnitString()
                 </nhs-table-cell>
                 @if (Model.IsAmendment)
                 {

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/FundingSources/FundingSources.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/FundingSources/FundingSources.cs
@@ -19,31 +19,34 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.FundingSources
         private static readonly CallOffId GPITFuturesCallOffId = new(90006, 1);
         private static readonly CallOffId NoFundingCallOffId = new(90015, 1);
 
-        private static readonly Dictionary<string, string> ParametersDFOCVC = new()
-        {
-            { nameof(InternalOrgId), InternalOrgId },
-            { "CallOffId", DFOCVCCallOffId.ToString() },
-        };
-
-        private static readonly Dictionary<string, string> ParametersGPITFutures = new()
-        {
-            { nameof(InternalOrgId), InternalOrgId },
-            { "CallOffId", GPITFuturesCallOffId.ToString() },
-        };
-
-        private static readonly Dictionary<string, string> ParametersNoFunding = new()
-        {
-            { nameof(InternalOrgId), InternalOrgId },
-            { "CallOffId", NoFundingCallOffId.ToString() },
-        };
-
         public FundingSources(LocalWebApplicationFactory factory)
             : base(
                  factory,
                  typeof(FundingSourceController),
                  nameof(FundingSourceController.FundingSources),
-                 ParametersGPITFutures)
+                 GetParameters(GPITFuturesCallOffId))
         {
+        }
+
+        [Theory]
+        [InlineData(90033, 1, true)]
+        [InlineData(90033, 2, false)]
+        public void FundingSources_MultipleFrameworks_AllSectionsDisplayed(int orderNumber, int revision, bool changeFrameworkDisplayed)
+        {
+            var callOffId = new CallOffId(orderNumber, revision);
+
+            NavigateToUrl(
+                typeof(FundingSourceController),
+                nameof(FundingSourceController.FundingSources),
+                GetParameters(callOffId));
+
+            CommonActions.PageTitle().Should().BeEquivalentTo($"Funding sources - Order {callOffId}".FormatForComparison());
+            CommonActions.GoBackLinkDisplayed().Should().BeTrue();
+            CommonActions.SaveButtonDisplayed().Should().BeTrue();
+            CommonActions.ElementIsDisplayed(Objects.Ordering.FundingSources.ChangeFramework).Should().Be(changeFrameworkDisplayed);
+            CommonActions.ElementIsDisplayed(Objects.Ordering.FundingSources.LocalOnlyFundingSourcesTable).Should().BeFalse();
+            CommonActions.ElementIsDisplayed(Objects.Ordering.FundingSources.EditableFundingSourcesTable).Should().BeTrue();
+            CommonActions.ElementIsDisplayed(Objects.Ordering.FundingSources.NoFundingRequiredSourcesTable).Should().BeFalse();
         }
 
         [Fact]
@@ -52,11 +55,12 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.FundingSources
             NavigateToUrl(
                 typeof(FundingSourceController),
                 nameof(FundingSourceController.FundingSources),
-                ParametersDFOCVC);
+                GetParameters(DFOCVCCallOffId));
 
             CommonActions.PageTitle().Should().BeEquivalentTo($"Funding sources - Order {DFOCVCCallOffId}".FormatForComparison());
             CommonActions.GoBackLinkDisplayed().Should().BeTrue();
             CommonActions.SaveButtonDisplayed().Should().BeTrue();
+            CommonActions.ElementIsDisplayed(Objects.Ordering.FundingSources.ChangeFramework).Should().BeFalse();
             CommonActions.ElementIsDisplayed(Objects.Ordering.FundingSources.LocalOnlyFundingSourcesTable).Should().BeTrue();
             CommonActions.ElementIsDisplayed(Objects.Ordering.FundingSources.EditableFundingSourcesTable).Should().BeFalse();
             CommonActions.ElementIsDisplayed(Objects.Ordering.FundingSources.NoFundingRequiredSourcesTable).Should().BeFalse();
@@ -68,6 +72,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.FundingSources
             CommonActions.PageTitle().Should().BeEquivalentTo($"Funding sources - Order {GPITFuturesCallOffId}".FormatForComparison());
             CommonActions.GoBackLinkDisplayed().Should().BeTrue();
             CommonActions.SaveButtonDisplayed().Should().BeTrue();
+            CommonActions.ElementIsDisplayed(Objects.Ordering.FundingSources.ChangeFramework).Should().BeFalse();
             CommonActions.ElementIsDisplayed(Objects.Ordering.FundingSources.LocalOnlyFundingSourcesTable).Should().BeFalse();
             CommonActions.ElementIsDisplayed(Objects.Ordering.FundingSources.EditableFundingSourcesTable).Should().BeTrue();
             CommonActions.ElementIsDisplayed(Objects.Ordering.FundingSources.NoFundingRequiredSourcesTable).Should().BeFalse();
@@ -79,11 +84,12 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.FundingSources
             NavigateToUrl(
                 typeof(FundingSourceController),
                 nameof(FundingSourceController.FundingSources),
-                ParametersNoFunding);
+                GetParameters(NoFundingCallOffId));
 
             CommonActions.PageTitle().Should().BeEquivalentTo($"Funding sources - Order {NoFundingCallOffId}".FormatForComparison());
             CommonActions.GoBackLinkDisplayed().Should().BeTrue();
             CommonActions.SaveButtonDisplayed().Should().BeTrue();
+            CommonActions.ElementIsDisplayed(Objects.Ordering.FundingSources.ChangeFramework).Should().BeFalse();
             CommonActions.ElementIsDisplayed(Objects.Ordering.FundingSources.LocalOnlyFundingSourcesTable).Should().BeFalse();
             CommonActions.ElementIsDisplayed(Objects.Ordering.FundingSources.EditableFundingSourcesTable).Should().BeFalse();
             CommonActions.ElementIsDisplayed(Objects.Ordering.FundingSources.NoFundingRequiredSourcesTable).Should().BeTrue();
@@ -120,6 +126,15 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.FundingSources
                 typeof(FundingSourceController),
                 nameof(FundingSourceController.FundingSource))
                 .Should().BeTrue();
+        }
+
+        private static Dictionary<string, string> GetParameters(CallOffId callOffId)
+        {
+            return new()
+            {
+                { nameof(InternalOrgId), InternalOrgId },
+                { "CallOffId", callOffId.ToString() },
+            };
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Objects/Ordering/FundingSources.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Objects/Ordering/FundingSources.cs
@@ -11,6 +11,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.Ordering
 
         public static By LocalOnlyFundingSourcesTable => ByExtensions.DataTestId("funding-sources-items-local-only");
 
+        public static By ChangeFramework => ByExtensions.DataTestId("funding-sources-multiple-frameworks-change");
+
         public static By NoFundingRequiredSourcesTable => ByExtensions.DataTestId("funding-sources-items-no-funding-required");
 
         public static By EditLink => By.LinkText("Edit");

--- a/tests/NHSD.GPIT.BuyingCatalogue.ServiceContracts.UnitTests/Orders/OrderWrapperTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.ServiceContracts.UnitTests/Orders/OrderWrapperTests.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using AutoFixture;
+using FluentAssertions;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.Framework.Calculations;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders;
+using NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.AutoFixtureCustomisations;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.UnitTests.Orders
+{
+    public static class OrderWrapperTests
+    {
+        [Theory]
+        [CommonAutoData]
+        public static void OrderWrapper_RolledUp_Uses_Old_Order_Data_Apart_From_Revision(IFixture fixture)
+        {
+            var order = fixture.Build<Order>()
+                .With(o => o.Revision, 1)
+                .Create();
+
+            var amendedOrder = order.BuidAmendment(2);
+            amendedOrder.Description = $"Edited-{order.Description}";
+
+            var orderWrapper = new OrderWrapper(new[] { order, amendedOrder });
+
+            orderWrapper.Previous.Revision.Should().Be(1);
+            orderWrapper.Previous.Description.Should().Be(order.Description);
+            orderWrapper.Order.Revision.Should().Be(2);
+            orderWrapper.Order.Description.Should().Be($"Edited-{order.Description}");
+            orderWrapper.RolledUp.Revision.Should().Be(2);
+            orderWrapper.RolledUp.Description.Should().Be(order.Description);
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static void OrderWrapper_RolledUp_Uses_Old_OrderItem_Data(CatalogueItem catalogueItem, IFixture fixture)
+        {
+            OrderItem orderItem = BuildOrderItem(fixture, catalogueItem, OrderItemFundingType.LocalFunding);
+            OrderItem amendedOrderItem = BuildOrderItem(fixture, catalogueItem, OrderItemFundingType.MixedFunding);
+
+            Order order = BuildOrder(fixture, new[] { orderItem });
+            var amendedOrder = order.BuidAmendment(2);
+            amendedOrder.OrderItems = new HashSet<OrderItem> { amendedOrderItem };
+
+            var orderWrapper = new OrderWrapper(new[] { order, amendedOrder });
+
+            orderWrapper.Previous.OrderItems.Count.Should().Be(1);
+            orderWrapper.Previous.OrderItems.First().OrderItemRecipients.Count.Should().Be(1);
+            orderWrapper.Previous.OrderItems.First().FundingType.Should().Be(OrderItemFundingType.LocalFunding);
+            orderWrapper.Order.OrderItems.Count.Should().Be(1);
+            orderWrapper.Order.OrderItems.First().OrderItemRecipients.Count.Should().Be(1);
+            orderWrapper.Order.OrderItems.First().FundingType.Should().Be(OrderItemFundingType.MixedFunding);
+            orderWrapper.RolledUp.OrderItems.Count.Should().Be(1);
+            orderWrapper.RolledUp.OrderItems.First().OrderItemRecipients.Count.Should().Be(2);
+            orderWrapper.Previous.OrderItems.First().FundingType.Should().Be(OrderItemFundingType.LocalFunding);
+        }
+
+        private static Order BuildOrder(IFixture fixture, OrderItem[] orderItems)
+        {
+            return fixture.Build<Order>()
+                .With(o => o.Revision, 1)
+                .With(o => o.OrderItems, new HashSet<OrderItem>(orderItems))
+                .Create();
+        }
+
+        private static OrderItem BuildOrderItem(
+            IFixture fixture,
+            CatalogueItem catalogueItem,
+            OrderItemFundingType fundingType)
+        {
+            var quantity = 1;
+
+            var itemPrice = fixture.Build<OrderItemPrice>()
+                .Without(p => p.OrderItem)
+                .With(p => p.OrderItemPriceTiers, new HashSet<OrderItemPriceTier>())
+                .Create();
+
+            var recipient = fixture.Build<OrderItemRecipient>()
+                .With(r => r.Quantity, itemPrice.IsPerServiceRecipient() ? quantity : null)
+                .Create();
+
+            var funding = fixture.Build<OrderItemFunding>()
+                .Without(p => p.OrderItem)
+                .With(f => f.OrderItemFundingType, fundingType)
+                .Create();
+
+            var orderItem = fixture.Build<OrderItem>()
+                .Without(i => i.OrderItemFunding)
+                .With(i => i.CatalogueItem, catalogueItem)
+                .With(i => i.CatalogueItemId, catalogueItem.Id)
+                .With(i => i.OrderItemPrice, itemPrice)
+                .With(i => i.Quantity, itemPrice.IsPerServiceRecipient() ? null : quantity)
+                .With(i => i.OrderItemRecipients, new HashSet<OrderItemRecipient> { recipient })
+                .With(i => i.OrderItemFunding, funding)
+                .Create();
+
+            return orderItem;
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/FundingSourceStatusProviderTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/FundingSourceStatusProviderTests.cs
@@ -96,8 +96,11 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         }
 
         [Theory]
-        [CommonAutoData]
+        [CommonInlineAutoData(1, TaskProgress.Completed)]
+        [CommonInlineAutoData(2, TaskProgress.Amended)]
         public static void Get_AllFundingSourceInfoEntered_ReturnsCompleted(
+            int revision,
+            TaskProgress expectedTaskProgress,
             Order order,
             FundingSourceStatusProvider service)
         {
@@ -106,9 +109,11 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
                 DeliveryDates = TaskProgress.Completed,
             };
 
+            order.Revision = revision;
+
             var actual = service.Get(new OrderWrapper(order), state);
 
-            actual.Should().Be(TaskProgress.Completed);
+            actual.Should().Be(expectedTaskProgress);
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/ImplementationPlanStatusProviderTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/ImplementationPlanStatusProviderTests.cs
@@ -79,14 +79,16 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         }
 
         [Theory]
-        [CommonAutoData]
+        [CommonInlineAutoData(TaskProgress.Completed)]
+        [CommonInlineAutoData(TaskProgress.Amended)]
         public static void Get_ContractInfoNotEntered_ReturnsNotStarted(
+            TaskProgress fundingTaskProgress,
             Order order,
             ImplementationPlanStatusProvider service)
         {
             var state = new OrderProgress
             {
-                FundingSource = TaskProgress.Completed,
+                FundingSource = fundingTaskProgress,
             };
 
             order.ContractFlags.UseDefaultImplementationPlan = null;
@@ -97,16 +99,19 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         }
 
         [Theory]
-        [CommonInlineAutoData(true)]
-        [CommonInlineAutoData(false)]
+        [CommonInlineAutoData(TaskProgress.Completed, true)]
+        [CommonInlineAutoData(TaskProgress.Completed, false)]
+        [CommonInlineAutoData(TaskProgress.Amended, true)]
+        [CommonInlineAutoData(TaskProgress.Amended, false)]
         public static void Get_ContractInfoEntered_ReturnsCompleted(
+            TaskProgress fundingTaskProgress,
             bool useDefaultImplementationPlan,
             Order order,
             ImplementationPlanStatusProvider service)
         {
             var state = new OrderProgress
             {
-                FundingSource = TaskProgress.Completed,
+                FundingSource = fundingTaskProgress,
             };
 
             order.ContractFlags.UseDefaultImplementationPlan = useDefaultImplementationPlan;

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/SolutionOrServiceStatusProviderTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/SolutionOrServiceStatusProviderTests.cs
@@ -116,8 +116,11 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         }
 
         [Theory]
-        [CommonAutoData]
+        [CommonInlineAutoData(1, TaskProgress.Completed)]
+        [CommonInlineAutoData(2, TaskProgress.Amended)]
         public static void Get_SolutionSelected_EverythingPopulated_ReturnsCompleted(
+            int revision,
+            TaskProgress expectedTaskProgress,
             Order order,
             SolutionOrServiceStatusProvider service)
         {
@@ -126,13 +129,14 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
                 CommencementDateStatus = TaskProgress.Completed,
             };
 
+            order.Revision = revision;
             order.AssociatedServicesOnly = false;
             order.OrderItems.ForEach(x => x.CatalogueItem.CatalogueItemType = CatalogueItemType.AdditionalService);
             order.OrderItems.First().CatalogueItem.CatalogueItemType = CatalogueItemType.Solution;
 
             var actual = service.Get(new OrderWrapper(order), state);
 
-            actual.Should().Be(TaskProgress.Completed);
+            actual.Should().Be(expectedTaskProgress);
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/SolutionOrServiceStatusProviderTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/SolutionOrServiceStatusProviderTests.cs
@@ -57,8 +57,10 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         }
 
         [Theory]
-        [CommonAutoData]
+        [CommonInlineAutoData(CatalogueItemType.AdditionalService)]
+        [CommonInlineAutoData(CatalogueItemType.AssociatedService)]
         public static void Get_NoSolutionSelected_ReturnsNotStarted(
+            CatalogueItemType itemType,
             Order order,
             SolutionOrServiceStatusProvider service)
         {
@@ -68,11 +70,64 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             };
 
             order.AssociatedServicesOnly = false;
-            order.OrderItems.ForEach(x => x.CatalogueItem.CatalogueItemType = CatalogueItemType.AdditionalService);
+            order.OrderItems.ForEach(x => x.CatalogueItem.CatalogueItemType = itemType);
 
             var actual = service.Get(new OrderWrapper(order), state);
 
             actual.Should().Be(TaskProgress.NotStarted);
+        }
+
+        [Theory]
+        [CommonAutoData]
+        public static void Get_NothingAmended_ReturnsNotStarted(
+            Order order,
+            SolutionOrServiceStatusProvider service)
+        {
+            var state = new OrderProgress
+            {
+                CommencementDateStatus = TaskProgress.Completed,
+            };
+
+            order.Revision = 1;
+            order.AssociatedServicesOnly = false;
+            order.OrderItems.ForEach(x => x.CatalogueItem.CatalogueItemType = CatalogueItemType.AdditionalService);
+            var amendedOrder = order.BuidAmendment(2);
+
+            var actual = service.Get(new OrderWrapper(new[] { order, amendedOrder }), state);
+
+            actual.Should().Be(TaskProgress.NotStarted);
+        }
+
+        [Theory]
+        [CommonInlineAutoData(CatalogueItemType.Solution)]
+        [CommonInlineAutoData(CatalogueItemType.AdditionalService)]
+        [CommonInlineAutoData(CatalogueItemType.AssociatedService)]
+        public static void Get_Amending_ReturnsInProgress(
+            CatalogueItemType itemType,
+            Order order,
+            SolutionOrServiceStatusProvider service)
+        {
+            var state = new OrderProgress
+            {
+                CommencementDateStatus = TaskProgress.Completed,
+            };
+
+            order.Revision = 1;
+            order.AssociatedServicesOnly = false;
+            order.OrderItems.ForEach(x => x.CatalogueItem.CatalogueItemType = itemType);
+            var amendedOrder = order.BuidAmendment(2);
+            var orderItem = order.OrderItems.First();
+            var orderItemToAdd = new OrderItem
+            {
+                OrderId = order.Id,
+                CatalogueItemId = orderItem.CatalogueItemId,
+                CatalogueItem = orderItem.CatalogueItem,
+            };
+            amendedOrder.OrderItems.Add(orderItemToAdd);
+
+            var actual = service.Get(new OrderWrapper(new[] { order, amendedOrder }), state);
+
+            actual.Should().Be(TaskProgress.InProgress);
         }
 
         [Theory]

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/SolutionSelection/Review/ReviewExpanderModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/SolutionSelection/Review/ReviewExpanderModelTests.cs
@@ -17,8 +17,11 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Solution
 
             model.IsAmendment.Should().BeFalse();
             model.IsOrderItemAdded.Should().BeTrue();
-            model.OrderItem.Should().Be(orderItem);
-
+            model.OrderItemPrice.Should().Be(orderItem.OrderItemPrice);
+            model.CatalogueItem.Should().Be(orderItem.CatalogueItem);
+            model.OrderItemRecipients.Should().BeEquivalentTo(orderItem.OrderItemRecipients);
+            model.RolledUpTotalQuantity.Should().Be(orderItem.TotalQuantity);
+            model.PreviousTotalQuantity.Should().Be(0);
             orderItem.OrderItemRecipients.ForEach(x => model.IsServiceRecipientAdded(x.OdsCode).Should().BeTrue());
         }
 
@@ -31,7 +34,11 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Solution
 
             model.IsAmendment.Should().BeTrue();
             model.IsOrderItemAdded.Should().BeFalse();
-            model.OrderItem.Should().Be(orderItem);
+            model.OrderItemPrice.Should().Be(orderItem.OrderItemPrice);
+            model.CatalogueItem.Should().Be(orderItem.CatalogueItem);
+            model.OrderItemRecipients.Should().BeEquivalentTo(orderItem.OrderItemRecipients);
+            model.RolledUpTotalQuantity.Should().Be(orderItem.TotalQuantity);
+            model.PreviousTotalQuantity.Should().Be(orderItem.TotalQuantity);
 
             orderItem.OrderItemRecipients.ForEach(x => model.IsServiceRecipientAdded(x.OdsCode).Should().BeFalse());
         }


### PR DESCRIPTION
`TotalCostForOrderItem` replaces `CalculateTotalCostForContractLength` and takes an order so it's amendment aware and can use either the maximum term or the term based on the planned delivery dates for the recipients.

As part of the work on `FundingSources.cshtml` I replaced `FormatFundingType` and `FormatFundingTypeColour` with functionality built into `nhs-tag` using `status-enum` rather than `text` and `colour`

I've added `OrderWrapperTests` mainly to document some of the existing behaviour around the rolled up order. While the rolled up order contains all the order items and recipients, the order and order item data itself is taken from the oldest/previous order.

I tidied up `ReviewExpanderModel` and `_ReviewExpander.cshtml` because I initially expected to reuse some of the logic on the model but this wasn't necessary in the end - however I think the changes are worth keeping. As part of this I added `Price` to `ReviewExpanderModel` as this simplified some of the logic in the view too.
