### PR TITLE
1a. Filtering - Changes to the results header section

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Models/PageOptions.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Models/PageOptions.cs
@@ -39,9 +39,6 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models
             [Display(Name = "Z to A")]
             ZToA,
 
-            [Display(Name = "Framework")]
-            Framework,
-
             [Display(Name = "Last published")]
             LastPublished,
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Solutions/SolutionsFilterService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Solutions/SolutionsFilterService.cs
@@ -52,8 +52,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Solutions
                 PageOptions.SortOptions.LastPublished => query.OrderByDescending(ci => ci.LastPublished)
                                                                 .ThenBy(ci => ci.Name),
                 PageOptions.SortOptions.ZToA => query.OrderByDescending(ci => ci.Name),
-                PageOptions.SortOptions.Framework => query.OrderBy(ci => ci.Solution.FrameworkSolutions.OrderBy(fs => fs.Framework.Name).First().Framework.Name)
-                                                            .ThenBy(ci => ci.Name),
                 PageOptions.SortOptions.AtoZ or _ => query.OrderBy(ci => ci.Name),
             };
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/SolutionsModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Models/SolutionsModel.cs
@@ -19,7 +19,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models
 
         public const string AdviceTextNosearch = "Search for Catalogue Solutions that match the needs of your organisation.";
         public const string AdviceTextSearchNoresults = "There are no Catalogue Solutions that meet your search criteria.";
-        public const string AdviceTextSearchResults = "These are the Catalogue Solutions that meet your search criteria.";
+        public const string AdviceTextSearchResults = "These are the Catalogue Solutions that meet your search criteria. You can apply additional filters to refine your results further, or compare these results.";
 
         public SolutionsModel()
         {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/Index.cshtml
@@ -64,13 +64,15 @@
     <div class="nhsuk-grid-column-full">
         <nhs-page-title title="@ViewBag.Title"
                         advice="@Model.AdviceText" />
-
-        <vc:nhs-suggestion-search id="marketing-suggestion-search"
+         @if (!Model.SearchCriteriaApplied)
+        {
+            <vc:nhs-suggestion-search id="marketing-suggestion-search"
                                   ajax-url="@Url.Action(
                                                 nameof(SolutionsController.FilterSearchSuggestions),
                                                 typeof(SolutionsController).ControllerName())"
                                   title-text="Search for solution by solution name or supplier name"
                                   query-parameter-name="search"/>
+        }
 
         <nhs-warning-callout label-text="GP IT Futures framework expired">
             <p>Lot 1 of the GP IT Futures framework expired on 31 March 2023. This means you can no longer carry out new procurements of solutions and services offered under that framework.</p>
@@ -78,14 +80,16 @@
             <p>You’ll still be able to use the Buying Catalogue to browse and procure solutions and services from the Digital First Online Consultation and Video Consultation (DFOCVC) framework.</p>
             <p>However, orders placed under the GP IT Futures framework will not be completed until the replacement framework is live.</p>
         </nhs-warning-callout>
-
-        <vc:nhs-action-link text="Filter Catalogue Solutions"
+        @if (!Model.SearchCriteriaApplied)
+        {
+            <vc:nhs-action-link text="Filter Catalogue Solutions"
                             url="@Url.Action(
                                 nameof(FilterController.FilterCapabilities),
                                 typeof(FilterController).ControllerName(),
                                 new { SelectedCapabilityIds = Model.SearchSummary.SelectedCapabilityIds,
                                       SelectedEpicIds = Model.SearchSummary.SelectedEpicIds, 
                                       search = Model.SearchSummary.SearchTerm})" />
+        }
 
 
         @if (Model.SearchCriteriaApplied)
@@ -95,7 +99,7 @@
             <br/>
 
             @if (!string.IsNullOrWhiteSpace(Model.SearchSummary.SearchTerm)){
-                <h3 data-test-id="search-term-title">Search term:</h3>
+                <h3 data-test-id="search-term-title">Selected Capabilities and Epics</h3>
                 <p data-test-id="search-term-content">@($"'{Model.SearchSummary.SearchTerm}'")</p>
             }
 
@@ -121,7 +125,8 @@
                     Edit Capabilities
                 </a>
 
-                <a asp-area="@typeof(FilterController).AreaName()"
+                <a style="margin-right:20px;"
+                    asp-area="@typeof(FilterController).AreaName()"
                     asp-controller="@typeof(FilterController).ControllerName()"
                     asp-action="@nameof(FilterController.FilterEpics)"
                     asp-route-selectedCapabilityIds="@Model.SearchSummary.SelectedCapabilityIds"
@@ -129,12 +134,13 @@
                     asp-route-search="@Model.SearchSummary.SearchTerm">
                     Edit Epics
                 </a>
-            </p>
 
-            <vc:nhs-secondary-button 
-                type="Secondary" 
-                url="@Url.Action(nameof(SolutionsController.Index), typeof(SolutionsController).ControllerName())" 
-                text="Clear search criteria" />
+                <a asp-area="@typeof(SolutionsController).AreaName()"
+                    asp-controller="@typeof(SolutionsController).ControllerName()"
+                    asp-action="@nameof(SolutionsController.Index)">
+                    Start a new search
+                </a>
+            </p>
 
             @if (Model.CatalogueItems.Count == 0)
             {

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/CatalogueSolutions.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/PublicBrowse/Solution/CatalogueSolutions.cs
@@ -216,7 +216,6 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 
                 CommonActions.ElementIsDisplayed(SolutionsObjects.SearchTermTitle).Should().BeTrue();
                 CommonActions.ElementIsDisplayed(SolutionsObjects.SearchTermContent).Should().BeTrue();
-                CommonActions.ElementIsDisplayed(SolutionsObjects.ClearSearchCriteriaLink).Should().BeTrue();
                 CommonActions.ElementTextContains(SolutionsObjects.SearchTermContent, $"'{solutionName}'").Should().BeTrue();
             });
         }
