### PR TITLE
Unpublish services with solution

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Catalogue/Models/AssociatedService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Catalogue/Models/AssociatedService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Users.Models;
 

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/AssociatedServices/IAssociatedServicesService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/AssociatedServices/IAssociatedServicesService.cs
@@ -25,6 +25,8 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.AssociatedServices
 
         Task RelateAssociatedServicesToSolution(CatalogueItemId solutionId, IEnumerable<CatalogueItemId> associatedServices);
 
+        Task RemoveServiceFromSolution(CatalogueItemId solutionId, CatalogueItemId associatedServiceId);
+
         Task EditDetails(CatalogueItemId associatedServiceId, AssociatedServicesDetailsModel model);
 
         Task<CatalogueItemId> AddAssociatedService(CatalogueItem solution, AssociatedServicesDetailsModel model);

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/PublishStatus/IPublicationStatusService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/PublishStatus/IPublicationStatusService.cs
@@ -6,6 +6,6 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.PublishStatus
 {
     public interface IPublicationStatusService
     {
-        public Task SetPublicationStatus(CatalogueItemId catalogueItemId, PublicationStatus publicationStatus);
+        Task SetPublicationStatus(CatalogueItemId catalogueItemId, PublicationStatus publicationStatus);
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/PublishStatus/ISolutionPublicationStatusService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/PublishStatus/ISolutionPublicationStatusService.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+
+namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.PublishStatus;
+
+public interface ISolutionPublicationStatusService
+{
+    Task SetPublicationStatus(CatalogueItemId catalogueItemId, PublicationStatus publicationStatus);
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/AdditionalServices/AdditionalServicesService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/AdditionalServices/AdditionalServicesService.cs
@@ -77,7 +77,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.AdditionalServices
         {
             if (!catalogueItemId.HasValue)
             {
-                return new List<CatalogueItem>();
+                return Enumerable.Empty<CatalogueItem>().ToList();
             }
 
             return publishedOnly

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/AssociatedServices/AssociatedServicesService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/AssociatedServices/AssociatedServicesService.cs
@@ -53,7 +53,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.AssociatedServices
         {
             if (catalogueItemId is null)
             {
-                return new List<CatalogueItem>();
+                return Enumerable.Empty<CatalogueItem>().ToList();
             }
 
             return await dbContext.SupplierServiceAssociations
@@ -114,11 +114,24 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.AssociatedServices
             await dbContext.SaveChangesAsync();
         }
 
+        public async Task RemoveServiceFromSolution(CatalogueItemId solutionId, CatalogueItemId associatedServiceId)
+        {
+            var associatedServiceAssociation = await dbContext.SupplierServiceAssociations.AsNoTracking()
+                .FirstOrDefaultAsync(
+                    x => x.CatalogueItemId == solutionId && x.AssociatedServiceId == associatedServiceId);
+
+            if (associatedServiceAssociation is null) return;
+
+            dbContext.SupplierServiceAssociations.Remove(associatedServiceAssociation);
+            await dbContext.SaveChangesAsync();
+        }
+
         public async Task<List<CatalogueItem>> GetAllSolutionsForAssociatedService(CatalogueItemId associatedServiceId)
             => await dbContext
                 .SupplierServiceAssociations
                 .Where(ssa => ssa.AssociatedServiceId == associatedServiceId)
-                .Select(ssa => ssa.CatalogueItem).ToListAsync();
+                .Select(ssa => ssa.CatalogueItem)
+                .ToListAsync();
 
         public async Task<CatalogueItemId> AddAssociatedService(
             CatalogueItem solution,

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/PublishStatus/SolutionPublicationStatusService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/PublishStatus/SolutionPublicationStatusService.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.AdditionalServices;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.AssociatedServices;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.PublishStatus;
+
+namespace NHSD.GPIT.BuyingCatalogue.Services.PublishStatus;
+
+public class SolutionPublicationStatusService : ISolutionPublicationStatusService
+{
+    private readonly IAdditionalServicesService additionalServicesService;
+    private readonly IAssociatedServicesService associatedServicesService;
+    private readonly IPublicationStatusService publicationStatusService;
+
+    public SolutionPublicationStatusService(
+        IAdditionalServicesService additionalServicesService,
+        IAssociatedServicesService associatedServicesService,
+        IPublicationStatusService publicationStatusService)
+    {
+        this.additionalServicesService = additionalServicesService
+            ?? throw new ArgumentNullException(nameof(additionalServicesService));
+        this.associatedServicesService = associatedServicesService
+            ?? throw new ArgumentNullException(nameof(associatedServicesService));
+        this.publicationStatusService = publicationStatusService
+            ?? throw new ArgumentNullException(nameof(publicationStatusService));
+    }
+
+    public async Task SetPublicationStatus(CatalogueItemId catalogueItemId, PublicationStatus publicationStatus)
+    {
+        await publicationStatusService.SetPublicationStatus(catalogueItemId, publicationStatus);
+
+        if (publicationStatus is not PublicationStatus.Unpublished) return;
+
+        await UnpublishAdditionalServicesAsync(catalogueItemId);
+
+        await UnpublishStaleAssociatedServicesAsync(catalogueItemId);
+    }
+
+    private async Task UnpublishAdditionalServicesAsync(CatalogueItemId catalogueItemId)
+    {
+        var additionalServices = await additionalServicesService.GetAdditionalServicesBySolutionId(catalogueItemId, true);
+        foreach (var additionalService in additionalServices)
+        {
+            await publicationStatusService.SetPublicationStatus(additionalService.Id, PublicationStatus.Unpublished);
+        }
+    }
+
+    private async Task UnpublishStaleAssociatedServicesAsync(CatalogueItemId catalogueItemId)
+    {
+        var associatedServices =
+            await associatedServicesService.GetPublishedAssociatedServicesForSolution(catalogueItemId);
+
+        foreach (var associatedService in associatedServices)
+        {
+            var referencedSolutions =
+                await associatedServicesService.GetAllSolutionsForAssociatedService(associatedService.Id);
+            if (referencedSolutions.Any(x => x.PublishedStatus != PublicationStatus.Unpublished)) continue;
+
+            await publicationStatusService.SetPublicationStatus(associatedService.Id, PublicationStatus.Unpublished);
+            await associatedServicesService.RemoveServiceFromSolution(catalogueItemId, associatedService.Id);
+        }
+    }
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/CatalogueSolutionsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/CatalogueSolutionsController.cs
@@ -28,13 +28,13 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
         private readonly ISolutionsService solutionsService;
         private readonly ISuppliersService suppliersService;
         private readonly ICapabilitiesService capabilitiesService;
-        private readonly IPublicationStatusService publicationStatusService;
+        private readonly ISolutionPublicationStatusService publicationStatusService;
 
         public CatalogueSolutionsController(
             ISolutionsService solutionsService,
             ISuppliersService suppliersService,
             ICapabilitiesService capabilitiesService,
-            IPublicationStatusService publicationStatusService)
+            ISolutionPublicationStatusService publicationStatusService)
         {
             this.solutionsService = solutionsService ?? throw new ArgumentNullException(nameof(solutionsService));
             this.suppliersService = suppliersService ?? throw new ArgumentNullException(nameof(suppliersService));
@@ -133,6 +133,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
                 return View("ManageCatalogueSolution", model);
 
             var solution = await solutionsService.GetSolutionThin(solutionId);
+
+            if (solution.PublishedStatus == model.SelectedPublicationStatus) return RedirectToAction(nameof(Index));
 
             await publicationStatusService.SetPublicationStatus(solutionId, model.SelectedPublicationStatus);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/SolutionSelection/Shared/SelectServicesModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/SolutionSelection/Shared/SelectServicesModel.cs
@@ -64,7 +64,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection
         {
             if (order == null)
             {
-                return new List<OrderItem>();
+                return Enumerable.Empty<OrderItem>().ToList();
             }
 
             return catalogueItemType switch

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/PublishStatus/SolutionPublicationStatusServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/PublishStatus/SolutionPublicationStatusServiceTests.cs
@@ -1,0 +1,124 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using AutoFixture.Idioms;
+using AutoFixture.Xunit2;
+using Moq;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.AdditionalServices;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.AssociatedServices;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.PublishStatus;
+using NHSD.GPIT.BuyingCatalogue.Services.PublishStatus;
+using NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.AutoFixtureCustomisations;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.PublishStatus;
+
+public static class SolutionPublicationStatusServiceTests
+{
+    [Fact]
+    public static void Constructors_VerifyGuardClauses()
+    {
+        var fixture = new Fixture().Customize(new AutoMoqCustomization());
+        var assertion = new GuardClauseAssertion(fixture);
+        var constructors = typeof(SolutionPublicationStatusService).GetConstructors();
+
+        assertion.Verify(constructors);
+    }
+
+    [Theory]
+    [CommonAutoData]
+    public static async Task SetPublicationStatus_CallsPublicationStatusService(
+        CatalogueItemId catalogueItemId,
+        PublicationStatus publicationStatus,
+        [Frozen] Mock<IPublicationStatusService> publicationStatusService,
+        SolutionPublicationStatusService service)
+    {
+        await service.SetPublicationStatus(catalogueItemId, publicationStatus);
+
+        publicationStatusService.Verify(x => x.SetPublicationStatus(catalogueItemId, publicationStatus));
+    }
+
+    [Theory]
+    [CommonAutoData]
+    public static async Task SetPublicationStatus_Unpublish_UnpublishesAdditionalServices(
+        CatalogueItemId catalogueItemId,
+        List<CatalogueItem> additionalServices,
+        [Frozen] Mock<IPublicationStatusService> publicationStatusService,
+        [Frozen] Mock<IAdditionalServicesService> additionalServicesService,
+        SolutionPublicationStatusService service)
+    {
+        additionalServicesService
+            .Setup(x => x.GetAdditionalServicesBySolutionId(catalogueItemId, true))
+            .ReturnsAsync(additionalServices);
+
+        await service.SetPublicationStatus(catalogueItemId, PublicationStatus.Unpublished);
+
+        additionalServices.ForEach(
+            x => publicationStatusService.Verify(y => y.SetPublicationStatus(x.Id, PublicationStatus.Unpublished)));
+    }
+
+    [Theory]
+    [CommonAutoData]
+    public static async Task SetPublicationStatus_Unpublish_UnpublishesStaleAssociatedServices(
+        CatalogueItemId catalogueItemId,
+        List<CatalogueItem> associatedServices,
+        [Frozen] Mock<IPublicationStatusService> publicationStatusService,
+        [Frozen] Mock<IAssociatedServicesService> associatedServicesService,
+        SolutionPublicationStatusService service)
+    {
+        associatedServicesService
+            .Setup(x => x.GetPublishedAssociatedServicesForSolution(catalogueItemId))
+            .ReturnsAsync(associatedServices);
+
+        associatedServicesService
+            .Setup(x => x.GetAllSolutionsForAssociatedService(It.IsAny<CatalogueItemId>()))
+            .ReturnsAsync(Enumerable.Empty<CatalogueItem>().ToList());
+
+        await service.SetPublicationStatus(catalogueItemId, PublicationStatus.Unpublished);
+
+        associatedServices.ForEach(
+            x => publicationStatusService.Verify(y => y.SetPublicationStatus(x.Id, PublicationStatus.Unpublished)));
+    }
+
+    [Theory]
+    [CommonAutoData]
+    public static async Task SetPublicationStatus_Unpublish_DoesNotUnpublishReferencedAssociatedServices(
+        CatalogueItemId catalogueItemId,
+        CatalogueItem referencedSolution,
+        List<CatalogueItem> associatedServices,
+        [Frozen] Mock<IPublicationStatusService> publicationStatusService,
+        [Frozen] Mock<IAssociatedServicesService> associatedServicesService,
+        SolutionPublicationStatusService service)
+    {
+        var associatedService = associatedServices.First();
+
+        referencedSolution.PublishedStatus = PublicationStatus.Published;
+
+        associatedServicesService
+            .Setup(x => x.GetPublishedAssociatedServicesForSolution(catalogueItemId))
+            .ReturnsAsync(associatedServices);
+
+        associatedServicesService
+            .Setup(x => x.GetAllSolutionsForAssociatedService(associatedService.Id))
+            .ReturnsAsync(new List<CatalogueItem> { referencedSolution });
+
+        associatedServicesService
+            .Setup(x => x.GetAllSolutionsForAssociatedService(It.Is<CatalogueItemId>(y => y != associatedService.Id)))
+            .ReturnsAsync(Enumerable.Empty<CatalogueItem>().ToList());
+
+        await service.SetPublicationStatus(catalogueItemId, PublicationStatus.Unpublished);
+
+        publicationStatusService.Verify(
+            x => x.SetPublicationStatus(associatedService.Id, It.IsAny<PublicationStatus>()),
+            Times.Never());
+
+        associatedServices.Skip(1)
+            .ToList()
+            .ForEach(
+                x => publicationStatusService.Verify(y => y.SetPublicationStatus(x.Id, PublicationStatus.Unpublished)));
+    }
+}


### PR DESCRIPTION
When a solution is unpublished, the following should apply.
1. Additional services, under the solution, should be unpublished.
2. Associated services, when not referenced by any other published soultions, should be unpublished and the link between Solution and Associated Service broken.