### PR TITLE
Validation text change and display error for all the input quantities

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Validators/SolutionSelection/Quantity/SelectServiceRecipientQuantityModelValidator.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Validators/SolutionSelection/Quantity/SelectServiceRecipientQuantityModelValidator.cs
@@ -7,7 +7,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Validators.SolutionSelec
     {
         public SelectServiceRecipientQuantityModelValidator()
         {
-            RuleForEach(x => x.ServiceRecipients).SetValidator(new ServiceRecipientQuantityModelValidator());
+            RuleForEach(x => x.ServiceRecipients).Cascade(CascadeMode.Continue).SetValidator(new ServiceRecipientQuantityModelValidator());
         }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Validators/SolutionSelection/Quantity/ServiceRecipientQuantityModelValidator.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Validators/SolutionSelection/Quantity/ServiceRecipientQuantityModelValidator.cs
@@ -5,10 +5,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Validators.SolutionSelec
 {
     public class ServiceRecipientQuantityModelValidator : AbstractValidator<ServiceRecipientQuantityModel>
     {
-        public const string ValueNotEnteredErrorMessage = "Enter a quantity for this organisation";
-        public const string ValueNotNumericErrorMessage = "Quantity must be a number";
-        public const string ValueNotAnIntegerErrorMessage = "Quantity must be a whole number";
-        public const string ValueNegativeErrorMessage = "Quantity must be greater than zero";
+        public const string ValueNotEnteredErrorMessage = "Enter a practice list size for {0}";
+        public const string ValueNotNumericErrorMessage = "Practice list size for {0} must be a number";
+        public const string ValueNotAnIntegerErrorMessage = "Practice list size for {0} must be a whole number";
+        public const string ValueNegativeErrorMessage = "Practice list size for {0} must be greater than zero";
 
         public ServiceRecipientQuantityModelValidator()
         {
@@ -17,19 +17,19 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Validators.SolutionSelec
 
                 .Must(HaveAValue)
                 .OverridePropertyName(x => x.InputQuantity)
-                .WithMessage(ValueNotEnteredErrorMessage)
+                .WithMessage(model => string.Format(ValueNotEnteredErrorMessage, model.Name))
 
                 .Must(HaveANumericValue)
                 .OverridePropertyName(x => x.InputQuantity)
-                .WithMessage(ValueNotNumericErrorMessage)
+                .WithMessage(model => string.Format(ValueNotNumericErrorMessage, model.Name))
 
                 .Must(HaveAnIntegerValue)
                 .OverridePropertyName(x => x.InputQuantity)
-                .WithMessage(ValueNotAnIntegerErrorMessage)
+                .WithMessage(model => string.Format(ValueNotAnIntegerErrorMessage, model.Name))
 
                 .Must(HaveAPositiveValue)
                 .OverridePropertyName(x => x.InputQuantity)
-                .WithMessage(ValueNegativeErrorMessage);
+                .WithMessage(model => string.Format(ValueNegativeErrorMessage, model.Name));
         }
 
         private static bool HaveAValue(ServiceRecipientQuantityModel model) => !string.IsNullOrWhiteSpace(model.InputQuantity);

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Quantity/Base/SelectRecipientQuantity.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Quantity/Base/SelectRecipientQuantity.cs
@@ -18,6 +18,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Qu
     {
         private readonly int orderId;
         private readonly CatalogueItemId catalogueItemId;
+        private string serviceRecipientName = "Test Service Recipient One";
 
         protected SelectRecipientQuantity(LocalWebApplicationFactory factory, Dictionary<string, string> parameters)
             : base(factory, typeof(QuantityController), nameof(QuantityController.SelectServiceRecipientQuantity), parameters)
@@ -61,7 +62,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Qu
 
             CommonActions.ElementTextEqualTo(
                 QuantityObjects.InputQuantityInputError(0),
-                ServiceRecipientQuantityModelValidator.ValueNotEnteredErrorMessage).Should().BeTrue();
+                string.Format(ServiceRecipientQuantityModelValidator.ValueNotEnteredErrorMessage, serviceRecipientName)).Should().BeTrue();
         }
 
         [Fact]
@@ -79,7 +80,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Qu
 
             CommonActions.ElementTextEqualTo(
                 QuantityObjects.InputQuantityInputError(0),
-                ServiceRecipientQuantityModelValidator.ValueNotNumericErrorMessage).Should().BeTrue();
+                string.Format(ServiceRecipientQuantityModelValidator.ValueNotNumericErrorMessage, serviceRecipientName)).Should().BeTrue();
         }
 
         [Fact]
