### PR TITLE
Fix the previous order totals for subsequent amends

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/Order.Custom.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/Order.Custom.cs
@@ -243,5 +243,23 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
                 SupplierContact = SupplierContact.Clone(),
             };
         }
+
+        public OrderItem InitialiseOrderItem(CatalogueItem catalogueItem)
+        {
+            return new OrderItem
+            {
+                OrderId = Id,
+                CatalogueItemId = catalogueItem.Id,
+                CatalogueItem = catalogueItem,
+                Created = DateTime.UtcNow,
+            };
+        }
+
+        public OrderItem InitialiseOrderItem(CatalogueItem catalogueItem, OrderItemPrice orderItemPrice)
+        {
+            var orderItem = InitialiseOrderItem(catalogueItem);
+            orderItem.OrderItemPrice = orderItemPrice;
+            return orderItem;
+        }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/OrderItemPrice.Custom.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/OrderItemPrice.Custom.cs
@@ -35,7 +35,7 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
             }
         }
 
-        public OrderItemPrice(OrderItemPrice existingPrice)
+        private OrderItemPrice(OrderItemPrice existingPrice)
             : this()
         {
             CatalogueItemId = existingPrice.CatalogueItemId;
@@ -56,6 +56,11 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
         }
 
         public ICollection<IPriceTier> PriceTiers => OrderItemPriceTiers.Cast<IPriceTier>().ToList();
+
+        public OrderItemPrice Copy()
+        {
+            return new OrderItemPrice(this);
+        }
 
         public string ToPriceUnitString()
         {

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/OrderItemPriceTier.Custom.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/OrderItemPriceTier.Custom.cs
@@ -15,7 +15,7 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
             OrderItemPrice = price;
         }
 
-        public OrderItemPriceTier(OrderItemPrice price, OrderItemPriceTier tier)
+        internal OrderItemPriceTier(OrderItemPrice price, OrderItemPriceTier tier)
         {
             OrderId = price.OrderId;
             CatalogueItemId = price.CatalogueItemId;

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/OrderWrapper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/OrderWrapper.cs
@@ -30,6 +30,8 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders
                 : new List<Order>();
         }
 
+        public IEnumerable<Order> PreviousOrders => previous;
+
         public bool IsAmendment => Order.CallOffId.IsAmendment;
 
         public Order Last => previous.Any()

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/Summary.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/Summary.cshtml
@@ -285,10 +285,10 @@
                             <strong>Total cost of contract:</strong>
                         </nhs-table-cell>
                         <nhs-table-cell numeric="true">
-                            £@($"{Model.Previous.TotalCost(true):N2}")
+                            £@($"{Model.OrderWrapper.TotalPreviousCost(true):N2}")
                         </nhs-table-cell>
                         <nhs-table-cell numeric="true">
-                            £@($"{Model.OrderWrapper.TotalCost(true) - Model.Previous.TotalCost(true):N2}")
+                            £@($"{Model.OrderWrapper.TotalCost(true) - Model.OrderWrapper.TotalPreviousCost(true):N2}")
                         </nhs-table-cell>
                         <nhs-table-cell numeric="true">
                             £@($"{Model.OrderWrapper.TotalCost(true):N2}")
@@ -315,7 +315,7 @@
                     </nhs-summary-list-row>
 
                     <nhs-summary-list-row label-text="@($"Total cost of contract{contractTerm}:")" data-test-id="total-cost-summary">