@@ -232,6 +231,60 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
                     .Should()
                     .BeTrue();
             });
+        }
+
+        [Fact]
+        public void CatalogueSolutions_ClickStartNewSearchLink_ExpectedResult()
+        {
+            using var context = GetEndToEndDbContext();
+            var solution = context.Solutions.Include(s => s.CatalogueItem).First(s => s.CatalogueItem.PublishedStatus == PublicationStatus.Published);
+
+            CommonActions.ElementAddValue(SolutionsObjects.SearchBar, solution.CatalogueItem.Name);
+            CommonActions.WaitUntilElementIsDisplayed(SolutionsObjects.SearchListBox);
+
+            CommonActions.ClickLinkElement(SolutionsObjects.SearchButton);
+
+            CommonActions.ClickLinkElement(SolutionsObjects.StartNewSearch);
+
+            CommonActions.PageLoadedCorrectGetIndex(typeof(SolutionsController), nameof(SolutionsController.Index))
+                .Should()
+                .BeTrue();
+        }
+
+        [Fact]
+        public void CatalogueSolutions_ClickEditCapabilitiesLink_ExpectedResult()
+        {
+            using var context = GetEndToEndDbContext();
+            var solution = context.Solutions.Include(s => s.CatalogueItem).First(s => s.CatalogueItem.PublishedStatus == PublicationStatus.Published);
+
+            CommonActions.ElementAddValue(SolutionsObjects.SearchBar, solution.CatalogueItem.Name);
+            CommonActions.WaitUntilElementIsDisplayed(SolutionsObjects.SearchListBox);
+
+            CommonActions.ClickLinkElement(SolutionsObjects.SearchButton);
+
+            CommonActions.ClickLinkElement(SolutionsObjects.EditCapabilities);
+
+            CommonActions.PageLoadedCorrectGetIndex(typeof(FilterController), nameof(FilterController.FilterCapabilities))
+                .Should()
+                .BeTrue();
+        }
+
+        [Fact]
+        public void CatalogueSolutions_ClickEditEpicsLink_ExpectedResult()
+        {
+            using var context = GetEndToEndDbContext();
+            var solution = context.Solutions.Include(s => s.CatalogueItem).First(s => s.CatalogueItem.PublishedStatus == PublicationStatus.Published);
+
+            CommonActions.ElementAddValue(SolutionsObjects.SearchBar, solution.CatalogueItem.Name);
+            CommonActions.WaitUntilElementIsDisplayed(SolutionsObjects.SearchListBox);
+
+            CommonActions.ClickLinkElement(SolutionsObjects.SearchButton);
+
+            CommonActions.ClickLinkElement(SolutionsObjects.EditEpics);
+
+            CommonActions.PageLoadedCorrectGetIndex(typeof(FilterController), nameof(FilterController.FilterEpics))
+                .Should()
+                .BeTrue();
         }
 
         [Fact]
@@ -279,7 +332,6 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 
                 CommonActions.ClickLinkElement(SolutionsObjects.SearchButton);
 
-                CommonActions.ElementIsDisplayed(SolutionsObjects.SearchBar).Should().BeTrue();
                 CommonActions.ElementIsDisplayed(SolutionsObjects.NoResultsElement).Should().BeTrue();
                 CommonActions.ElementIsDisplayed(SolutionsObjects.SolutionsList).Should().BeFalse();
             });
@@ -295,8 +347,6 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.PublicBrowse.Solution
 
                 CommonActions.ClickLinkElement(SolutionsObjects.SearchButton);
                 CommonActions.WaitUntilElementIsDisplayed(SolutionsObjects.NoResultsElement);
-
-                CommonActions.ClickLinkElement(SolutionsObjects.ClearSearchCriteriaLink);
 
                 CommonActions.PageLoadedCorrectGetIndex(
                     typeof(SolutionsController),

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Objects/PublicBrowse/SolutionsObjects.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Objects/PublicBrowse/SolutionsObjects.cs
@@ -21,8 +21,9 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.PublicBrowse
         public static By SortBySelect => By.Id("SelectedSortOption");
 
         public static By FilterCatalogueSolutionsLink => By.LinkText("Filter Catalogue Solutions");
-
-        public static By ClearSearchCriteriaLink => By.LinkText("Clear search criteria");
+        public static By StartNewSearch => By.LinkText("Start a new search");
+        public static By EditCapabilities => By.LinkText("Edit Capabilities");
+        public static By EditEpics => By.LinkText("Edit Epics");
 
         public static By SolutionsLink => By.CssSelector("div.nhsuk-grid-column-two-thirds h2 a");
 


### PR DESCRIPTION
Changes made to the result header section when user has filtered the catalogue solutions are new lede text is displayed,  new action link to Start a new search, 'Framework' removed from dropdown, search bar is removed, Clear search criteria is removed and  'Filter Catalogue Solutions' CTA is removed.