@@ -97,7 +98,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Qu
 
             CommonActions.ElementTextEqualTo(
                 QuantityObjects.InputQuantityInputError(0),
-                ServiceRecipientQuantityModelValidator.ValueNegativeErrorMessage).Should().BeTrue();
+                string.Format(ServiceRecipientQuantityModelValidator.ValueNegativeErrorMessage, serviceRecipientName)).Should().BeTrue();
         }
 
         [Fact]
@@ -115,7 +116,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Qu
 
             CommonActions.ElementTextEqualTo(
                 QuantityObjects.InputQuantityInputError(0),
-                ServiceRecipientQuantityModelValidator.ValueNotAnIntegerErrorMessage).Should().BeTrue();
+                string.Format(ServiceRecipientQuantityModelValidator.ValueNotAnIntegerErrorMessage, serviceRecipientName)).Should().BeTrue();
         }
 
         [Fact]

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/SolutionSelection/Quantity/SelectServiceRecipientQuantityModelValidatorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/SolutionSelection/Quantity/SelectServiceRecipientQuantityModelValidatorTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.TestHelper;
+using Moq;
+using NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.AutoFixtureCustomisations;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.Quantity;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Validators.SolutionSelection.Quantity;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Validators.SolutionSelection.Quantity
+{
+    public class SelectServiceRecipientQuantityModelValidatorTests
+    {
+        private readonly SelectServiceRecipientQuantityModelValidator validator;
+
+        public SelectServiceRecipientQuantityModelValidatorTests()
+        {
+            validator = new SelectServiceRecipientQuantityModelValidator();
+            validator.RuleForEach(x => x.ServiceRecipients)
+                     .Cascade(CascadeMode.Continue)
+                     .SetValidator(new ServiceRecipientQuantityModelValidator());
+        }
+
+        [Theory]
+        [CommonInlineAutoData("-1", false)]
+        [CommonInlineAutoData("0.5", false)]
+        [CommonInlineAutoData("a", false)]
+        [CommonInlineAutoData("0", false)]
+        [CommonInlineAutoData("1", true)]
+        public void Validate__ShouldValidateServiceRecipients_CompareResults(string quantity, bool expected)
+        {
+#pragma warning disable SA1413
+            var model = new SelectServiceRecipientQuantityModel
+            {
+                ServiceRecipients = new ServiceRecipientQuantityModel[]
+                {
+                    new ServiceRecipientQuantityModel
+                    {
+                        InputQuantity = quantity
+                    }
+                }
+            };
+#pragma warning restore SA1413
+
+            var result = validator.Validate(model);
+
+            Assert.Equal(expected, result.IsValid);
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/SolutionSelection/Quantity/ServiceRecipientQuantityModelValidatorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/SolutionSelection/Quantity/ServiceRecipientQuantityModelValidatorTests.cs
@@ -23,7 +23,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Validators.Solu
             var result = validator.TestValidate(model);
 
             result.ShouldHaveValidationErrorFor(x => x.InputQuantity)
-                .WithErrorMessage(ServiceRecipientQuantityModelValidator.ValueNotEnteredErrorMessage);
+                .WithErrorMessage(string.Format(ServiceRecipientQuantityModelValidator.ValueNotEnteredErrorMessage, model.Name));
         }
 
         [Theory]
@@ -39,7 +39,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Validators.Solu
             var result = validator.TestValidate(model);
 
             result.ShouldHaveValidationErrorFor(x => x.InputQuantity)
-                .WithErrorMessage(ServiceRecipientQuantityModelValidator.ValueNotNumericErrorMessage);
+                .WithErrorMessage(string.Format(ServiceRecipientQuantityModelValidator.ValueNotNumericErrorMessage, model.Name));
         }
 
         [Theory]
@@ -56,7 +56,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Validators.Solu
             var result = validator.TestValidate(model);
 
             result.ShouldHaveValidationErrorFor(x => x.InputQuantity)
-                .WithErrorMessage(ServiceRecipientQuantityModelValidator.ValueNotAnIntegerErrorMessage);
+                .WithErrorMessage(string.Format(ServiceRecipientQuantityModelValidator.ValueNotAnIntegerErrorMessage, model.Name));
         }
 
         [Theory]
@@ -70,7 +70,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Validators.Solu
             var result = validator.TestValidate(model);
 
             result.ShouldHaveValidationErrorFor(x => x.InputQuantity)
-                .WithErrorMessage(ServiceRecipientQuantityModelValidator.ValueNegativeErrorMessage);
+                .WithErrorMessage(string.Format(ServiceRecipientQuantityModelValidator.ValueNegativeErrorMessage, model.Name));
         }
 
         [Theory]


### PR DESCRIPTION
Displayed all validation messages triggered on the page at once and refined the validation texts for questions relating to practice list size.