### PR TITLE
Restrict admin delete to delete the latest amendment only

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.Framework/Calculations/CataloguePriceCalculations.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Framework/Calculations/CataloguePriceCalculations.cs
@@ -198,7 +198,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Framework.Calculations
                 return 0;
             }
 
-            var deliveryDate = orderItem.OrderItemRecipients.First().DeliveryDate;
+            var deliveryDate = orderItem.OrderItemRecipients.FirstOrDefault()?.DeliveryDate;
             if (deliveryDate.HasValue)
             {
                 var term = endDate.RemainingTerm(deliveryDate.Value);

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ManageOrders/DeleteNotLatestModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ManageOrders/DeleteNotLatestModel.cs
@@ -1,0 +1,17 @@
+﻿using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Models;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ManageOrders
+{
+    public sealed class DeleteNotLatestModel : NavBaseModel
+    {
+        public DeleteNotLatestModel(CallOffId callOffId)
+        {
+            CallOffId = callOffId;
+        }
+
+        public CallOffId CallOffId { get; set; }
+
+        public bool IsAmendment => CallOffId.IsAmendment;
+    }
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ManageOrders/DeleteOrderModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/ManageOrders/DeleteOrderModel.cs
@@ -12,21 +12,14 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ManageOrders
         {
         }
 
-        public DeleteOrderModel(Order order)
+        public DeleteOrderModel(CallOffId callOffId)
         {
-            CallOffId = order.CallOffId;
-
-            if (order.OrderDeletionApproval != null)
-            {
-                var approvalDate = order.OrderDeletionApproval.DateOfApproval;
-
-                ApprovalDay = approvalDate.Day.ToString("00");
-                ApprovalMonth = approvalDate.Month.ToString("00");
-                ApprovalYear = approvalDate.Year.ToString("0000");
-            }
+            CallOffId = callOffId;
         }
 
         public CallOffId CallOffId { get; set; }
+
+        public bool IsAmendment => CallOffId.IsAmendment;
 
         public string NameOfRequester { get; set; }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ManageOrders/DeleteNotLatest.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ManageOrders/DeleteNotLatest.cshtml
@@ -1,0 +1,24 @@
+﻿@model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ManageOrders.DeleteNotLatestModel;
+@{
+    var title = Model.IsAmendment
+    ? "This amendment cannot be deleted"
+    : "This order cannot be deleted";
+
+    var advice = Model.IsAmendment
+        ? "This amendment cannot be deleted as a more recent amendment already exists. Any more recent amendments must be deleted before you can delete this one."
+        : "This order cannot be deleted as a more recent amendment already exists. To delete this order you must first delete the amendment.";
+}
+
+<div data-test-id="delete-amendment-in-progress-page">
+    <partial name="Partials/_BackLink" model="Model" />
+    <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-two-thirds">
+            <nhs-page-title title="@title"
+                            caption="Order @Model.CallOffId"
+                            advice="@advice" />
+
+            <br />
+            <vc:nhs-secondary-button text="Return to orders dashboard" url="@Url.Action(nameof(ManageOrdersController.Index))" type="Primary" />
+        </div>
+    </div>
+</div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ManageOrders/DeleteNotLatest.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ManageOrders/DeleteNotLatest.cshtml
@@ -1,8 +1,8 @@
 ﻿@model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ManageOrders.DeleteNotLatestModel;
 @{
-    var title = Model.IsAmendment
-    ? "This amendment cannot be deleted"
-    : "This order cannot be deleted";
+    var orderOrAmendment = Model.IsAmendment
+        ? "amendment"
+        : "order";
 
     var advice = Model.IsAmendment
         ? "This amendment cannot be deleted as a more recent amendment already exists. Any more recent amendments must be deleted before you can delete this one."
@@ -13,7 +13,7 @@
     <partial name="Partials/_BackLink" model="Model" />
     <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
-            <nhs-page-title title="@title"
+            <nhs-page-title title="This @orderOrAmendment cannot be deleted"
                             caption="Order @Model.CallOffId"
                             advice="@advice" />
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ManageOrders/DeleteOrder.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ManageOrders/DeleteOrder.cshtml
@@ -1,24 +1,12 @@
 ﻿@model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ManageOrders.DeleteOrderModel;
 @{
-    var title = Model.IsAmendment
-        ? "Are you sure you want to delete this amendment?"
-        : "Are you sure you want to delete this order?";
-
-    var advice = Model.IsAmendment
-        ? "Provide details for the person who requested that this amendment be deleted and the person who approved it."
-        : "Provide details for the person who requested that this order be deleted and the person who approved it.";
-
-    var warning = Model.IsAmendment
-        ? "Deleting an amendment"
-        : "Deleting an order";
+    var orderOrAmendment = Model.IsAmendment
+        ? "amendment"
+        : "order";
 
     var warningDetail = Model.IsAmendment
         ? "Deleting an amendment is permanent and any information already changed will be lost. The order will revert to its previous version."
         : "Deleting an order will remove it from the buyer’s orders dashboard permanently. It will still be visible on your orders dashboard with a status of deleted, but you’ll not be able to change the order status back once deleted.";
-
-    var button = Model.IsAmendment
-        ? "Delete amendment"
-        : "Delete order";
 }
 
 <div data-test-id="delete-order-page">
@@ -26,11 +14,11 @@
     <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
             <nhs-validation-summary />
-            <nhs-page-title title="@title"
+            <nhs-page-title title="Are you sure you want to delete this @orderOrAmendment?"
                             caption="Order @Model.CallOffId"
-                            advice="@advice" />
+                            advice="Provide details for the person who requested that this @orderOrAmendment be deleted and the person who approved it." />
 
-            <nhs-warning-callout label-text="@warning" data-test-id="delete-warning-callout">
+            <nhs-warning-callout label-text="Deleting an @orderOrAmendment" data-test-id="delete-warning-callout">
                 <p>@warningDetail</p>
             </nhs-warning-callout>
 
@@ -60,7 +48,7 @@
                 </nhs-fieldset-form-label>
 
                 <br />
-                <nhs-submit-button text="@button" />
+                <nhs-submit-button text="Delete @orderOrAmendment" />
                 <div>
                     <a href="@Model.BackLink">Cancel</a>
                 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ManageOrders/DeleteOrder.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ManageOrders/DeleteOrder.cshtml
@@ -1,28 +1,46 @@
 ﻿@model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ManageOrders.DeleteOrderModel;
 @{
-    ViewBag.Title = "Are you sure you want to delete this order?";
+    var title = Model.IsAmendment
+        ? "Are you sure you want to delete this amendment?"
+        : "Are you sure you want to delete this order?";
+
+    var advice = Model.IsAmendment
+        ? "Provide details for the person who requested that this amendment be deleted and the person who approved it."
+        : "Provide details for the person who requested that this order be deleted and the person who approved it.";
+
+    var warning = Model.IsAmendment
+        ? "Deleting an amendment"
+        : "Deleting an order";
+
+    var warningDetail = Model.IsAmendment
+        ? "Deleting an amendment is permanent and any information already changed will be lost. The order will revert to its previous version."
+        : "Deleting an order will remove it from the buyer’s orders dashboard permanently. It will still be visible on your orders dashboard with a status of deleted, but you’ll not be able to change the order status back once deleted.";
+
+    var button = Model.IsAmendment
+        ? "Delete amendment"
+        : "Delete order";
 }
 
 <div data-test-id="delete-order-page">
     <partial name="Partials/_BackLink" model="Model" />
     <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
-            <nhs-validation-summary/>
-            <nhs-page-title title="@ViewBag.Title"
+            <nhs-validation-summary />
+            <nhs-page-title title="@title"
                             caption="Order @Model.CallOffId"
-                            advice="Provide details for the person who requested that this order be deleted and the person who approved it." />
+                            advice="@advice" />
 
-                <nhs-warning-callout label-text="Deleting an order" data-test-id="delete-warning-callout">
-                    <p>Deleting an order will remove it from the buyer’s orders dashboard permanently. It will still be visible on your orders dashboard with a status of deleted, but you’ll not be able to change the order status back once deleted.</p>
-                </nhs-warning-callout>
+            <nhs-warning-callout label-text="@warning" data-test-id="delete-warning-callout">
+                <p>@warningDetail</p>
+            </nhs-warning-callout>
 
-                <form method="post">
-                    <input type="hidden" asp-for="BackLink" />
-                    <input type="hidden" asp-for="OrderCreationDate" />
+            <form method="post">
+                <input type="hidden" asp-for="BackLink" />
+                <input type="hidden" asp-for="OrderCreationDate" />
 
                 <nhs-fieldset-form-container asp-for="@Model" data-test-id="delete-request-name"
                                              label-text="Who requested the deletion?"
-                                             label-hint="Enter the name of the person who asked for this order to be deleted." 
+                                             label-hint="Enter the name of the person who asked for this order to be deleted."
                                              size="ExtraSmall">
                     <nhs-input asp-for="@Model.NameOfRequester" />
                 </nhs-fieldset-form-container>
@@ -36,13 +54,13 @@
 
                 <nhs-fieldset-form-label asp-for="@Model" data-test-id="delete-approve-date"
                                          label-text="What date was the approval given?"
-                                         label-hint="Enter the date that approval was given to delete this order, for example, 15 3 2020."
+                                         label-hint="Enter the date that approval was given to delete this order, for example 15 3 2020."
                                          size="ExtraSmall">
                     <nhs-date-input asp-for="@Model" day="ApprovalDay" month="ApprovalMonth" year="ApprovalYear" />
                 </nhs-fieldset-form-label>
 
-                <br/>
-                <nhs-submit-button text="Delete order"/>
+                <br />
+                <nhs-submit-button text="@button" />
                 <div>
                     <a href="@Model.BackLink">Cancel</a>
                 </div>

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageOrders/DeleteNotLatest.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageOrders/DeleteNotLatest.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.Admin.ManageOrders;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils.TestBases;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageOrders
+{
+    [Collection(nameof(AdminCollection))]
+    public sealed class DeleteNotLatest
+        : AuthorityTestBase
+    {
+        private const string InternalOrgId = "CG-03F";
+        private static readonly CallOffId CallOffId = new(90009, 1);
+
+        private static readonly Dictionary<string, string> Parameters =
+            new()
+            {
+                { nameof(InternalOrgId), InternalOrgId },
+                { nameof(CallOffId), CallOffId.ToString() },
+            };
+
+        public DeleteNotLatest(LocalWebApplicationFactory factory)
+        : base(
+              factory,
+              typeof(ManageOrdersController),
+              nameof(ManageOrdersController.DeleteNotLatest),
+              Parameters)
+        {
+        }
+
+        [Fact]
+        public void DeleteNotLatest_AllSectionsDisplayed()
+        {
+            CommonActions.GoBackLinkDisplayed().Should().BeTrue();
+            CommonActions.ElementIsDisplayed(DeleteNotLatestObjects.ReturnToOrdersDashboard);
+        }
+
+        [Fact]
+        public void DeleteNotLatest_ClickGoBackLink_ExpectedResult()
+        {
+            CommonActions.ClickGoBackLink();
+
+            CommonActions
+            .PageLoadedCorrectGetIndex(
+                typeof(ManageOrdersController),
+                nameof(ManageOrdersController.ViewOrder))
+            .Should()
+            .BeTrue();
+        }
+
+        [Fact]
+        public void DeleteNotLatest_ClickReturnToDashboard_ExpectedResult()
+        {
+            CommonActions.ClickLinkElement(DeleteNotLatestObjects.ReturnToOrdersDashboard);
+
+            CommonActions
+            .PageLoadedCorrectGetIndex(
+                typeof(ManageOrdersController),
+                nameof(ManageOrdersController.Index))
+            .Should()
+            .BeTrue();
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageOrders/DeleteOrder.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2E.PublicBrowseTests/Areas/Admin/ManageOrders/DeleteOrder.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
-using Microsoft.EntityFrameworkCore;
 using MoreLinq;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.Admin.ManageOrders;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Utils;
@@ -34,6 +33,28 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Areas.Admin.ManageOrders
               nameof(ManageOrdersController.DeleteOrder),
               Parameters)
         {
+        }
+
+        [Fact]
+        public void DeleteOrder_Redirects_When_Not_Latest()
+        {
+            var callOffId = new CallOffId(90030, 1);
+
+            NavigateToUrl(
+                typeof(ManageOrdersController),
+                nameof(ManageOrdersController.DeleteOrder),
+                new Dictionary<string, string>
+                {
+                    { nameof(InternalOrgId), InternalOrgId },
+                    { nameof(CallOffId), callOffId.ToString() },
+                });
+
+            CommonActions
+            .PageLoadedCorrectGetIndex(
+                typeof(ManageOrdersController),
+                nameof(ManageOrdersController.DeleteNotLatest))
+            .Should()
+            .BeTrue();
         }
 
         [Fact]

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Objects/Admin/HomeObjects.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Objects/Admin/HomeObjects.cs
@@ -6,7 +6,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.Admin
     {
         public static By ManageCatalogueSolutionsLink => By.LinkText("Manage Catalogue Solutions");
 
-        public static By ManageFrameworksLink => By.LinkText("Manage Frameworks");
+        public static By ManageFrameworksLink => By.LinkText("Manage frameworks");
 
         public static By ManageSupplierDefinedEpicsLink => By.LinkText("Manage supplier defined Epics");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Objects/Admin/ManageOrders/DeleteNotLatest.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Objects/Admin/ManageOrders/DeleteNotLatest.cs
@@ -1,0 +1,9 @@
+﻿using OpenQA.Selenium;
+
+namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.Admin.ManageOrders
+{
+    public static class DeleteNotLatestObjects
+    {
+        public static By ReturnToOrdersDashboard => By.LinkText("Return to orders dashboard");
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/ManageOrders/DeleteNotLatestModelTest.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/ManageOrders/DeleteNotLatestModelTest.cs
@@ -1,0 +1,22 @@
+﻿using FluentAssertions;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.AutoFixtureCustomisations;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ManageOrders;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.ManageOrders
+{
+    public static class DeleteNotLatestModelTest
+    {
+        [Theory]
+        [CommonAutoData]
+        public static void WithValidArguments_PropertiesCorrectlySet(
+            CallOffId callOffId)
+        {
+            var model = new DeleteNotLatestModel(callOffId);
+
+            model.CallOffId.Should().Be(callOffId);
+            model.IsAmendment.Should().Be(callOffId.IsAmendment);
+        }
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/ManageOrders/DeleteOrderModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/ManageOrders/DeleteOrderModelTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using FluentAssertions;
+﻿using FluentAssertions;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.AutoFixtureCustomisations;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.ManageOrders;
@@ -12,20 +11,20 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.ManageOr
         [Theory]
         [CommonAutoData]
         public static void WithValidArguments_PropertiesCorrectlySet(
-            EntityFramework.Ordering.Models.Order order)
+            CallOffId callOffId)
         {
-            var model = new DeleteOrderModel(order);
+            var model = new DeleteOrderModel(callOffId);
 
-            model.CallOffId.Should().Be(order.CallOffId);
+            model.CallOffId.Should().Be(callOffId);
+            model.IsAmendment.Should().Be(callOffId.IsAmendment);
         }
 
         [Theory]
         [CommonAutoData]
         public static void WithNullOrderDeletionApproval_PropertiesCorrectlySet(
-            EntityFramework.Ordering.Models.Order order)
+            CallOffId callOffId)
         {
-            order.OrderDeletionApproval = null;
-            var model = new DeleteOrderModel(order);
+            var model = new DeleteOrderModel(callOffId);
 
             model.ApprovalDay.Should().BeNull();
             model.ApprovalMonth.Should().BeNull();
@@ -34,29 +33,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.ManageOr
 
         [Theory]
         [CommonAutoData]
-        public static void WithOrderDeletionApproval_PropertiesCorrectlySet(
-            EntityFramework.Ordering.Models.Order order)
-        {
-            const int testDay = 1;
-            const int testMonth = 1;
-            const int testYear = 2022;
-
-            var oda = new OrderDeletionApproval() { DateOfApproval = new DateTime(testYear, testMonth, testDay) };
-            order.OrderDeletionApproval = oda;
-            var model = new DeleteOrderModel(order);
-
-            model.ApprovalDate.Should().NotBeNull();
-            model.ApprovalDay.Should().Be(testDay.ToString("00"));
-            model.ApprovalMonth.Should().Be(testMonth.ToString("00"));
-            model.ApprovalYear.Should().Be(testYear.ToString("0000"));
-        }
-
-        [Theory]
-        [CommonAutoData]
         public static void ApprovalDate_InvalidDayMonthYear_ReturnsNull(
-            EntityFramework.Ordering.Models.Order order)
+            CallOffId callOffId)
         {
-            var model = new DeleteOrderModel(order);
+            var model = new DeleteOrderModel(callOffId);
             model.ApprovalDay = "A";
             model.ApprovalMonth = "B";
             model.ApprovalYear = "C";


### PR DESCRIPTION
This PR changes the admin manage orders delete functionality

- Content changes to the confirmation screen when you delete an amendment 
- You can only delete the latest amendment

This also includes 
- A fix for `InvalidOperationException: Sequence contains no elements` in `CataloguePriceCalculations.cs`
- A fix for a failing integration test - changing `Manage Frameworks` to `Manage frameworks`
