### PR TITLE
Change the admin manage orders download CSV options to add a prefix to the file name for amended orders

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/ManageOrdersController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/ManageOrdersController.cs
@@ -96,8 +96,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             using var memoryStream = new MemoryStream();
             await csvService.CreateFullOrderCsvAsync(orderId, memoryStream);
             memoryStream.Position = 0;
+            var callOffIdPrefix = GetFileNamePrefix(callOffId);
 
-            return File(memoryStream.ToArray(), "application/octet-stream", $"{callOffId}_{externalOrgId}_full.csv");
+            return File(memoryStream.ToArray(), "application/octet-stream", $"{callOffIdPrefix}{externalOrgId}_full.csv");
         }
 
         [HttpGet("{callOffId}/download/patient-order-csv")]
@@ -107,8 +108,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             using var memoryStream = new MemoryStream();
             await csvService.CreatePatientNumberCsvAsync(orderId, memoryStream);
             memoryStream.Position = 0;
+            var callOffIdPrefix = GetFileNamePrefix(callOffId);
 
-            return File(memoryStream.ToArray(), "application/octet-stream", $"{callOffId}_{externalOrgId}_patient.csv");
+            return File(memoryStream.ToArray(), "application/octet-stream", $"{callOffIdPrefix}{externalOrgId}_patient.csv");
         }
 
         [HttpGet("{callOffId}/download/pdf")]
@@ -169,6 +171,13 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             await orderAdminService.DeleteOrder(model.CallOffId, model.NameOfRequester, model.NameOfApprover, model.ApprovalDate);
 
             return RedirectToAction(nameof(Index));
+        }
+
+        private static string GetFileNamePrefix(CallOffId callOffId)
+        {
+            return callOffId.IsAmendment
+                ? $"Amendment_{callOffId}_"
+                : $"{callOffId}_";
         }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
@@ -389,6 +389,8 @@
                         }
                     </div>
 
+                    <div style="page-break-after: always"></div>
+
                     <div class="pdf-container">
                         <h1>Indicative costs for this order</h1>
                         <h3>Indicative costs not including VAT</h3>

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/ManageOrdersControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/ManageOrdersControllerTests.cs
@@ -160,37 +160,45 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
         }
 
         [Theory]
-        [CommonAutoData]
+        [CommonInlineAutoData(1, 1, "")]
+        [CommonInlineAutoData(1, 2, "Amendment_")]
         public static async Task Get_DownloadFullOrderCsv_ReturnsExpectedResult(
-            CallOffId callOffId,
+            int orderNumber,
+            int revision,
+            string prefix,
             string externalOrgId,
             [Frozen] Mock<ICsvService> csvService,
             ManageOrdersController controller)
         {
+            var callOffId = new CallOffId(orderNumber, revision);
             var result = (await controller.DownloadFullOrderCsv(callOffId, externalOrgId)).As<FileContentResult>();
 
             csvService.VerifyAll();
 
             result.Should().NotBeNull();
             result.ContentType.Should().Be("application/octet-stream");
-            result.FileDownloadName.Should().Be($"{callOffId}_{externalOrgId}_full.csv");
+            result.FileDownloadName.Should().Be($"{prefix}{callOffId}_{externalOrgId}_full.csv");
         }
 
         [Theory]
-        [CommonAutoData]
+        [CommonInlineAutoData(1, 1, "")]
+        [CommonInlineAutoData(1, 2, "Amendment_")]
         public static async Task Get_DownloadPatientNumberCsv_ReturnsExpectedResult(
-            CallOffId callOffId,
+            int orderNumber,
+            int revision,
+            string prefix,
             string externalOrgId,
             [Frozen] Mock<ICsvService> csvService,
             ManageOrdersController controller)
         {
+            var callOffId = new CallOffId(orderNumber, revision);
             var result = (await controller.DownloadPatientNumberCsv(callOffId, externalOrgId)).As<FileContentResult>();
 
             csvService.VerifyAll();
 
             result.Should().NotBeNull();
             result.ContentType.Should().Be("application/octet-stream");
-            result.FileDownloadName.Should().Be($"{callOffId}_{externalOrgId}_patient.csv");
+            result.FileDownloadName.Should().Be($"{prefix}{callOffId}_{externalOrgId}_patient.csv");
         }
 
         [Theory]


### PR DESCRIPTION
This PR 

- Changes the admin manage orders `Download full order CSV` and `Download patient only CSV` options to prefix the downloaded file name with `Amendment_` for amended orders.
- Adds a page break to the PDF so that the indicative cost section is on its own page.