-                        £@($"{Model.Order.TotalCost():N2}")
+                        £@($"{Model.OrderWrapper.TotalCost():N2}")
                         @if (!Model.Order.MaximumTerm.HasValue)
                         {
                             <br />

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/ReviewSolutions/ReviewSolutions.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/ReviewSolutions/ReviewSolutions.cshtml
@@ -124,10 +124,10 @@
                         <strong>Total cost of contract:</strong>
                     </nhs-table-cell>
                     <nhs-table-cell numeric="true">
-                        £@($"{Model.Previous.TotalCost(true):N2}")
+                        £@($"{Model.OrderWrapper.TotalPreviousCost(true):N2}")
                     </nhs-table-cell>
                     <nhs-table-cell numeric="true">
-                        £@($"{Model.OrderWrapper.TotalCost(true)-Model.Previous.TotalCost(true):N2}")
+                        £@($"{Model.OrderWrapper.TotalCost(true)-Model.OrderWrapper.TotalPreviousCost(true):N2}")
                     </nhs-table-cell>
                     <nhs-table-cell numeric="true">
                         £@($"{Model.OrderWrapper.TotalCost(true):N2}")
@@ -152,7 +152,7 @@
                  </nhs-summary-list-row>
 
                  <nhs-summary-list-row label-text="Total cost of contract (@Model.ContractLength months):">
-                     £@($"{Model.Order.TotalCost(true):N2}")
+                     £@($"{Model.OrderWrapper.TotalCost(true):N2}")
                  </nhs-summary-list-row>
              </nhs-summary-list>
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
@@ -450,13 +450,13 @@
                                         <strong>Total cost of contract</strong>
                                     </td>
                                     <td>
-                                        £@($"{Model.Previous.TotalCost(true):N2}")
+                                        £@($"{Model.OrderWrapper.TotalPreviousCost(true):N2}")
                                     </td>
                                     <td>
-                                        £@($"{Model.OrderWrapper.TotalCost(true) - Model.Previous.TotalCost(true):N2}")
+                                        £@($"{Model.OrderWrapper.TotalCost(true) - Model.OrderWrapper.TotalPreviousCost(true):N2}")
                                     </td>
                                     <td>
-                                        £@($"{Model.RolledUp.TotalCost(true):N2}")
+                                        £@($"{Model.OrderWrapper.TotalCost(true):N2}")
                                     </td>
                                 </tr>
                             </table>
@@ -477,7 +477,7 @@
                                 </pdf-summary-list-row>
 
                                 <pdf-summary-list-row label-text="Total cost of contract @contractTerm">
-                                    @($"£{Model.Order.TotalCost():N2}")
+                                    @($"£{Model.OrderWrapper.TotalCost():N2}")
                                     @if (!Model.Order.MaximumTerm.HasValue)
                                     {
                                         <br />

--- a/tests/NHSD.GPIT.BuyingCatalogue.Framework.UnitTests/Calculations/CataloguePriceCalculationsTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Framework.UnitTests/Calculations/CataloguePriceCalculationsTests.cs
@@ -426,9 +426,21 @@ namespace NHSD.GPIT.BuyingCatalogue.Framework.UnitTests.Calculations
             orderItem.TotalCost().Should().Be(0);
         }
 
+        [Fact]
+        public static void OrderWrapper_Null_TotalPreviousCost_Returns_0()
+        {
+            ((OrderWrapper)null).TotalPreviousCost().Should().Be(0);
+        }
+
+        [Fact]
+        public static void OrderWrapper_Null_TotalCost_Returns_0()
+        {
+            ((OrderWrapper)null).TotalCost().Should().Be(0);
+        }
+
         [Theory]
         [CommonAutoData]
-        public static void OrderWrapper_TotalCost(IFixture fixture)
+        public static void OrderWrapper_TotalCost_And_TotalPreviousCost_One_Amendment(IFixture fixture)
         {
             var maximumTerm = 12;
             var price = 12M;
@@ -458,7 +470,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Framework.UnitTests.Calculations
 
         [Theory]
         [CommonAutoData]
-        public static void OrderWrapper_TotalCost_MultipleAmendments(IFixture fixture)
+        public static void OrderWrapper_TotalCost_And_TotalPreviousCosts_Multiple_Amendments(IFixture fixture)
         {
             var maximumTerm = 12;
             var price = 12M;


### PR DESCRIPTION
This PR removes the `TotalCost` extension method for an `order` in favour off the `orderWrapper` methods `TotalCost` and  `TotalPreviousCost`. 

Calls like `OrderWrapper.Previous.TotalCost()` are replaced with `OrderWrapper.TotalPreviousCost()` which carries out the calculation for the original order (using the maximum term) and each revision (using a term derived from the planned delivery dates).