### PR TITLE
Migrate Integration Tests to CollectionFixtures

### DIFF
--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/AddNominatedOrganisation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/AddNominatedOrganisation.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.AccountManagement
 {
-    public class AddNominatedOrganisation : AccountManagerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AccountManagementCollection))]
+    public class AddNominatedOrganisation : AccountManagerTestBase, IDisposable
     {
         private const int OrganisationId = 176;
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/AddNominatedOrganisation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/AddNominatedOrganisation.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.AccountManagement
 {
-    [Collection(nameof(AccountManagementCollection))]
+    [Collection(nameof(SharedContextCollection))]
     public class AddNominatedOrganisation : AccountManagerTestBase, IDisposable
     {
         private const int OrganisationId = 176;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/AddUser.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/AddUser.cs
@@ -18,7 +18,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.AccountManagement
 {
-    public sealed class AddUser : AccountManagerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AccountManagementCollection))]
+    public sealed class AddUser : AccountManagerTestBase
     {
         private const int OrganisationId = 176;
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/AddUser.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/AddUser.cs
@@ -18,7 +18,7 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.AccountManagement
 {
-    [Collection(nameof(AccountManagementCollection))]
+    [Collection(nameof(SharedContextCollection))]
     public sealed class AddUser : AccountManagerTestBase
     {
         private const int OrganisationId = 176;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/Details.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/Details.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.AccountManagement
 {
-    [Collection(nameof(AccountManagementCollection))]
+    [Collection(nameof(SharedContextCollection))]
     public sealed class Details : AccountManagerTestBase
     {
         private const int OrganisationId = 176;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/Details.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/Details.cs
@@ -12,7 +12,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.AccountManagement
 {
-    public sealed class Details : AccountManagerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AccountManagementCollection))]
+    public sealed class Details : AccountManagerTestBase
     {
         private const int OrganisationId = 176;
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/EditUser.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/EditUser.cs
@@ -106,22 +106,6 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.AccountManagement
         }
 
         [Fact]
-        public void EditUser_IncludesWhitespace_RemovesWhitespace()
-        {
-            CommonActions.ClearInputElement(AddUserObjects.FirstName);
-            AccountManagementPages.AddUser.EnterFirstName("    Alice    ");
-            CommonActions.ClearInputElement(AddUserObjects.LastName);
-            AccountManagementPages.AddUser.EnterLastName("    Smith    ");
-            CommonActions.ClearInputElement(AddUserObjects.Email);
-            AccountManagementPages.AddUser.EnterEmailAddress("    " + ValidEmail + "    ");
-            CommonActions.ClickSave();
-
-            CommonActions.PageLoadedCorrectGetIndex(
-                typeof(ManageAccountController),
-                nameof(ManageAccountController.Users)).Should().BeTrue();
-        }
-
-        [Fact]
         public void EditUser_EmptyInput_ThrowsErrors()
         {
             CommonActions.ClearInputElement(AddUserObjects.FirstName);

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/EditUser.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/EditUser.cs
@@ -18,7 +18,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.AccountManagement
 {
-    public sealed class EditUser : AccountManagerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AccountManagementCollection))]
+    public sealed class EditUser : AccountManagerTestBase, IDisposable
     {
         private const int OrganisationId = 176;
         private const int UserId = 5;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/EditUser.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/EditUser.cs
@@ -18,7 +18,7 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.AccountManagement
 {
-    [Collection(nameof(AccountManagementCollection))]
+    [Collection(nameof(SharedContextCollection))]
     public sealed class EditUser : AccountManagerTestBase, IDisposable
     {
         private const int OrganisationId = 176;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/NominatedOrganisations.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/NominatedOrganisations.cs
@@ -13,7 +13,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.AccountManagement
 {
-    public class NominatedOrganisations : AccountManagerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AccountManagementCollection))]
+    public class NominatedOrganisations : AccountManagerTestBase, IDisposable
     {
         private const int OrganisationId = 176;
         private const int RelatedOrganisationId = 5;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/NominatedOrganisations.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/NominatedOrganisations.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.AccountManagement
 {
-    [Collection(nameof(AccountManagementCollection))]
+    [Collection(nameof(SharedContextCollection))]
     public class NominatedOrganisations : AccountManagerTestBase, IDisposable
     {
         private const int OrganisationId = 176;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/RelatedOrganisations.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/RelatedOrganisations.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.AccountManagement
 {
-    [Collection(nameof(AccountManagementCollection))]
+    [Collection(nameof(SharedContextCollection))]
     public class RelatedOrganisations : AccountManagerTestBase, IDisposable
     {
         private const int OrganisationId = 176;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/RelatedOrganisations.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/RelatedOrganisations.cs
@@ -13,7 +13,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.AccountManagement
 {
-    public class RelatedOrganisations : AccountManagerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AccountManagementCollection))]
+    public class RelatedOrganisations : AccountManagerTestBase, IDisposable
     {
         private const int OrganisationId = 176;
         private const int RelatedOrganisationId = 3;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/RemoveNominatedOrganisation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/RemoveNominatedOrganisation.cs
@@ -13,7 +13,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.AccountManagement
 {
-    public class RemoveNominatedOrganisation : AccountManagerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AccountManagementCollection))]
+    public class RemoveNominatedOrganisation : AccountManagerTestBase, IDisposable
     {
         private const int OrganisationId = 176;
         private const int NominatedOrganisationId = 5;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/RemoveNominatedOrganisation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/RemoveNominatedOrganisation.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.AccountManagement
 {
-    [Collection(nameof(AccountManagementCollection))]
+    [Collection(nameof(SharedContextCollection))]
     public class RemoveNominatedOrganisation : AccountManagerTestBase, IDisposable
     {
         private const int OrganisationId = 176;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/RemoveRelatedOrganisation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/RemoveRelatedOrganisation.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.AccountManagement
 {
-    [Collection(nameof(AccountManagementCollection))]
+    [Collection(nameof(SharedContextCollection))]
     public class RemoveRelatedOrganisation : AccountManagerTestBase, IDisposable
     {
         private const int OrganisationId = 176;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/RemoveRelatedOrganisation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/RemoveRelatedOrganisation.cs
@@ -13,7 +13,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.AccountManagement
 {
-    public class RemoveRelatedOrganisation : AccountManagerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AccountManagementCollection))]
+    public class RemoveRelatedOrganisation : AccountManagerTestBase, IDisposable
     {
         private const int OrganisationId = 176;
         private const int RelatedOrganisationId = 3;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/Users.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/Users.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.AccountManagement
 {
-    [Collection(nameof(AccountManagementCollection))]
+    [Collection(nameof(SharedContextCollection))]
     public class Users : AccountManagerTestBase
     {
         private const int OrganisationId = 176;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/Users.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/AccountManagement/Users.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.AccountManagement
 {
-    public class Users : AccountManagerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AccountManagementCollection))]
+    public class Users : AccountManagerTestBase
     {
         private const int OrganisationId = 176;
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AddSolution.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AddSolution.cs
@@ -11,7 +11,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution
 {
-    public sealed class AddSolution : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class AddSolution : AuthorityTestBase
     {
         public AddSolution(LocalWebApplicationFactory factory)
             : base(

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AdditionalServices/AddAdditionalService.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AdditionalServices/AddAdditionalService.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.AdditionalServices
 {
-    public sealed class AddAdditionalService : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class AddAdditionalService : AuthorityTestBase
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AdditionalServices/AdditionalServiceCapabilities.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AdditionalServices/AdditionalServiceCapabilities.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.AdditionalServices
 {
-    public sealed class AdditionalServiceCapabilities : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class AdditionalServiceCapabilities : AuthorityTestBase
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
         private static readonly CatalogueItemId AdditionalServiceId = new(99999, "001A99");

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AdditionalServices/AdditionalServices.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AdditionalServices/AdditionalServices.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.AdditionalServices
 {
-    public sealed class AdditionalServices : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class AdditionalServices : AuthorityTestBase
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
         private static readonly CatalogueItemId SolutionIdNoAdditionalService = new(99997, "001");

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AdditionalServices/EditAdditionalService.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AdditionalServices/EditAdditionalService.cs
@@ -17,7 +17,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.AdditionalServices
 {
-    public sealed class EditAdditionalService : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditAdditionalService : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId IncompleteSolutionId = new(99999, "001");
         private static readonly CatalogueItemId IncompleteAdditionalServiceId = new(99999, "001A99");

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AdditionalServices/EditAdditionalServiceDetails.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AdditionalServices/EditAdditionalServiceDetails.cs
@@ -13,7 +13,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.AdditionalServices
 {
-    public sealed class EditAdditionalServiceDetails : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditAdditionalServiceDetails : AuthorityTestBase
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AssociatedServices/AddAssociatedService.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AssociatedServices/AddAssociatedService.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution
 {
-    public sealed class AddAssociatedService : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class AddAssociatedService : AuthorityTestBase
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AssociatedServices/AssociatedServices.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AssociatedServices/AssociatedServices.cs
@@ -14,7 +14,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.AssociatedServices
 {
-    public sealed class AssociatedServices : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class AssociatedServices : AuthorityTestBase
     {
         private const string TargetServiceId = "99999-S-999";
         private static readonly CatalogueItemId SolutionId = new(99999, "001");

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AssociatedServices/EditAssociatedService.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AssociatedServices/EditAssociatedService.cs
@@ -18,7 +18,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution
 {
-    public sealed class EditAssociatedService : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditAssociatedService : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId IncompleteSolutionId = new(99999, "001");
         private static readonly CatalogueItemId IncompleteAssociatedServiceId = new(99999, "S-998");

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AssociatedServices/EditAssociatedServiceDetails.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/AssociatedServices/EditAssociatedServiceDetails.cs
@@ -11,7 +11,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.AssociatedServices
 {
-    public sealed class EditAssociatedServiceDetails : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditAssociatedServiceDetails : AuthorityTestBase
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/AddClientApplicationType.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/AddClientApplicationType.cs
@@ -11,7 +11,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes
 {
-    public sealed class AddClientApplicationType : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class AddClientApplicationType : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/BrowserBased/AdditionalInformation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/BrowserBased/AdditionalInformation.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes.BrowserBased
 {
-    public sealed class AdditionalInformation : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class AdditionalInformation : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/BrowserBased/BrowserBasedDashboard.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/BrowserBased/BrowserBasedDashboard.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes.BrowserBased
 {
-    public sealed class BrowserBasedDashboard : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class BrowserBasedDashboard : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/BrowserBased/ConnectivityAndResolution.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/BrowserBased/ConnectivityAndResolution.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes.BrowserBased
 {
-    public sealed class ConnectivityAndResolution : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class ConnectivityAndResolution : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/BrowserBased/HardwareRequirements.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/BrowserBased/HardwareRequirements.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes.BrowserBased
 {
-    public sealed class HardwareRequirements : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class HardwareRequirements : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/BrowserBased/PluginsOrExtensions.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/BrowserBased/PluginsOrExtensions.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes.BrowserBased
 {
-    public sealed class PluginsOrExtensions : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class PluginsOrExtensions : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/BrowserBased/SupportedBrowsers.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/BrowserBased/SupportedBrowsers.cs
@@ -15,7 +15,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes.BrowserBased
 {
-    public sealed class SupportedBrowsers : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class SupportedBrowsers : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/ClientApplication.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/ClientApplication.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes
 {
-    public sealed class ClientApplication : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class ClientApplication : AuthorityTestBase
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
         private static readonly CatalogueItemId SolutionWithClientApplications = new CatalogueItemId(99999, "001");

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/DeleteClientApplicationType.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/DeleteClientApplicationType.cs
@@ -16,7 +16,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes
 {
-    public sealed class DeleteClientApplicationType : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class DeleteClientApplicationType : AuthorityTestBase
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/Desktop/AdditionalInformation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/Desktop/AdditionalInformation.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes.Desktop
 {
-    public sealed class AdditionalInformation : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class AdditionalInformation : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/Desktop/Connectivity.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/Desktop/Connectivity.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes.Desktop
 {
-    public sealed class Connectivity : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class Connectivity : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/Desktop/DesktopDashboard.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/Desktop/DesktopDashboard.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes.Desktop
 {
-    public sealed class DesktopDashboard : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class DesktopDashboard : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/Desktop/HardwareRequirements.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/Desktop/HardwareRequirements.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes.Desktop
 {
-    public sealed class HardwareRequirements : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class HardwareRequirements : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/Desktop/MemoryAndStorage.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/Desktop/MemoryAndStorage.cs
@@ -14,7 +14,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes.Desktop
 {
-    public sealed class MemoryAndStorage : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class MemoryAndStorage : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/Desktop/SupportedOperatingSystems.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/Desktop/SupportedOperatingSystems.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes.Desktop
 {
-    public sealed class SupportedOperatingSystems : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class SupportedOperatingSystems : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/Desktop/ThirdPartyComponents.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/Desktop/ThirdPartyComponents.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes.Desktop
 {
-    public sealed class ThirdPartyComponents : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class ThirdPartyComponents : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/MobileOrTablet/AdditionalInformation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/MobileOrTablet/AdditionalInformation.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes.MobileOrTablet
 {
-    public sealed class AdditionalInformation : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class AdditionalInformation : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/MobileOrTablet/Connectivity.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/MobileOrTablet/Connectivity.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes.MobileOrTablet
 {
-    public sealed class Connectivity : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class Connectivity : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/MobileOrTablet/HardwareRequirements.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/MobileOrTablet/HardwareRequirements.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes.MobileOrTablet
 {
-    public sealed class HardwareRequirements : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class HardwareRequirements : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/MobileOrTablet/MemoryAndStorage.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/MobileOrTablet/MemoryAndStorage.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes.MobileOrTablet
 {
-    public sealed class MemoryAndStorage : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class MemoryAndStorage : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/MobileOrTablet/MobileOrTabletDashboard.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/MobileOrTablet/MobileOrTabletDashboard.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes.MobileOrTablet
 {
-    public sealed class MobileOrTabletDashboard : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class MobileOrTabletDashboard : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/MobileOrTablet/SupportedOperatingSystems.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/MobileOrTablet/SupportedOperatingSystems.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes.MobileOrTablet
 {
-    public sealed class SupportedOperatingSystems : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class SupportedOperatingSystems : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/MobileOrTablet/ThirdPartyComponents.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ClientApplicationTypes/MobileOrTablet/ThirdPartyComponents.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ClientApplicationTypes.MobileOrTablet
 {
-    public sealed class ThirdPartyComponents : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class ThirdPartyComponents : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Description.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Description.cs
@@ -16,7 +16,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution
 {
-    public sealed class Description : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class Description : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Details.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Details.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution
 {
-    public sealed class Details : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class Details : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/DevelopmentPlans/AddWorkOffPlan.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/DevelopmentPlans/AddWorkOffPlan.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.DevelopmentPlans
 {
-    public sealed class AddWorkOffPlan : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class AddWorkOffPlan : AuthorityTestBase
     {
         private const string NoStandardSelectedError = "Select a Standard";
         private const string NoDetailsError = "Enter Work-off Plan item details";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/DevelopmentPlans/DeleteWorkOffPlan.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/DevelopmentPlans/DeleteWorkOffPlan.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.DevelopmentPlans
 {
-    public class DeleteWorkOffPlan : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public class DeleteWorkOffPlan : AuthorityTestBase
     {
         private const int WorkOffPlanId = 2;
         private static readonly CatalogueItemId SolutionId = new(99998, "001");

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/DevelopmentPlans/DevelopmentPlans.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/DevelopmentPlans/DevelopmentPlans.cs
@@ -14,7 +14,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.DevelopmentPlans
 {
-    public sealed class DevelopmentPlans : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class DevelopmentPlans : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/DevelopmentPlans/EditWorkOffPlan.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/DevelopmentPlans/EditWorkOffPlan.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.DevelopmentPlans
 {
-    public sealed class EditWorkOffPlan : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditWorkOffPlan : AuthorityTestBase, IDisposable
     {
         private const int WorkOffPlanId = 1;
         private static readonly CatalogueItemId SolutionId = new(99998, "001");

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/EditSupplierDetails.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/EditSupplierDetails.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution
 {
-    public sealed class EditSupplierDetails : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditSupplierDetails : AuthorityTestBase
     {
         private static readonly CatalogueItemId SolutionId = new(99998, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Features.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Features.cs
@@ -13,7 +13,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution
 {
-    public sealed class Features : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class Features : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/HostingTypes/DeleteHostingType.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/HostingTypes/DeleteHostingType.cs
@@ -12,7 +12,8 @@ using CommonSelectors = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.Com
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.HostingTypes
 {
-    public sealed class DeleteHostingType : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class DeleteHostingType : AuthorityTestBase
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
         private static readonly ServiceContracts.Solutions.HostingType HostingType = ServiceContracts.Solutions.HostingType.Hybrid;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/HostingTypes/EditHybridHostingType.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/HostingTypes/EditHybridHostingType.cs
@@ -10,7 +10,8 @@ using CommonSelectors = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.Com
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.HostingTypes
 {
-    public sealed class EditHybridHostingType : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditHybridHostingType : AuthorityTestBase
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/HostingTypes/EditOnPremiseHostingType.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/HostingTypes/EditOnPremiseHostingType.cs
@@ -10,7 +10,8 @@ using CommonSelectors = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.Com
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.HostingTypes
 {
-    public sealed class EditOnPremiseHostingType : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditOnPremiseHostingType : AuthorityTestBase
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/HostingTypes/EditPrivateCloudHostingType.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/HostingTypes/EditPrivateCloudHostingType.cs
@@ -10,7 +10,8 @@ using CommonSelectors = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.Com
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.HostingTypes
 {
-    public sealed class EditPrivateCloudHostingType : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditPrivateCloudHostingType : AuthorityTestBase
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/HostingTypes/EditPublicCloudHostingType.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/HostingTypes/EditPublicCloudHostingType.cs
@@ -10,7 +10,8 @@ using CommonSelectors = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.Com
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.HostingTypes
 {
-    public sealed class EditPublicCloudHostingType : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditPublicCloudHostingType : AuthorityTestBase
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/HostingTypes/HostingType.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/HostingTypes/HostingType.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.HostingTypes
 {
-    public sealed class HostingType : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class HostingType : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Implementation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Implementation.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution
 {
-    public sealed class Implementation : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class Implementation : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Interoperability/AddGPConnectIntegration.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Interoperability/AddGPConnectIntegration.cs
@@ -16,7 +16,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.Interoperability
 {
-    public sealed class AddGPConnectIntegration : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class AddGPConnectIntegration : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Interoperability/AddIM1Integration.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Interoperability/AddIM1Integration.cs
@@ -16,7 +16,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.Interoperability
 {
-    public sealed class AddIM1Integration : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class AddIM1Integration : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Interoperability/DeleteGpConnectIntegration.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Interoperability/DeleteGpConnectIntegration.cs
@@ -16,7 +16,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.Interoperability
 {
-    public sealed class DeleteGpConnectIntegration : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class DeleteGpConnectIntegration : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new CatalogueItemId(99999, "001");
         private static readonly Guid IntegrationId = Integrations.GetIntegrations[2].Id;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Interoperability/DeleteIm1Integration.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Interoperability/DeleteIm1Integration.cs
@@ -16,7 +16,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.Interoperability
 {
-    public sealed class DeleteIm1Integration : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class DeleteIm1Integration : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new CatalogueItemId(99999, "001");
         private static readonly Guid IntegrationId = Integrations.GetIntegrations[0].Id;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Interoperability/EditGpConnectIntegration.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Interoperability/EditGpConnectIntegration.cs
@@ -17,7 +17,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.Interoperability
 {
-    public sealed class EditGpConnectIntegration : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditGpConnectIntegration : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new CatalogueItemId(99999, "001");
         private static readonly Guid IntegrationId = Integrations.GetIntegrations[2].Id;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Interoperability/EditIm1Integration.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Interoperability/EditIm1Integration.cs
@@ -17,7 +17,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.Interoperability
 {
-    public sealed class EditIm1Integration : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditIm1Integration : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new CatalogueItemId(99999, "001");
         private static readonly Guid IntegrationId = Integrations.GetIntegrations[0].Id;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Interoperability/EditInteroperability.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/Interoperability/EditInteroperability.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.Interoperability
 {
-    public sealed class EditInteroperability : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditInteroperability : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "002");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/AddSLAContact.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/AddSLAContact.cs
@@ -16,7 +16,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ServiceLevelAgreements
 {
-    public sealed class AddSLAContact : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class AddSLAContact : AuthorityTestBase
     {
         private const string ChannelErrorNoInput = "Enter a contact channel";
         private const string ContactInformationNoInput = "Enter contact information";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/AddServiceAvailabilityTimes.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/AddServiceAvailabilityTimes.cs
@@ -16,7 +16,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ServiceLevelAgreements
 {
-    public sealed class AddServiceAvailabilityTimes : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class AddServiceAvailabilityTimes : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99998, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/AddSlaType.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/AddSlaType.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ServiceLevelAgreements
 {
-    public sealed class AddSlaType : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class AddSlaType : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/DeleteSLAContact.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/DeleteSLAContact.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ServiceLevelAgreements
 {
-    public sealed class DeleteSLAContact : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class DeleteSLAContact : AuthorityTestBase
     {
         private const int ContactId = 2;
         private static readonly CatalogueItemId SolutionId = new(99998, "002");

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/DeleteServiceAvailabilityTimes.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/DeleteServiceAvailabilityTimes.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ServiceLevelAgreements
 {
-    public sealed class DeleteServiceAvailabilityTimes : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class DeleteServiceAvailabilityTimes : AuthorityTestBase
     {
         private const int CancelLinkServiceAvailabilityTimesId = 2;
         private const int ServiceAvailabilityTimesId = 3;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/EditSLAContact.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/EditSLAContact.cs
@@ -16,7 +16,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ServiceLevelAgreements
 {
-    public sealed class EditSLAContact : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditSLAContact : AuthorityTestBase, IDisposable
     {
         private const string ChannelErrorNoInput = "Enter a contact channel";
         private const string ContactInformationNoInput = "Enter contact information";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/EditServiceAvailabilityTimes.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/EditServiceAvailabilityTimes.cs
@@ -16,7 +16,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ServiceLevelAgreements
 {
-    public sealed class EditServiceAvailabilityTimes : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditServiceAvailabilityTimes : AuthorityTestBase, IDisposable
     {
         private const int SingleAvailabilityTimesId = 1;
         private const int ServiceAvailabilityTimesId = 2;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/EditServiceLevelAgreement.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/EditServiceLevelAgreement.cs
@@ -13,7 +13,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ServiceLevelAgreements
 {
-    public sealed class EditServiceLevelAgreement : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditServiceLevelAgreement : AuthorityTestBase
     {
         private static readonly CatalogueItemId SolutionId = new(99998, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/EditSlaType.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/EditSlaType.cs
@@ -12,7 +12,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ServiceLevelAgreements
 {
-    public sealed class EditSlaType : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditSlaType : AuthorityTestBase
     {
         private static readonly CatalogueItemId SolutionId = new(99998, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/EditSlaTypeConfirmation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/EditSlaTypeConfirmation.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ServiceLevelAgreements
 {
-    public sealed class EditSlaTypeConfirmation : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditSlaTypeConfirmation : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99998, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/ServiceLevels/AddServiceLevel.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/ServiceLevels/AddServiceLevel.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ServiceLevelAgreements.ServiceLevels
 {
-    public sealed class AddServiceLevel : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class AddServiceLevel : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99998, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/ServiceLevels/DeleteServiceLevel.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/ServiceLevels/DeleteServiceLevel.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ServiceLevelAgreements
 {
-    public sealed class DeleteServiceLevel : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class DeleteServiceLevel : AuthorityTestBase
     {
         private const int CancelLinkServiceLevelId = 2;
         private const int ServiceLevelId = 3;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/ServiceLevels/EditServiceLevel.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/ServiceLevelAgreements/ServiceLevels/EditServiceLevel.cs
@@ -16,7 +16,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution.ServiceLevelAgreements.ServiceLevels
 {
-    public sealed class EditServiceLevel : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditServiceLevel : AuthorityTestBase, IDisposable
     {
         private const int SingleServiceLevelId = 1;
         private const int ServiceLevelId = 2;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/SolutionCapabilities.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AddNewSolution/SolutionCapabilities.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.AddNewSolution
 {
-    public sealed class SolutionCapabilities : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class SolutionCapabilities : AuthorityTestBase
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AdminDashboard.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/AdminDashboard.cs
@@ -8,7 +8,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin
 {
-    public sealed class AdminDashboard : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class AdminDashboard : AuthorityTestBase
     {
         public AdminDashboard(LocalWebApplicationFactory factory, ITestOutputHelper testOutputHelper)
             : base(factory, typeof(HomeController), nameof(HomeController.Index), null, testOutputHelper)

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/EmailDomainManagement/AddEmailDomain.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/EmailDomainManagement/AddEmailDomain.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.EmailDomainManagement;
 
-public class AddEmailDomain : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+[Collection(nameof(AdminCollection))]
+public class AddEmailDomain : AuthorityTestBase
 {
     public AddEmailDomain(LocalWebApplicationFactory factory)
     : base(

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/EmailDomainManagement/DeleteEmailDomain.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/EmailDomainManagement/DeleteEmailDomain.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.EmailDomainManagement;
 
-public class DeleteEmailDomain : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+[Collection(nameof(AdminCollection))]
+public class DeleteEmailDomain : AuthorityTestBase
 {
     private const int Id = 1;
     private static readonly Dictionary<string, string> Parameters = new() { { nameof(Id), Id.ToString() }, };

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/EmailDomainManagement/DeleteEmailDomain.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/EmailDomainManagement/DeleteEmailDomain.cs
@@ -85,6 +85,6 @@ public class DeleteEmailDomain : AuthorityTestBase
             .Should()
             .BeTrue();
 
-        context.EmailDomains.Count().Should().Be(1);
+        context.EmailDomains.Count().Should().Be(2);
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/EmailDomainManagement/ViewEmailDomains.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/EmailDomainManagement/ViewEmailDomains.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.EmailDomainManagement;
 
-public class ViewEmailDomains : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+[Collection(nameof(AdminCollection))]
+public class ViewEmailDomains : AuthorityTestBase
 {
     public ViewEmailDomains(LocalWebApplicationFactory factory)
     : base(

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/EmailDomainManagement/ViewEmailDomains.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/EmailDomainManagement/ViewEmailDomains.cs
@@ -34,7 +34,8 @@ public class ViewEmailDomains : AuthorityTestBase
         CommonActions.ElementIsDisplayed(EmailDomainManagementObjects.DomainsTable).Should().BeTrue();
 
         using var context = GetEndToEndDbContext();
-        context.EmailDomains.Remove(context.EmailDomains.AsNoTracking().First());
+        var emailDomains = context.EmailDomains.AsNoTracking().ToList();
+        context.EmailDomains.RemoveRange(context.EmailDomains.AsNoTracking());
         context.SaveChanges();
 
         Driver.Navigate().Refresh();
@@ -43,6 +44,9 @@ public class ViewEmailDomains : AuthorityTestBase
         CommonActions.ElementIsDisplayed(EmailDomainManagementObjects.DomainsTable).Should().BeFalse();
 
         CommonActions.ContinueButtonDisplayed().Should().BeTrue();
+
+        context.EmailDomains.AddRange(emailDomains);
+        context.SaveChanges();
     }
 
     [Fact]

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Import/ImportGpPracticeList.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Import/ImportGpPracticeList.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Import
 {
-    public class ImportGpPracticeList : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public class ImportGpPracticeList : AuthorityTestBase
     {
         public ImportGpPracticeList(LocalWebApplicationFactory factory)
             : base(factory, typeof(ImportController), nameof(ImportController.ImportGpPracticeList), null)

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Import/ImportGpPracticeListConfirmation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Import/ImportGpPracticeListConfirmation.cs
@@ -8,7 +8,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Import
 {
-    public class ImportGpPracticeListConfirmation : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public class ImportGpPracticeListConfirmation : AuthorityTestBase
     {
         public ImportGpPracticeListConfirmation(LocalWebApplicationFactory factory)
             : base(factory, typeof(ImportController), nameof(ImportController.ImportGpPracticeListConfirmation), null)

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Flat/AddFlatListPriceBase.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Flat/AddFlatListPriceBase.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base.Flat
 {
-    public abstract class AddFlatListPriceBase : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public abstract class AddFlatListPriceBase : AuthorityTestBase
     {
         private const string ActionName = "AddFlatListPrice";
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Flat/EditFlatListPriceBase.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Flat/EditFlatListPriceBase.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base.Flat
 {
-    public abstract class EditFlatListPriceBase : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public abstract class EditFlatListPriceBase : AuthorityTestBase
     {
         private const string ActionName = "EditFlatListPrice";
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/ManageListPricesBase.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/ManageListPricesBase.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base
 {
-    public abstract class ManageListPricesBase : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public abstract class ManageListPricesBase : AuthorityTestBase
     {
         protected ManageListPricesBase(
             LocalWebApplicationFactory factory,

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Tiered/AddTieredListPriceBase.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Tiered/AddTieredListPriceBase.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base.Tiered
 {
-    public abstract class AddTieredListPriceBase : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public abstract class AddTieredListPriceBase : AuthorityTestBase
     {
         protected AddTieredListPriceBase(
             LocalWebApplicationFactory factory,

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Tiered/AddTieredPriceTierBase.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Tiered/AddTieredPriceTierBase.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base.Tiered
 {
-    public abstract class AddTieredPriceTierBase : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public abstract class AddTieredPriceTierBase : AuthorityTestBase
     {
         private readonly IDictionary<string, string> parameters;
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Tiered/EditTierPriceBase.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Tiered/EditTierPriceBase.cs
@@ -11,7 +11,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base.Tiered
 {
-    public abstract class EditTierPriceBase : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public abstract class EditTierPriceBase : AuthorityTestBase
     {
         private const int TierIndex = 1;
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Tiered/EditTieredListPriceBase.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Tiered/EditTieredListPriceBase.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base.Tiered
 {
-    public abstract class EditTieredListPriceBase : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public abstract class EditTieredListPriceBase : AuthorityTestBase
     {
         private readonly IDictionary<string, string> parameters;
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Tiered/ListPriceTypeBase.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Tiered/ListPriceTypeBase.cs
@@ -13,7 +13,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base.Tiered
 {
-    public abstract class ListPriceTypeBase : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public abstract class ListPriceTypeBase : AuthorityTestBase
     {
         protected ListPriceTypeBase(
             LocalWebApplicationFactory factory,

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Tiered/TieredPriceTiersBase.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ListPrices/Base/Tiered/TieredPriceTiersBase.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ListPrices.Base.Tiered
 {
-    public abstract class TieredPriceTiersBase : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public abstract class TieredPriceTiersBase : AuthorityTestBase
     {
         private readonly IDictionary<string, string> parameters;
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageCatalogueSolution.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageCatalogueSolution.cs
@@ -16,7 +16,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin
 {
-    public sealed class ManageCatalogueSolution : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class ManageCatalogueSolution : AuthorityTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
         private static readonly CatalogueItemId UnpublishedSolutionId = new(99999, "002");

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageCatalogueSolutions.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageCatalogueSolutions.cs
@@ -13,7 +13,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin
 {
-    public sealed class ManageCatalogueSolutions : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class ManageCatalogueSolutions : AuthorityTestBase
     {
         public ManageCatalogueSolutions(LocalWebApplicationFactory factory)
             : base(

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageOrders/Dashboard.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageOrders/Dashboard.cs
@@ -16,7 +16,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageOrders
 {
-    public sealed class Dashboard : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class Dashboard : AuthorityTestBase
     {
         public Dashboard(LocalWebApplicationFactory factory, ITestOutputHelper testOutputHelper)
             : base(

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageOrders/DeleteOrder.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageOrders/DeleteOrder.cs
@@ -13,8 +13,9 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageOrders
 {
+    [Collection(nameof(AdminCollection))]
     public sealed class DeleteOrder
-        : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+        : AuthorityTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private static readonly CallOffId CallOffId = new(90009, 1);

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageOrders/ViewOrder.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageOrders/ViewOrder.cs
@@ -13,7 +13,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageOrders
 {
-    public sealed class ViewOrder : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class ViewOrder : AuthorityTestBase
     {
         private static readonly CallOffId CallOffId = new(90010, 1);
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageSuppliers/AddSupplier.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageSuppliers/AddSupplier.cs
@@ -10,7 +10,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageSuppliers
 {
-    public sealed class AddSupplier : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class AddSupplier : AuthorityTestBase
     {
         private const int TargetSupplierId = 99998;
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageSuppliers/AddSupplierContact.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageSuppliers/AddSupplierContact.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageSuppliers
 {
-    public sealed class AddSupplierContact : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class AddSupplierContact : AuthorityTestBase, IDisposable
     {
         private const int SupplierId = 99996;
         private const int DuplicateSupplierId = 99998;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageSuppliers/DeleteSupplierContact.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageSuppliers/DeleteSupplierContact.cs
@@ -15,7 +15,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageSuppliers
 {
-    public sealed class DeleteSupplierContact : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class DeleteSupplierContact : AuthorityTestBase
     {
         private const int SupplierId = 99998;
         private const int SupplierWithSingleContactId = 99995;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageSuppliers/EditSupplier.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageSuppliers/EditSupplier.cs
@@ -11,7 +11,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageSuppliers
 {
-    public sealed class EditSupplier : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditSupplier : AuthorityTestBase
     {
         private const int SupplierId = 99998;
         private const int InactiveSupplierId = 99996;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageSuppliers/EditSupplierAddress.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageSuppliers/EditSupplierAddress.cs
@@ -9,7 +9,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageSuppliers
 {
-    public sealed class EditSupplierAddress : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditSupplierAddress : AuthorityTestBase
     {
         private const int SupplierId = 99996;
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageSuppliers/EditSupplierContact.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageSuppliers/EditSupplierContact.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageSuppliers
 {
-    public sealed class EditSupplierContact : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditSupplierContact : AuthorityTestBase
     {
         private const int SupplierId = 99998;
         private const int ContactId = 3;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageSuppliers/ManageSupplierContacts.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageSuppliers/ManageSupplierContacts.cs
@@ -12,7 +12,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageSuppliers
 {
-    public sealed class ManageSupplierContacts : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class ManageSupplierContacts : AuthorityTestBase
     {
         private const int SupplierId = 99998;
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageSuppliers/ManageSuppliers.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageSuppliers/ManageSuppliers.cs
@@ -9,7 +9,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageSuppliers
 {
-    public sealed class ManageSuppliers : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class ManageSuppliers : AuthorityTestBase
     {
         private const int TargetSupplierId = 99998;
         private const int ActiveSupplierId = 99997;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/AddNominatedOrganisation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/AddNominatedOrganisation.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Organisations
 {
-    public class AddNominatedOrganisation : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public class AddNominatedOrganisation : AuthorityTestBase, IDisposable
     {
         private const int OrganisationId = 1;
         private const string ValidOrganisationId = "CG-15F";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/AddUser.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/AddUser.cs
@@ -17,7 +17,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Organisations
 {
-    public sealed class AddUser : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class AddUser : AuthorityTestBase
     {
         private const int NhsDigitalOrganisationId = 1;
         private const int OrganisationId = 2;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/AddUser.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/AddUser.cs
@@ -22,7 +22,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Organisations
     {
         private const int NhsDigitalOrganisationId = 1;
         private const int OrganisationId = 2;
-        private const string ValidEmail = "a@nhs.net";
+        private const string ValidEmail = "abc@nhs.net";
         private const string FirstNameRequired = "Enter a first name";
         private const string LastNameRequired = "Enter a last name";
         private const string EmailAddressRequired = "Enter an email address";
@@ -104,7 +104,6 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Organisations
         public async Task AddUser_AddUser_ExpectedResult()
         {
             var user = GenerateUser.Generate();
-            user.EmailAddress = ValidEmail;
 
             AdminPages.AddUser.EnterFirstName(user.FirstName);
             AdminPages.AddUser.EnterLastName(user.LastName);
@@ -118,7 +117,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Organisations
                 typeof(OrganisationsController),
                 nameof(OrganisationsController.Users)).Should().BeTrue();
 
-            await RemoveUserByEmail(ValidEmail);
+            await RemoveUserByEmail(user.EmailAddress);
         }
 
         [Fact]

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/Details.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/Details.cs
@@ -12,7 +12,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Organisations
 {
-    public sealed class Details : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class Details : AuthorityTestBase
     {
         private const int OrganisationId = 2;
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/EditUser.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/EditUser.cs
@@ -19,7 +19,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Organisations
 {
-    public sealed class EditUser : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditUser : AuthorityTestBase, IDisposable
     {
         private const int NhsDigitalOrganisationId = 1;
         private const int OrganisationId = 176;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/EditUser.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/EditUser.cs
@@ -25,7 +25,6 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Organisations
         private const int NhsDigitalOrganisationId = 1;
         private const int OrganisationId = 176;
         private const int UserId = 5;
-        private const string ValidEmail = "a@nhs.net";
         private const string FirstNameRequired = "Enter a first name";
         private const string LastNameRequired = "Enter a last name";
         private const string EmailAddressRequired = "Enter an email address";
@@ -138,24 +137,6 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Organisations
         {
             CommonActions.ClickRadioButtonWithText(OrganisationFunction.AccountManager.DisplayName);
             CommonActions.ClickRadioButtonWithText("Inactive");
-            CommonActions.ClearInputElement(AddUserObjects.Email);
-            AdminPages.AddUser.EnterEmailAddress(ValidEmail);
-            CommonActions.ClickSave();
-
-            CommonActions.PageLoadedCorrectGetIndex(
-                typeof(OrganisationsController),
-                nameof(OrganisationsController.Users)).Should().BeTrue();
-        }
-
-        [Fact]
-        public void EditUser_IncludesWhitespace_RemovesWhitespace()
-        {
-            CommonActions.ClearInputElement(AddUserObjects.FirstName);
-            AdminPages.AddUser.EnterFirstName("    Alice    ");
-            CommonActions.ClearInputElement(AddUserObjects.LastName);
-            AdminPages.AddUser.EnterLastName("    Smith    ");
-            CommonActions.ClearInputElement(AddUserObjects.Email);
-            AdminPages.AddUser.EnterEmailAddress("    " + ValidEmail + "    ");
             CommonActions.ClickSave();
 
             CommonActions.PageLoadedCorrectGetIndex(

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/Index.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/Index.cs
@@ -13,7 +13,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Organisations
 {
-    public sealed class Index : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class Index : AuthorityTestBase
     {
         public Index(LocalWebApplicationFactory factory)
             : base(factory, typeof(OrganisationsController), nameof(OrganisationsController.Index), null)

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/NominatedOrganisations.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/NominatedOrganisations.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Organisations
 {
-    public class NominatedOrganisations : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public class NominatedOrganisations : AuthorityTestBase, IDisposable
     {
         private const int OrganisationId = 1;
         private const int RelatedOrganisationId = 5;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/RelatedOrganisations.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/RelatedOrganisations.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Organisations
 {
-    public class RelatedOrganisations : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public class RelatedOrganisations : AuthorityTestBase, IDisposable
     {
         private const int OrganisationId = 2;
         private const int RelatedOrganisationId = 3;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/RemoveNominatedOrganisation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/RemoveNominatedOrganisation.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Organisations
 {
-    public class RemoveNominatedOrganisation : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public class RemoveNominatedOrganisation : AuthorityTestBase, IDisposable
     {
         private const int OrganisationId = 1;
         private const int NominatedOrganisationId = 5;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/RemoveRelatedOrganisation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/RemoveRelatedOrganisation.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Organisations
 {
-    public class RemoveRelatedOrganisation : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public class RemoveRelatedOrganisation : AuthorityTestBase, IDisposable
     {
         private const int OrganisationId = 2;
         private const int RelatedOrganisationId = 3;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/Users.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Organisations/Users.cs
@@ -16,7 +16,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Organisations
 {
-    public class Users : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public class Users : AuthorityTestBase, IDisposable
     {
         private const int OrganisationId = 2;
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/SupplierDefinedEpics/AddEpic.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/SupplierDefinedEpics/AddEpic.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.SupplierDefinedEpics
 {
-    public sealed class AddEpic : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class AddEpic : AuthorityTestBase
     {
         public AddEpic(LocalWebApplicationFactory factory)
             : base(

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/SupplierDefinedEpics/Dashboard.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/SupplierDefinedEpics/Dashboard.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.SupplierDefinedEpics
 {
-    public sealed class Dashboard : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class Dashboard : AuthorityTestBase
     {
         public Dashboard(LocalWebApplicationFactory factory)
             : base(

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/SupplierDefinedEpics/DeleteEpic.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/SupplierDefinedEpics/DeleteEpic.cs
@@ -12,7 +12,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.SupplierDefinedEpics
 {
-    public sealed class DeleteEpic : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class DeleteEpic : AuthorityTestBase
     {
         private const string EpicId = "S00007";
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/SupplierDefinedEpics/EditEpic.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/SupplierDefinedEpics/EditEpic.cs
@@ -13,7 +13,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.SupplierDefinedEpics
 {
-    public sealed class EditEpic : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public sealed class EditEpic : AuthorityTestBase
     {
         private const string EpicId = "S00001";
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Users/Add.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Users/Add.cs
@@ -18,10 +18,9 @@ using Xunit;
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Users
 {
     [Collection(nameof(AdminCollection))]
-    public class Add : AuthorityTestBase, IDisposable
+    public class Add : AuthorityTestBase
     {
         private const string NhsDigitalOrganisationName = "NHS Digital";
-        private const string ValidEmailAddress = "a@nhs.net";
 
         public Add(LocalWebApplicationFactory factory)
             : base(factory, typeof(UsersController), nameof(UsersController.Add))
@@ -157,11 +156,13 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Users
                 .First(x => x.Name != NhsDigitalOrganisationName)
                 .Name;
 
+            var buyerEmail = Strings.RandomBuyerEmail();
+
             CommonActions.AutoCompleteAddValue(UserObjects.SelectedOrganisation, organisationName);
             CommonActions.ClickLinkElement(UserObjects.AutoCompleteResult(0));
             CommonActions.ElementAddValue(UserObjects.FirstNameInput, Strings.RandomString(10));
             CommonActions.ElementAddValue(UserObjects.LastNameInput, Strings.RandomString(10));
-            CommonActions.ElementAddValue(UserObjects.EmailInput, ValidEmailAddress);
+            CommonActions.ElementAddValue(UserObjects.EmailInput, buyerEmail);
             CommonActions.ClickRadioButtonWithText("Buyer");
             CommonActions.ClickRadioButtonWithText("Active");
 
@@ -170,6 +171,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Users
             CommonActions.PageLoadedCorrectGetIndex(
                 typeof(UsersController),
                 nameof(UsersController.Index)).Should().BeTrue();
+
+            RemoveUserByEmail(buyerEmail).GetAwaiter().GetResult();
         }
 
         [Fact]
@@ -181,11 +184,13 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Users
                 .First(x => x.Name != NhsDigitalOrganisationName)
                 .Name;
 
+            var buyerEmail = Strings.RandomBuyerEmail();
+
             CommonActions.AutoCompleteAddValue(UserObjects.SelectedOrganisation, organisationName);
             CommonActions.ClickLinkElement(UserObjects.AutoCompleteResult(0));
             CommonActions.ElementAddValue(UserObjects.FirstNameInput, "    " + Strings.RandomString(10) + "    ");
             CommonActions.ElementAddValue(UserObjects.LastNameInput, "    " + Strings.RandomString(10) + "    ");
-            CommonActions.ElementAddValue(UserObjects.EmailInput, "    " + ValidEmailAddress + "    ");
+            CommonActions.ElementAddValue(UserObjects.EmailInput, "    " + buyerEmail + "    ");
             CommonActions.ClickRadioButtonWithText("Buyer");
             CommonActions.ClickRadioButtonWithText("Active");
 
@@ -194,6 +199,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Users
             CommonActions.PageLoadedCorrectGetIndex(
                 typeof(UsersController),
                 nameof(UsersController.Index)).Should().BeTrue();
+
+            RemoveUserByEmail(buyerEmail).GetAwaiter().GetResult();
         }
 
         [Fact]
@@ -224,11 +231,13 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Users
         [Fact]
         public void Add_Admin_InNhsDigital_ClickSave_DisplaysCorrectPage()
         {
+            var buyerEmail = Strings.RandomBuyerEmail();
+
             CommonActions.AutoCompleteAddValue(UserObjects.SelectedOrganisation, NhsDigitalOrganisationName);
             CommonActions.ClickLinkElement(UserObjects.AutoCompleteResult(0));
             CommonActions.ElementAddValue(UserObjects.FirstNameInput, Strings.RandomString(10));
             CommonActions.ElementAddValue(UserObjects.LastNameInput, Strings.RandomString(10));
-            CommonActions.ElementAddValue(UserObjects.EmailInput, ValidEmailAddress);
+            CommonActions.ElementAddValue(UserObjects.EmailInput, buyerEmail);
             CommonActions.ClickRadioButtonWithText("Admin");
             CommonActions.ClickRadioButtonWithText("Active");
 
@@ -237,6 +246,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Users
             CommonActions.PageLoadedCorrectGetIndex(
                 typeof(UsersController),
                 nameof(UsersController.Index)).Should().BeTrue();
+
+            RemoveUserByEmail(buyerEmail).GetAwaiter().GetResult();
         }
 
         [Fact]
@@ -248,11 +259,13 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Users
                 .First(x => x.Name != NhsDigitalOrganisationName)
                 .Name;
 
+            var buyerEmail = Strings.RandomBuyerEmail();
+
             CommonActions.AutoCompleteAddValue(UserObjects.SelectedOrganisation, organisationName);
             CommonActions.ClickLinkElement(UserObjects.AutoCompleteResult(0));
             CommonActions.ElementAddValue(UserObjects.FirstNameInput, Strings.RandomString(10));
             CommonActions.ElementAddValue(UserObjects.LastNameInput, Strings.RandomString(10));
-            CommonActions.ElementAddValue(UserObjects.EmailInput, ValidEmailAddress);
+            CommonActions.ElementAddValue(UserObjects.EmailInput, buyerEmail);
             CommonActions.ClickRadioButtonWithText("Account manager");
             CommonActions.ClickRadioButtonWithText("Active");
 
@@ -261,6 +274,8 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Users
             CommonActions.PageLoadedCorrectGetIndex(
                 typeof(UsersController),
                 nameof(UsersController.Index)).Should().BeTrue();
+
+            RemoveUserByEmail(buyerEmail).GetAwaiter().GetResult();
         }
 
         [Fact]
@@ -316,12 +331,14 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Users
             await RemoveUser(user2);
         }
 
-        public void Dispose()
+        private async Task RemoveUserByEmail(string email)
         {
-            var context = GetEndToEndDbContext();
-            var users = context.AspNetUsers.Where(x => x.Email == ValidEmailAddress).ToList();
-            context.AspNetUsers.RemoveRange(users);
-            context.SaveChanges();
+            await using var context = GetEndToEndDbContext();
+            var user = context.Users.FirstOrDefault(x => x.Email == email);
+            if (user == null) return;
+
+            context.Remove(user);
+            await context.SaveChangesAsync();
         }
 
         private async Task<AspNetUser> CreateUser(int organisationId, bool isEnabled = true, string accountType = "Buyer")

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Users/Add.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Users/Add.cs
@@ -17,7 +17,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Users
 {
-    public class Add : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public class Add : AuthorityTestBase, IDisposable
     {
         private const string NhsDigitalOrganisationName = "NHS Digital";
         private const string ValidEmailAddress = "a@nhs.net";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Users/Edit.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Users/Edit.cs
@@ -21,7 +21,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Users
 {
-    public class Edit : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(AdminCollection))]
+    public class Edit : AuthorityTestBase, IDisposable
     {
         private const int UserId = 5;
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Users/Index.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/Users/Index.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.Users
 {
-    public class Index : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(AdminCollection))]
+    public class Index : AuthorityTestBase
     {
         public Index(LocalWebApplicationFactory factory)
             : base(factory, typeof(UsersController), nameof(UsersController.Index))

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Authorization/LockedAccount.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Authorization/LockedAccount.cs
@@ -14,7 +14,7 @@ using Xunit;
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Authorization
 {
     [Collection(nameof(SharedContextCollection))]
-    public sealed class LockedAccount : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>
+    public sealed class LockedAccount : AnonymousTestBase
     {
         public LockedAccount(LocalWebApplicationFactory factory)
             : base(

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Authorization/LockedAccount.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Authorization/LockedAccount.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Authorization
 {
+    [Collection(nameof(SharedContextCollection))]
     public sealed class LockedAccount : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>
     {
         public LockedAccount(LocalWebApplicationFactory factory)

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Authorization/Login.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Authorization/Login.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Authorization
 {
+    [Collection(nameof(SharedContextCollection))]
     public sealed class Login : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
     {
         private const string EmailError = "Enter your email address";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Authorization/Login.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Authorization/Login.cs
@@ -11,7 +11,7 @@ using Xunit;
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Authorization
 {
     [Collection(nameof(SharedContextCollection))]
-    public sealed class Login : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    public sealed class Login : AnonymousTestBase, IDisposable
     {
         private const string EmailError = "Enter your email address";
         private const string PasswordError = "Enter your password";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Authorization/UpdatePassword.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Authorization/UpdatePassword.cs
@@ -15,7 +15,7 @@ using Xunit;
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Authorization
 {
     [Collection(nameof(SharedContextCollection))]
-    public sealed class UpdatePassword : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    public sealed class UpdatePassword : BuyerTestBase, IDisposable
     {
         private const string ValidPassword = "Pass123$$$$$$";
         private const string InvalidPassword = "Blah";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Authorization/UpdatePassword.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Authorization/UpdatePassword.cs
@@ -14,6 +14,7 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Authorization
 {
+    [Collection(nameof(SharedContextCollection))]
     public sealed class UpdatePassword : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
     {
         private const string ValidPassword = "Pass123$$$$$$";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/AmendOrder.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/AmendOrder.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering
 {
-    public class AmendOrder : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class AmendOrder : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private static readonly CallOffId CallOffId = new(90010, 1);

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CallOffPartyInformation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CallOffPartyInformation.cs
@@ -13,8 +13,9 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering
 {
+    [Collection(nameof(OrderingCollection))]
     public sealed class CallOffPartyInformation
-        : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+        : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
         private static readonly CallOffId CallOffId = new(90001, 1);

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CommencementDate/CommencementDate.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CommencementDate/CommencementDate.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.CommencementDate
 {
-    public sealed class CommencementDate : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public sealed class CommencementDate : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private static readonly CallOffId CallOffId = new(90003, 1);

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CommencementDate/CommencementDateAmendment.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CommencementDate/CommencementDateAmendment.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.CommencementDate
 {
-    public sealed class CommencementDateAmendment : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public sealed class CommencementDateAmendment : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
         private static readonly CallOffId CallOffId = new(90030, 2);

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CommencementDate/ConfirmChanges.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/CommencementDate/ConfirmChanges.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.CommencementDate
 {
-    public class ConfirmChanges : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class ConfirmChanges : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/AssociatedServicesBilling/BespokeBilling.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/AssociatedServicesBilling/BespokeBilling.cs
@@ -8,7 +8,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Contracts.AssociatedServicesBilling
 {
-    public class BespokeBilling : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public class BespokeBilling : BuyerTestBase
     {
         private const int OrderId = 90013;
         private const string InternalOrgId = "CG-03F";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/AssociatedServicesBilling/BespokeRequirements.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/AssociatedServicesBilling/BespokeRequirements.cs
@@ -9,7 +9,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Contracts.AssociatedServicesBilling
 {
-    public class BespokeRequirements : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public class BespokeRequirements : BuyerTestBase
     {
         private const int OrderId = 90013;
         private const string InternalOrgId = "CG-03F";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/AssociatedServicesBilling/ReviewBilling.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/AssociatedServicesBilling/ReviewBilling.cs
@@ -13,7 +13,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Contracts.AssociatedServicesBilling
 {
-    public class ReviewBilling : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class ReviewBilling : BuyerTestBase, IDisposable
     {
         private const int OrderId = 90013;
         private const string InternalOrgId = "CG-03F";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/AssociatedServicesBilling/SpecificRequirements.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/AssociatedServicesBilling/SpecificRequirements.cs
@@ -13,7 +13,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Contracts.AssociatedServicesBilling
 {
-    public class SpecificRequirements : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class SpecificRequirements : BuyerTestBase, IDisposable
     {
         private const int OrderId = 90013;
         private const string InternalOrgId = "CG-03F";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/DataProcessingPlans/BespokeDataProcessingPlan.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/DataProcessingPlans/BespokeDataProcessingPlan.cs
@@ -9,7 +9,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Contracts.DataProcessingPlans
 {
-    public class BespokeDataProcessingPlan : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public class BespokeDataProcessingPlan : BuyerTestBase
     {
         private const int OrderId = 90001;
         private const string InternalOrgId = "CG-03F";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/DataProcessingPlans/DefaultDataProcessingPlan.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/DataProcessingPlans/DefaultDataProcessingPlan.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Contracts.DataProcessingPlans
 {
-    public class DefaultDataProcessingPlan : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class DefaultDataProcessingPlan : BuyerTestBase, IDisposable
     {
         private const int OrderId = 90001;
         private const string InternalOrgId = "CG-03F";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/DeliveryDates/AmendDate.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/DeliveryDates/AmendDate.cs
@@ -18,7 +18,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Contracts.DeliveryDates
 {
-    public class AmendDate : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class AmendDate : BuyerTestBase, IDisposable
     {
         private const int OrderNumber = 90031;
         private const string InternalOrgId = "CG-03F";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/DeliveryDates/ConfirmChanges.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/DeliveryDates/ConfirmChanges.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Contracts.DeliveryDates
 {
-    public class ConfirmChanges : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class ConfirmChanges : BuyerTestBase, IDisposable
     {
         private const int OrderId = 90009;
         private const string InternalOrgId = "CG-03F";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/DeliveryDates/Edit/Base/EditDates.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/DeliveryDates/Edit/Base/EditDates.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Contracts.DeliveryDates.Edit.Base
 {
-    public abstract class EditDates : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public abstract class EditDates : BuyerTestBase
     {
         private readonly int orderId;
         private readonly CatalogueItemId catalogueItemId;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/DeliveryDates/MatchDates.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/DeliveryDates/MatchDates.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Contracts.DeliveryDates
 {
-    public class MatchDates : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class MatchDates : BuyerTestBase, IDisposable
     {
         private const int OrderId = 91007;
         private const string InternalOrgId = "CG-03F";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/DeliveryDates/Review.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/DeliveryDates/Review.cs
@@ -11,7 +11,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Contracts.DeliveryDates
 {
-    public class Review : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public class Review : BuyerTestBase
     {
         private const int OrderId = 91007;
         private const string InternalOrgId = "CG-03F";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/DeliveryDates/SelectDate.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/DeliveryDates/SelectDate.cs
@@ -16,7 +16,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Contracts.DeliveryDates
 {
-    public class SelectDate : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class SelectDate : BuyerTestBase, IDisposable
     {
         private const int OrderId = 90006;
         private const string InternalOrgId = "CG-03F";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/ImplementationPlans/CustomImplementationPlan.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/ImplementationPlans/CustomImplementationPlan.cs
@@ -9,7 +9,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Contracts.ImplementationPlans
 {
-    public class CustomImplementationPlan : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public class CustomImplementationPlan : BuyerTestBase
     {
         private const int OrderId = 90001;
         private const string InternalOrgId = "CG-03F";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/ImplementationPlans/DefaultImplementationPlan.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/ImplementationPlans/DefaultImplementationPlan.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Contracts.ImplementationPlans
 {
-    public class DefaultImplementationPlan : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class DefaultImplementationPlan : BuyerTestBase, IDisposable
     {
         private const int OrderId = 90001;
         private const string InternalOrgId = "CG-03F";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/ReviewContract/ContractSummary.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Contracts/ReviewContract/ContractSummary.cs
@@ -18,7 +18,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Contracts.ReviewContract
 {
-    public class ContractSummary : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class ContractSummary : BuyerTestBase, IDisposable
     {
         private const int OrderId = 90009;
         private const string InternalOrgId = "CG-03F";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/DeleteAmendment.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/DeleteAmendment.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering
 {
-    public sealed class DeleteAmendment : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public sealed class DeleteAmendment : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private static readonly CallOffId CallOffId = new(90030, 2);

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/DeleteOrder.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/DeleteOrder.cs
@@ -12,8 +12,9 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering
 {
+    [Collection(nameof(OrderingCollection))]
     public sealed class DeleteOrder
-        : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+        : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private static readonly CallOffId CallOffId = new(90009, 1);

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/FundingSources/ConfirmChangeFramework.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/FundingSources/ConfirmChangeFramework.cs
@@ -13,7 +13,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.FundingSources
 {
-    public sealed class ConfirmChangeFramework : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public sealed class ConfirmChangeFramework : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const string SelectedFrameworkId = "DFOCVC001";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/FundingSources/FundingSource.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/FundingSources/FundingSource.cs
@@ -15,7 +15,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.FundingSources
 {
-    public sealed class FundingSource : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public sealed class FundingSource : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private static readonly CallOffId CallOffId = new(90006, 1);

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/FundingSources/FundingSources.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/FundingSources/FundingSources.cs
@@ -11,7 +11,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.FundingSources
 {
-    public sealed class FundingSources : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public sealed class FundingSources : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
         private static readonly CallOffId DFOCVCCallOffId = new(90005, 1);

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/FundingSources/SelectFramework.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/FundingSources/SelectFramework.cs
@@ -17,7 +17,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.FundingSources
 {
-    public sealed class SelectFramework : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public sealed class SelectFramework : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private static readonly CallOffId CallOffIdMultipleFrameworks = new(90020, 1);

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/NewOrderDashboard.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/NewOrderDashboard.cs
@@ -11,8 +11,9 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering
 {
+    [Collection(nameof(OrderingCollection))]
     public sealed class NewOrderDashboard
-        : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+        : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/NewOrderDescription.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/NewOrderDescription.cs
@@ -14,8 +14,9 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering
 {
+    [Collection(nameof(OrderingCollection))]
     public sealed class NewOrderDescription
-        : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+        : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
         private const OrderTriageValue Option = OrderTriageValue.Over250K;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/OrderCompleted.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/OrderCompleted.cs
@@ -16,7 +16,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering
 {
-    public class OrderCompleted : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class OrderCompleted : BuyerTestBase, IDisposable
     {
         private const int OrderId = 90010;
         private const string InternalOrgId = "CG-03F";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/OrderDashboard.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/OrderDashboard.cs
@@ -16,7 +16,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering
 {
-    public sealed class OrderDashboard : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public sealed class OrderDashboard : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
         private static readonly CallOffId CallOffId = new(90009, 1);

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/OrderDescription.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/OrderDescription.cs
@@ -12,8 +12,9 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering
 {
+    [Collection(nameof(OrderingCollection))]
     public sealed class OrderDescription
-        : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+        : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
         private static readonly CallOffId CallOffId = new(90001, 1);

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/OrderReadyToStart.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/OrderReadyToStart.cs
@@ -14,8 +14,9 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering
 {
+    [Collection(nameof(OrderingCollection))]
     public sealed class OrderReadyToStart
-        : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+        : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
         private const OrderTriageValue Option = OrderTriageValue.Between40KTo250K;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/OrderSummary.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/OrderSummary.cs
@@ -17,7 +17,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering
 {
-    public class OrderSummary : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public class OrderSummary : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/OrderTriage/OrderItemType.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/OrderTriage/OrderItemType.cs
@@ -11,7 +11,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.OrderTriage
 {
-    public sealed class OrderItemType : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public sealed class OrderItemType : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/OrderTriage/OrderTriageIndex.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/OrderTriage/OrderTriageIndex.cs
@@ -12,8 +12,9 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.OrderTriage
 {
+    [Collection(nameof(OrderingCollection))]
     public sealed class OrderTriageIndex
-        : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+        : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/OrderTriage/OrderTriageSelection.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/OrderTriage/OrderTriageSelection.cs
@@ -13,8 +13,9 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.OrderTriage
 {
+    [Collection(nameof(OrderingCollection))]
     public sealed class OrderTriageSelection
-        : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+        : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
         private const OrderTriageValue Option = OrderTriageValue.Under40K;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/OrganisationDashboard.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/OrganisationDashboard.cs
@@ -19,8 +19,9 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering
 {
+    [Collection(nameof(OrderingCollection))]
     public sealed class OrganisationDashboard
-        : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+        : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/ProxyBuyer/OrderItemType.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/ProxyBuyer/OrderItemType.cs
@@ -9,8 +9,9 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.ProxyBuyer
 {
+    [Collection(nameof(OrderingCollection))]
     public sealed class OrderItemType
-        : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+        : BuyerTestBase
     {
         private const string InternalOrgId = "CG-15F";
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/ProxyBuyer/OrderReadyToStart.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/ProxyBuyer/OrderReadyToStart.cs
@@ -9,8 +9,9 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.ProxyBuyer
 {
+    [Collection(nameof(OrderingCollection))]
     public sealed class OrderReadyToStart
-        : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+        : BuyerTestBase
     {
         private const string InternalOrgId = "CG-15F";
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/ProxyBuyer/OrderSelectOrganisation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/ProxyBuyer/OrderSelectOrganisation.cs
@@ -11,8 +11,9 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.ProxyBuyer
 {
+    [Collection(nameof(OrderingCollection))]
     public class OrderSelectOrganisation
-        : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+        : BuyerTestBase
     {
         private const string InternalOrgId = "CG-15F";
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/ProxyBuyer/OrganisationDashboard.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/ProxyBuyer/OrganisationDashboard.cs
@@ -13,7 +13,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.ProxyBuyer
 {
-    public sealed class OrganisationDashboard : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public sealed class OrganisationDashboard : BuyerTestBase
     {
         private const string InternalOrgId = "CG-15F";
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AdditionalServices/ConfirmAdditionalServiceChanges.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AdditionalServices/ConfirmAdditionalServiceChanges.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.AdditionalServices
 {
-    public class ConfirmAdditionalServiceChanges : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class ConfirmAdditionalServiceChanges : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderId = 90007;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AdditionalServices/ConfirmAdditionalServiceRecipients.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AdditionalServices/ConfirmAdditionalServiceRecipients.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.AdditionalServices
 {
-    public class ConfirmAdditionalServiceRecipients : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class ConfirmAdditionalServiceRecipients : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderId = 91012;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AdditionalServices/ConfirmAdditionalServiceRecipientsAmendment.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AdditionalServices/ConfirmAdditionalServiceRecipientsAmendment.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.AdditionalServices
 {
-    public class ConfirmAdditionalServiceRecipientsAmendment : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class ConfirmAdditionalServiceRecipientsAmendment : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderId = 90031;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AdditionalServices/EditAdditionalServices.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AdditionalServices/EditAdditionalServices.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.AdditionalServices
 {
-    public class EditAdditionalServices : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class EditAdditionalServices : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderId = 90007;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AdditionalServices/EditAdditionalServicesAmendment.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AdditionalServices/EditAdditionalServicesAmendment.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.AdditionalServices
 {
-    public class EditAdditionalServicesAmendment : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class EditAdditionalServicesAmendment : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderId = 90031;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AdditionalServices/SelectAdditionalServiceRecipients.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AdditionalServices/SelectAdditionalServiceRecipients.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.AdditionalServices
 {
-    public class SelectAdditionalServiceRecipients : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class SelectAdditionalServiceRecipients : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderId = 90007;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AdditionalServices/SelectAdditionalServiceRecipientsAmendment.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AdditionalServices/SelectAdditionalServiceRecipientsAmendment.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.AdditionalServices
 {
-    public class SelectAdditionalServiceRecipientsAmendment : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class SelectAdditionalServiceRecipientsAmendment : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderNumber = 90031;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AdditionalServices/SelectAdditionalServices.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AdditionalServices/SelectAdditionalServices.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.AdditionalServices
 {
-    public class SelectAdditionalServices : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class SelectAdditionalServices : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderId = 90005;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AssociatedServices/AddAssociatedServices.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AssociatedServices/AddAssociatedServices.cs
@@ -12,7 +12,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.AssociatedServices
 {
-    public class AddAssociatedServices : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public class AddAssociatedServices : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
         private static readonly CallOffId CallOffId = new(90004, 1);

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AssociatedServices/ConfirmAssociatedServiceChanges.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AssociatedServices/ConfirmAssociatedServiceChanges.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.AssociatedServices
 {
-    public class ConfirmAssociatedServiceChanges : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class ConfirmAssociatedServiceChanges : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderId = 90008;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AssociatedServices/EditAssociatedServices.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AssociatedServices/EditAssociatedServices.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.AssociatedServices
 {
-    public class EditAssociatedServices : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class EditAssociatedServices : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderId = 90008;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AssociatedServices/EditAssociatedServicesOnly.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AssociatedServices/EditAssociatedServicesOnly.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.AssociatedServices
 {
-    public class EditAssociatedServicesOnly : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class EditAssociatedServicesOnly : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderId = 90014;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AssociatedServices/SelectAssociatedServiceRecipients.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AssociatedServices/SelectAssociatedServiceRecipients.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.AssociatedServices
 {
-    public class SelectAssociatedServiceRecipients : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class SelectAssociatedServiceRecipients : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderId = 90008;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AssociatedServices/SelectAssociatedServiceRecipientsAssociatedServicesOnly.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AssociatedServices/SelectAssociatedServiceRecipientsAssociatedServicesOnly.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.AssociatedServices
 {
-    public class SelectAssociatedServiceRecipientsAssociatedServicesOnly : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class SelectAssociatedServiceRecipientsAssociatedServicesOnly : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderId = 90017;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AssociatedServices/SelectAssociatedServices.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/AssociatedServices/SelectAssociatedServices.cs
@@ -16,7 +16,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.AssociatedServices
 {
-    public class SelectAssociatedServices : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class SelectAssociatedServices : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderId = 90012;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/ConfirmCatalogueSolutionChanges.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/ConfirmCatalogueSolutionChanges.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.CatalogueSolutions
 {
-    public class ConfirmCatalogueSolutionChanges : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class ConfirmCatalogueSolutionChanges : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderId = 90012;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/ConfirmCatalogueSolutionChangesAssociatedServicesOnly.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/ConfirmCatalogueSolutionChangesAssociatedServicesOnly.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.CatalogueSolutions
 {
-    public class ConfirmCatalogueSolutionChangesAssociatedServicesOnly : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class ConfirmCatalogueSolutionChangesAssociatedServicesOnly : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderId = 90016;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/ConfirmCatalogueSolutionRecipients.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/ConfirmCatalogueSolutionRecipients.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.CatalogueSolutions
 {
-    public class ConfirmCatalogueSolutionRecipients : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class ConfirmCatalogueSolutionRecipients : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderNumber = 91012;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/ConfirmCatalogueSolutionRecipientsAmendment.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/ConfirmCatalogueSolutionRecipientsAmendment.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.CatalogueSolutions
 {
-    public class ConfirmCatalogueSolutionRecipientsAmendment : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class ConfirmCatalogueSolutionRecipientsAmendment : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderNumber = 90030;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/ConfirmCatalogueSolutionWithServicesChanges.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/ConfirmCatalogueSolutionWithServicesChanges.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.CatalogueSolutions
 {
-    public class ConfirmCatalogueSolutionWithServicesChanges : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class ConfirmCatalogueSolutionWithServicesChanges : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderId = 91012;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/EditCatalogueSolution.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/EditCatalogueSolution.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.CatalogueSolutions
 {
-    public class EditCatalogueSolution : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public class EditCatalogueSolution : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderId = 90012;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/EditCatalogueSolutionAssociatedServicesOnly.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/EditCatalogueSolutionAssociatedServicesOnly.cs
@@ -9,7 +9,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.CatalogueSolutions
 {
-    public class EditCatalogueSolutionAssociatedServicesOnly : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public class EditCatalogueSolutionAssociatedServicesOnly : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderId = 90014;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/SelectCatalogueSolution.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/SelectCatalogueSolution.cs
@@ -16,7 +16,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.CatalogueSolutions
 {
-    public class SelectCatalogueSolution : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class SelectCatalogueSolution : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const string SolutionName = "E2E With Contact With Single Price";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/SelectCatalogueSolutionAssociatedServicesOnly.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/SelectCatalogueSolutionAssociatedServicesOnly.cs
@@ -16,7 +16,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.CatalogueSolutions
 {
-    public class SelectCatalogueSolutionAssociatedServicesOnly : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class SelectCatalogueSolutionAssociatedServicesOnly : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const string SolutionName = "E2E With Contact With Single Price";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/SelectCatalogueSolutionRecipients.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/SelectCatalogueSolutionRecipients.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.CatalogueSolutions
 {
-    public class SelectCatalogueSolutionRecipients : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class SelectCatalogueSolutionRecipients : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderId = 90005;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/SelectCatalogueSolutionRecipientsAmendment.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/CatalogueSolutions/SelectCatalogueSolutionRecipientsAmendment.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.CatalogueSolutions
 {
-    public class SelectCatalogueSolutionRecipientsAmendment : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public class SelectCatalogueSolutionRecipientsAmendment : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderNumber = 90030;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/ImportServiceRecipients/ImportServiceRecipients.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/ImportServiceRecipients/ImportServiceRecipients.cs
@@ -11,7 +11,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.ImportServiceRecipients;
 
-public class ImportServiceRecipients : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+[Collection(nameof(OrderingCollection))]
+public class ImportServiceRecipients : BuyerTestBase
 {
     private const string InternalOrgId = "CG-03F";
     private const int OrderId = 90005;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/ImportServiceRecipients/ValidateImportOdsCodes.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/ImportServiceRecipients/ValidateImportOdsCodes.cs
@@ -11,7 +11,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.ImportServiceRecipients;
 
-public class ValidateImportOdsCodes : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+[Collection(nameof(OrderingCollection))]
+public class ValidateImportOdsCodes : BuyerTestBase
 {
     private const string InternalOrgId = "CG-03F";
     private const int OrderId = 90005;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/ImportServiceRecipients/ValidateImportOrganisationNames.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/ImportServiceRecipients/ValidateImportOrganisationNames.cs
@@ -11,7 +11,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.ImportServiceRecipients;
 
-public class ValidateImportOrganisationNames : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+[Collection(nameof(OrderingCollection))]
+public class ValidateImportOrganisationNames : BuyerTestBase
 {
     private const string InternalOrgId = "CG-03F";
     private const int OrderId = 90005;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Prices/Base/ConfirmPrice.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Prices/Base/ConfirmPrice.cs
@@ -15,7 +15,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Prices.Base
 {
-    public abstract class ConfirmPrice : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public abstract class ConfirmPrice : BuyerTestBase, IDisposable
     {
         private readonly int orderId;
         private readonly CatalogueItemId catalogueItemId;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Prices/Base/EditPrice.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Prices/Base/EditPrice.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Prices.Base
 {
-    public abstract class EditPrice : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public abstract class EditPrice : BuyerTestBase, IDisposable
     {
         private readonly int orderId;
         private readonly CatalogueItemId catalogueItemId;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Prices/Base/SelectPrice.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Prices/Base/SelectPrice.cs
@@ -9,7 +9,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Prices.Base
 {
-    public abstract class SelectPrice : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public abstract class SelectPrice : BuyerTestBase
     {
         protected SelectPrice(LocalWebApplicationFactory factory, Dictionary<string, string> parameters)
             : base(factory, typeof(PricesController), nameof(PricesController.SelectPrice), parameters)

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Prices/ViewPriceCatalogueSolution.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Prices/ViewPriceCatalogueSolution.cs
@@ -11,7 +11,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Prices
 {
-    public class ViewPriceCatalogueSolution : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public class ViewPriceCatalogueSolution : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
         private static readonly CallOffId CallOffId = new(90030, 2);

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Quantity/Base/SelectQuantity.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Quantity/Base/SelectQuantity.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.Ordering.Quantity;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
@@ -14,10 +16,11 @@ using Xunit;
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Quantity.Base
 {
     [Collection(nameof(OrderingCollection))]
-    public abstract class SelectQuantity : BuyerTestBase, IDisposable
+    public abstract class SelectQuantity : BuyerTestBase
     {
         private readonly int orderId;
         private readonly CatalogueItemId catalogueItemId;
+        private List<OrderItem> originalOrderItems;
 
         protected SelectQuantity(LocalWebApplicationFactory factory, Dictionary<string, string> parameters)
             : base(factory, typeof(QuantityController), nameof(QuantityController.SelectQuantity), parameters)
@@ -127,20 +130,29 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Qu
             orderItems.First().Quantity.Should().Be(1234);
         }
 
-        public void Dispose()
+        public override async Task InitializeAsync()
         {
-            var context = GetEndToEndDbContext();
-            var orderItems = GetOrderItems();
+            originalOrderItems = GetOrderItems();
 
-            orderItems.ForEach(x => x.Quantity = null);
+            await base.InitializeAsync();
+        }
 
-            context.UpdateRange(orderItems);
-            context.SaveChanges();
+        public override async Task DisposeAsync()
+        {
+            await using var context = GetEndToEndDbContext();
+
+            context.OrderItems.RemoveRange(GetOrderItems());
+            context.OrderItems.AddRange(originalOrderItems);
+
+            await context.SaveChangesAsync();
+
+            await base.DisposeAsync();
         }
 
         private List<OrderItem> GetOrderItems()
         {
             return GetEndToEndDbContext().OrderItems
+                .AsNoTracking()
                 .Where(x => x.OrderId == orderId
                     && x.CatalogueItemId == catalogueItemId)
                 .ToList();

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Quantity/Base/SelectQuantity.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Quantity/Base/SelectQuantity.cs
@@ -13,7 +13,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Quantity.Base
 {
-    public abstract class SelectQuantity : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public abstract class SelectQuantity : BuyerTestBase, IDisposable
     {
         private readonly int orderId;
         private readonly CatalogueItemId catalogueItemId;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Quantity/Base/SelectRecipientQuantity.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Quantity/Base/SelectRecipientQuantity.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Quantity.Base
 {
-    public abstract class SelectRecipientQuantity : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public abstract class SelectRecipientQuantity : BuyerTestBase, IDisposable
     {
         private readonly int orderId;
         private readonly CatalogueItemId catalogueItemId;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Quantity/ViewOrderItemQuantity.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Quantity/ViewOrderItemQuantity.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Quantity
 {
-    public class ViewOrderItemQuantity : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public class ViewOrderItemQuantity : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
         private static readonly CallOffId CallOffId = new(90031, 2);

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Quantity/ViewServiceRecipientQuantity.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Quantity/ViewServiceRecipientQuantity.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Quantity
 {
-    public class ViewServiceRecipientQuantity : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public class ViewServiceRecipientQuantity : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
         private static readonly CallOffId CallOffId = new(90031, 2);

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Review/ReviewSolutions.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Review/ReviewSolutions.cs
@@ -11,7 +11,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Review
 {
-    public class ReviewSolutions : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public class ReviewSolutions : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
         private const int OrderId = 90013;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Review/ReviewSolutionsAmendment.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/Review/ReviewSolutionsAmendment.cs
@@ -11,7 +11,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.Review
 {
-    public class ReviewSolutionsAmendment : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public class ReviewSolutionsAmendment : BuyerTestBase
     {
         private const int OrderId = 90032;
         private const string InternalOrgId = "CG-03F";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/TaskList/Base/TaskListBase.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/SolutionSelection/TaskList/Base/TaskListBase.cs
@@ -12,7 +12,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.SolutionSelection.TaskList.Base
 {
-    public abstract class TaskListBase : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public abstract class TaskListBase : BuyerTestBase
     {
         protected TaskListBase(LocalWebApplicationFactory factory, Dictionary<string, string> parameters)
             : base(factory, typeof(TaskListController), nameof(TaskListController.TaskList), parameters)

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Supplier/NewContact.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Supplier/NewContact.cs
@@ -12,7 +12,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Supplier
 {
-    public sealed class NewContact : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public sealed class NewContact : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
         private static readonly CallOffId CallOffId = new(91002, 1);

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Supplier/SelectSupplierAssociatedServicesOnly.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Supplier/SelectSupplierAssociatedServicesOnly.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Supplier
 {
-    public class SelectSupplierAssociatedServicesOnly : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(OrderingCollection))]
+    public class SelectSupplierAssociatedServicesOnly : BuyerTestBase
     {
         private const string InternalOrgId = "CG-03F";
         private const string SearchTerm = "E2E Test Supplier";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Supplier/SupplierInformation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Supplier/SupplierInformation.cs
@@ -17,7 +17,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Supplier
 {
-    public sealed class SupplierInformation : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(OrderingCollection))]
+    public sealed class SupplierInformation : BuyerTestBase, IDisposable
     {
         private const string InternalOrgId = "CG-03F";
         private const string SupplierName = "E2E Test Supplier With Contact";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Supplier/SupplierInformationSupplierSelected.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Ordering/Supplier/SupplierInformationSupplierSelected.cs
@@ -14,7 +14,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Ordering.Supplier
 {
-    public sealed class SupplierInformationSupplierSelected : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IAsyncLifetime
+    [Collection(nameof(OrderingCollection))]
+    public sealed class SupplierInformationSupplierSelected : BuyerTestBase, IAsyncLifetime
     {
         private const string InternalOrgId = "CG-03F";
         private const int SupplierContactId = 2;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Filtering/FilterCapabilities.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Filtering/FilterCapabilities.cs
@@ -12,7 +12,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Filtering
 {
-    public class FilterCapabilities : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(SharedContextCollection))]
+    public class FilterCapabilities : BuyerTestBase
     {
         public FilterCapabilities(LocalWebApplicationFactory factory)
             : base(factory, typeof(FilterController), nameof(FilterController.FilterCapabilities), null)

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Filtering/FilterEpics.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Filtering/FilterEpics.cs
@@ -12,7 +12,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Filtering
 {
-    public class FilterEpics : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(SharedContextCollection))]
+    public class FilterEpics : BuyerTestBase
     {
         private static readonly IEnumerable<int> CapabilityIds = new[] { 1, 2, 3, 4, 5 };
         private static readonly Dictionary<string, string> Parameters = new()

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Filtering/IncludeEpics.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Filtering/IncludeEpics.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Filtering
 {
-    public class IncludeEpics : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(SharedContextCollection))]
+    public class IncludeEpics : BuyerTestBase
     {
         private const string ValidCapabilityId = "1";
         private const string InvalidCapabilityId = "41";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Homepage/AccessibilityStatement.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Homepage/AccessibilityStatement.cs
@@ -9,7 +9,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Homepage
 {
-    public class AccessibilityStatement : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(SharedContextCollection))]
+    public class AccessibilityStatement : AnonymousTestBase
     {
         public AccessibilityStatement(LocalWebApplicationFactory factory, ITestOutputHelper testOutputHelper)
             : base(factory, typeof(HomeController), nameof(HomeController.AccessibilityStatement), null, testOutputHelper)

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Homepage/AdvancedTelephonyBetterPurchasing.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Homepage/AdvancedTelephonyBetterPurchasing.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Homepage
 {
-    public class AdvancedTelephonyBetterPurchasing : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(SharedContextCollection))]
+    public class AdvancedTelephonyBetterPurchasing : AnonymousTestBase
     {
         public AdvancedTelephonyBetterPurchasing(LocalWebApplicationFactory factory)
                : base(factory, typeof(HomeController), nameof(HomeController.AdvancedTelephonyBetterPurchaseFramework))

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Homepage/ContactUs.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Homepage/ContactUs.cs
@@ -9,7 +9,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Homepage
 {
-    public sealed class ContactUs : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class ContactUs : AnonymousTestBase
     {
         public ContactUs(LocalWebApplicationFactory factory, ITestOutputHelper testOutputHelper)
                : base(

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Homepage/ContactUsConfirmation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Homepage/ContactUsConfirmation.cs
@@ -11,7 +11,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Homepage
 {
-    public class ContactUsConfirmation : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(SharedContextCollection))]
+    public class ContactUsConfirmation : AnonymousTestBase
     {
         private static readonly Dictionary<string, string> Parameters = new();
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Homepage/CookieBanner.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Homepage/CookieBanner.cs
@@ -17,8 +17,9 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Homepage
 {
+    [Collection(nameof(SharedContextCollection))]
     public sealed class CookieBanner
-        : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+        : AnonymousTestBase, IDisposable
     {
         private static readonly Dictionary<string, string> Parameters = new();
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Homepage/CookieSettings.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Homepage/CookieSettings.cs
@@ -17,7 +17,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Homepage
 {
-    public sealed class CookieSettings : AuthorityTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class CookieSettings : AuthorityTestBase, IDisposable
     {
         private const string OptInRadioButtonText = "Use cookies to measure my website use";
         private const string OptOutRadioButtonText = "Do not use cookies to measure my website use";

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Homepage/HomePage.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Homepage/HomePage.cs
@@ -20,8 +20,9 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Homepage
 {
+    [Collection(nameof(SharedContextCollection))]
     public sealed class HomePage
-        : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+        : AnonymousTestBase, IDisposable
     {
         private static readonly Dictionary<string, string> Parameters = new();
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Homepage/PrivacyPolicy.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Homepage/PrivacyPolicy.cs
@@ -10,7 +10,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Homepage
 {
-    public sealed class PrivacyPolicy : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class PrivacyPolicy : AnonymousTestBase
     {
         private static readonly Dictionary<string, string> Parameters = new();
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Homepage/TermsOfUse.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Homepage/TermsOfUse.cs
@@ -14,9 +14,9 @@ using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Homepage
 {
+    [Collection(nameof(SharedContextCollection))]
     public sealed class TermsOfUse :
         AnonymousTestBase,
-        IClassFixture<LocalWebApplicationFactory>,
         IDisposable
     {
         public TermsOfUse(LocalWebApplicationFactory factory)

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/NominateOrganisation/Confirmation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/NominateOrganisation/Confirmation.cs
@@ -10,7 +10,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.NominateOrganisation
 {
-    public sealed class Confirmation : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class Confirmation : BuyerTestBase, IDisposable
     {
         public Confirmation(LocalWebApplicationFactory factory, ITestOutputHelper testOutputHelper)
             : base(

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/NominateOrganisation/Details.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/NominateOrganisation/Details.cs
@@ -12,7 +12,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.NominateOrganisation
 {
-    public sealed class Details : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class Details : BuyerTestBase, IDisposable
     {
         public Details(LocalWebApplicationFactory factory, ITestOutputHelper testOutputHelper)
             : base(

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/NominateOrganisation/Index.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/NominateOrganisation/Index.cs
@@ -11,7 +11,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.NominateOrganisation
 {
-    public sealed class Index : BuyerTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class Index : BuyerTestBase, IDisposable
     {
         public Index(LocalWebApplicationFactory factory, ITestOutputHelper testOutputHelper)
             : base(

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/ProcurementHub/Index.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/ProcurementHub/Index.cs
@@ -12,7 +12,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.ProcurementHub
 {
-    public sealed class Index : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class Index : AnonymousTestBase
     {
         private const string PrivacyPolicyLabelText = "I have read and understood the privacy policy";
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Registration/Confirmation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Registration/Confirmation.cs
@@ -9,7 +9,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Registration
 {
-    public sealed class Confirmation : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class Confirmation : AnonymousTestBase
     {
         public Confirmation(LocalWebApplicationFactory factory, ITestOutputHelper testOutputHelper)
             : base(

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Registration/Details.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Registration/Details.cs
@@ -10,7 +10,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Registration
 {
-    public sealed class Details : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class Details : AnonymousTestBase
     {
         private const string PrivacyPolicyLabelText = "I have read and understood the privacy policy";
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Registration/Index.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Registration/Index.cs
@@ -10,7 +10,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Registration
 {
-    public sealed class Index : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class Index : AnonymousTestBase
     {
         public Index(LocalWebApplicationFactory factory, ITestOutputHelper testOutputHelper)
             : base(

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/AdditionalServiceEpics.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/AdditionalServiceEpics.cs
@@ -15,7 +15,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class AdditionalServiceEpics : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class AdditionalServiceEpics : AnonymousTestBase, IDisposable
     {
         private static readonly int CapabilityId = 2;
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/AdditionalServicesCapabilities.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/AdditionalServicesCapabilities.cs
@@ -14,7 +14,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class AdditionalServicesCapabilities : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class AdditionalServicesCapabilities : AnonymousTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/AdditionalServicesDetails.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/AdditionalServicesDetails.cs
@@ -17,7 +17,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class AdditionalServicesDetails : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class AdditionalServicesDetails : AnonymousTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/ApplicationTypeDetails.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/ApplicationTypeDetails.cs
@@ -14,7 +14,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class ApplicationTypeDetails : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class ApplicationTypeDetails : AnonymousTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/AssociatedServicesDetails.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/AssociatedServicesDetails.cs
@@ -17,7 +17,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class AssociatedServicesDetails : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class AssociatedServicesDetails : AnonymousTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/CapabilitiesDetails.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/CapabilitiesDetails.cs
@@ -14,7 +14,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class CapabilitiesDetails : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class CapabilitiesDetails : AnonymousTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/CatalogueSolutions.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/CatalogueSolutions.cs
@@ -18,8 +18,9 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
+    [Collection(nameof(SharedContextCollection))]
     public sealed class CatalogueSolutions
-        : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>
+        : AnonymousTestBase
     {
         private static readonly Dictionary<string, string> Parameters = new();
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/DevelopmentPlans.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/DevelopmentPlans.cs
@@ -15,7 +15,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class DevelopmentPlans : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class DevelopmentPlans : AnonymousTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionWithAllSections = new(99998, "001");
         private static readonly CatalogueItemId SolutionWithDefaultSection = new(99998, "002");

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/FeatureDetails.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/FeatureDetails.cs
@@ -14,7 +14,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class FeatureDetails : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class FeatureDetails : AnonymousTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/ImplementationDetails.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/ImplementationDetails.cs
@@ -15,7 +15,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class ImplementationDetails : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class ImplementationDetails : AnonymousTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/Interoperability.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/Interoperability.cs
@@ -16,7 +16,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class Interoperability : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class Interoperability : AnonymousTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/ListPriceDetails.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/ListPriceDetails.cs
@@ -14,7 +14,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class ListPriceDetails : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class ListPriceDetails : AnonymousTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/ServiceLevelAgreement.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/ServiceLevelAgreement.cs
@@ -15,7 +15,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class ServiceLevelAgreement : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class ServiceLevelAgreement : AnonymousTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/SolutionDescription.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/SolutionDescription.cs
@@ -17,7 +17,8 @@ using Objects = NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class SolutionDescription : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class SolutionDescription : AnonymousTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/Standards.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/Standards.cs
@@ -15,7 +15,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class Standards : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class Standards : AnonymousTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionWithAllSections = new(99998, "001");
         private static readonly CatalogueItemId SolutionWithDefaultSection = new(99998, "002");

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/SupplierDetails.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/SupplierDetails.cs
@@ -14,7 +14,8 @@ using Xunit.Abstractions;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 {
-    public sealed class SupplierDetails : AnonymousTestBase, IClassFixture<LocalWebApplicationFactory>, IDisposable
+    [Collection(nameof(SharedContextCollection))]
+    public sealed class SupplierDetails : AnonymousTestBase, IDisposable
     {
         private static readonly CatalogueItemId SolutionId = new(99999, "001");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Fixtures/AccountManagementCollection.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Fixtures/AccountManagementCollection.cs
@@ -1,0 +1,9 @@
+﻿using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests;
+
+[CollectionDefinition(nameof(AccountManagementCollection))]
+public sealed class AccountManagementCollection : ICollectionFixture<LocalWebApplicationFactory>
+{
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Fixtures/AccountManagementCollection.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Fixtures/AccountManagementCollection.cs
@@ -1,9 +1,0 @@
-﻿using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
-using Xunit;
-
-namespace NHSD.GPIT.BuyingCatalogue.E2ETests;
-
-[CollectionDefinition(nameof(AccountManagementCollection))]
-public sealed class AccountManagementCollection : ICollectionFixture<LocalWebApplicationFactory>
-{
-}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Fixtures/AdminCollection.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Fixtures/AdminCollection.cs
@@ -1,0 +1,9 @@
+﻿using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests;
+
+[CollectionDefinition(nameof(AdminCollection))]
+public sealed class AdminCollection : ICollectionFixture<LocalWebApplicationFactory>
+{
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Fixtures/OrderingCollection.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Fixtures/OrderingCollection.cs
@@ -1,0 +1,10 @@
+﻿using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests;
+
+[CollectionDefinition(nameof(OrderingCollection))]
+public sealed class OrderingCollection : ICollectionFixture<LocalWebApplicationFactory>
+{
+
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Fixtures/SharedContextCollection.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Fixtures/SharedContextCollection.cs
@@ -1,0 +1,10 @@
+﻿using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests;
+
+[CollectionDefinition(nameof(SharedContextCollection))]
+public sealed class SharedContextCollection : ICollectionFixture<LocalWebApplicationFactory>
+{
+
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/EmailDomainSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/EmailDomainSeedData.cs
@@ -7,7 +7,8 @@ internal static class EmailDomainSeedData
 {
     internal static void Initialize(BuyingCatalogueDbContext context)
     {
-        context.EmailDomains.Add(new EmailDomain("@nhs.net"));
+        context.EmailDomains.Add(new("@nhs.net"));
+        context.EmailDomains.Add(new("@email.com"));
 
         context.SaveChanges();
     }

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/UserSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/UserSeedData.cs
@@ -15,6 +15,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
     internal static class UserSeedData
     {
         internal const string AliceEmail = "AliceSmith@email.com";
+        internal const string DaveEmail = "DaveSmith@email.com";
         internal const int BobId = 2;
         internal const int SueId = 3;
         internal const int AliceId = 4;
@@ -394,10 +395,10 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.SeedData
             var accountManagerUser = new AspNetUser
             {
                 Id = DaveId,
-                Email = "DaveSmith@email.com",
-                NormalizedEmail = "DAVESMITH@EMAIL.COM",
-                UserName = "DaveSmith@email.com",
-                NormalizedUserName = "DAVESMITH@EMAIL.COM",
+                Email = DaveEmail,
+                NormalizedEmail = DaveEmail.ToUpperInvariant(),
+                UserName = DaveEmail,
+                NormalizedUserName = DaveEmail.ToUpperInvariant(),
                 Disabled = false,
                 FirstName = "Dave",
                 LastName = "Smith",

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/UserSeedData.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/SeedData/UserSeedData.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.EntityFrameworkCore;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Database;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Addresses.Models;

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/TestBases/TestBase.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Utils/TestBases/TestBase.cs
@@ -334,9 +334,9 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases
             }
         }
 
-        public Task InitializeAsync() => Task.CompletedTask;
+        public virtual Task InitializeAsync() => Task.CompletedTask;
 
-        public Task DisposeAsync()
+        public virtual Task DisposeAsync()
         {
             NavigateToUrl(
                 typeof(AccountController),

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/RandomData/Strings.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/RandomData/Strings.cs
@@ -54,17 +54,21 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.RandomData
             var faker = new Faker("en_GB");
             return faker.Phone.PhoneNumber();
 
-        }       
+        }
 
         public static string RandomEmail(int numChars)
         {
             var faker = new Faker("en_GB");
             var email = faker.Internet.Email();
             var length = numChars - email.Length;
-            if (length > 0)
-                return string.Join(string.Empty, faker.Random.AlphaNumeric(numChars - email.Length), email);
+            return length > 0 ? string.Join(string.Empty, faker.Random.AlphaNumeric(numChars - email.Length), email) : email;
+        }
 
-            return email;
+        public static string RandomBuyerEmail()
+        {
+            var faker = new Faker("en_GB");
+
+            return faker.Internet.Email(provider: "nhs.net");
         }
 
         public static DateTime RandomDateSoon()

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Utils/RandomData/GenerateUser.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Utils/RandomData/GenerateUser.cs
@@ -13,7 +13,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Utils.RandomData
             return new Faker<User>("en_GB")
                 .RuleFor(u => u.FirstName, f => f.Name.FirstName())
                 .RuleFor(u => u.LastName, f => f.Name.LastName())
-                .RuleFor(u => u.EmailAddress, (f, u) => f.Internet.Email(u.FirstName, u.LastName))
+                .RuleFor(u => u.EmailAddress, (f, u) => f.Internet.Email(u.FirstName, u.LastName, "nhs.net"))
                 .Generate();
         }
 


### PR DESCRIPTION
The Integration tests have become a bit of a sticking point lately. It seems all devs are now unable to run these locally as they stand up too many Chrome instances.

Rather than use `IClassFixture<T>`, which instantiates `LocalWebApplicationFactory` per test class, this PR migrates the Integration Tests to use `CollectionDefinition` and `Collection` whereby `LocalWebApplicationFactory` is instantiated per collection. This does have the side effect of tests sharing state and so it is vital that all tests classes clean up after themselves.

3 Collections are introduced in order to keep the number of active Chrome instances low.
* `AdminCollection` - for any tests within the administration journey
* `OrderingCollection` - for any tests within the ordering journey
* `SharedContextCollection` - for any test areas that are either low in numbers or don't deal with complex scenarios. For example, the Authorization and PublicBrowse sections.
