### PR TITLE
Updates to Filtering schema

### DIFF
--- a/database/NHSD.GPITBuyingCatalogue.Database/Filtering/Tables/FilterClientApplicationTypes.sql
+++ b/database/NHSD.GPITBuyingCatalogue.Database/Filtering/Tables/FilterClientApplicationTypes.sql
@@ -1,6 +1,6 @@
 ﻿CREATE TABLE filtering.FilterClientApplicationTypes
 (
-     FilterClientApplicationTypeId int IDENTITY(1, 1) NOT NULL,
+     Id int IDENTITY(1, 1) NOT NULL,
      FilterId int NOT NULL,
      ClientApplicationTypeId int NOT NULL,
      LastUpdated datetime2(7) DEFAULT GETUTCDATE() NOT NULL,
@@ -8,7 +8,7 @@
      SysStartTime datetime2(0) GENERATED ALWAYS AS ROW START NOT NULL,
      SysEndTime datetime2(0) GENERATED ALWAYS AS ROW END NOT NULL,
      PERIOD FOR SYSTEM_TIME (SysStartTime, SysEndTime),
-     CONSTRAINT PK_FilterClientApplicationTypes PRIMARY KEY (FilterClientApplicationTypeId),
+     CONSTRAINT PK_FilterClientApplicationTypes PRIMARY KEY (Id),
      CONSTRAINT FK_FilterClientApplicationTypes_Filter FOREIGN KEY (FilterId) REFERENCES filtering.Filters(Id),
      CONSTRAINT FK_FilterClientApplicationTypes_LastUpdatedBy FOREIGN KEY (LastUpdatedBy) REFERENCES users.AspNetUsers(Id),
 ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = filtering.FilterClientApplicationTypes_History));

--- a/database/NHSD.GPITBuyingCatalogue.Database/Filtering/Tables/FilterHostingTypes.sql
+++ b/database/NHSD.GPITBuyingCatalogue.Database/Filtering/Tables/FilterHostingTypes.sql
@@ -1,6 +1,6 @@
 ﻿CREATE TABLE filtering.FilterHostingTypes
 (
-     FilterHostingTypeId int IDENTITY(1, 1) NOT NULL,
+     Id int IDENTITY(1, 1) NOT NULL,
      FilterId int NOT NULL,
      HostingTypeId int NOT NULL,
      LastUpdated datetime2(7) DEFAULT GETUTCDATE() NOT NULL,
@@ -8,7 +8,7 @@
      SysStartTime datetime2(0) GENERATED ALWAYS AS ROW START NOT NULL,
      SysEndTime datetime2(0) GENERATED ALWAYS AS ROW END NOT NULL,
      PERIOD FOR SYSTEM_TIME (SysStartTime, SysEndTime),
-     CONSTRAINT PK_FilterHostingTypes PRIMARY KEY (FilterHostingTypeId),
+     CONSTRAINT PK_FilterHostingTypes PRIMARY KEY (Id),
      CONSTRAINT FK_FilterHostingTypes_Filter FOREIGN KEY (FilterId) REFERENCES filtering.Filters(Id),
      CONSTRAINT FK_FilterHostingTypes_LastUpdatedBy FOREIGN KEY (LastUpdatedBy) REFERENCES users.AspNetUsers(Id),
 ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = filtering.FilterHostingTypes_History));

--- a/database/NHSD.GPITBuyingCatalogue.Database/Filtering/Tables/Filters.sql
+++ b/database/NHSD.GPITBuyingCatalogue.Database/Filtering/Tables/Filters.sql
@@ -7,7 +7,6 @@
     FrameworkId NVARCHAR(36) NULL,
     Created datetime2(7) CONSTRAINT DF_Filter_Created DEFAULT GETUTCDATE() NOT NULL,
     LastUpdated datetime2(7) DEFAULT GETUTCDATE() NOT NULL,
-    LastPublished datetime2(7) NULL,
     LastUpdatedBy int NULL,
     SysStartTime datetime2(0) GENERATED ALWAYS AS ROW START NOT NULL,
     SysEndTime datetime2(0) GENERATED ALWAYS AS ROW END NOT NULL,

--- a/database/NHSD.GPITBuyingCatalogue.Database/Filtering/TemporalTables/FilterClientApplicationTypes_History.sql
+++ b/database/NHSD.GPITBuyingCatalogue.Database/Filtering/TemporalTables/FilterClientApplicationTypes_History.sql
@@ -1,6 +1,6 @@
 ﻿CREATE TABLE filtering.FilterClientApplicationTypes_History
 (
-     FilterClientApplicationTypeId int NOT NULL,
+     Id int NOT NULL,
      FilterId int NOT NULL,
      ClientApplicationTypeId int NOT NULL,
      LastUpdated datetime2(7) NOT NULL,

--- a/database/NHSD.GPITBuyingCatalogue.Database/Filtering/TemporalTables/FilterHostingTypes_History.sql
+++ b/database/NHSD.GPITBuyingCatalogue.Database/Filtering/TemporalTables/FilterHostingTypes_History.sql
@@ -1,6 +1,6 @@
 ﻿CREATE TABLE filtering.FilterHostingTypes_History
 (
-     FilterHostingTypeId int NOT NULL,
+     Id int NOT NULL,
      FilterId int NOT NULL,
      HostingTypeId int NOT NULL,
      LastUpdated datetime2(7) NOT NULL,

--- a/database/NHSD.GPITBuyingCatalogue.Database/Filtering/TemporalTables/Filters_History.sql
+++ b/database/NHSD.GPITBuyingCatalogue.Database/Filtering/TemporalTables/Filters_History.sql
@@ -7,7 +7,6 @@
     FrameworkId NVARCHAR(36) NULL,
     Created datetime2(7) NOT NULL,
     LastUpdated datetime2(7) NOT NULL,
-    LastPublished datetime2(7) NULL,
     LastUpdatedBy int NULL,
     SysStartTime datetime2(0) NOT NULL,
     SysEndTime datetime2(0) NOT NULL

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Filtering/Configuration/FilterCapabilityEntityTypeConfiguration.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Filtering/Configuration/FilterCapabilityEntityTypeConfiguration.cs
@@ -29,7 +29,7 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Filtering.Configuration
             builder.HasOne(fc => fc.Capability)
                 .WithMany()
                 .HasForeignKey(fc => fc.CapabilityId)
-                .OnDelete(DeleteBehavior.ClientSetNull)
+                .OnDelete(DeleteBehavior.NoAction)
                 .HasConstraintName("FK_FilterCapabilities_Capability");
 
             builder.HasOne(e => e.LastUpdatedByUser)

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Filtering/Configuration/FilterClientApplicationTypeEntityTypeConfiguration.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Filtering/Configuration/FilterClientApplicationTypeEntityTypeConfiguration.cs
@@ -17,7 +17,7 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Filtering.Configuration
                     temp.HasPeriodEnd("SysEndTime");
                 }));
 
-            builder.HasKey(fcat => fcat.FilterClientApplicationTypeId);
+            builder.HasKey(fcat => fcat.Id);
 
             builder.Property(e => e.LastUpdated).HasDefaultValue(DateTime.UtcNow);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Filtering/Configuration/FilterEntityTypeConfiguration.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Filtering/Configuration/FilterEntityTypeConfiguration.cs
@@ -42,13 +42,13 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Filtering.Configuration
             builder.HasOne(i => i.Organisation)
                 .WithMany()
                 .HasForeignKey(i => i.OrganisationId)
-                .OnDelete(DeleteBehavior.ClientSetNull)
+                .OnDelete(DeleteBehavior.NoAction)
                 .HasConstraintName("FK_Filters_OrganisationId");
 
             builder.HasOne(i => i.Framework)
                 .WithMany()
                 .HasForeignKey(i => i.FrameworkId)
-                .OnDelete(DeleteBehavior.ClientSetNull)
+                .OnDelete(DeleteBehavior.NoAction)
                 .HasConstraintName("FK_Filters_FrameworkId");
 
             builder.HasOne(i => i.LastUpdatedByUser)

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Filtering/Configuration/FilterEpicEntityTypeConfiguration.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Filtering/Configuration/FilterEpicEntityTypeConfiguration.cs
@@ -29,7 +29,7 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Filtering.Configuration
             builder.HasOne(fe => fe.Epic)
                 .WithMany()
                 .HasForeignKey(fe => fe.EpicId)
-                .OnDelete(DeleteBehavior.ClientSetNull)
+                .OnDelete(DeleteBehavior.NoAction)
                 .HasConstraintName("FK_FilterEpics_Epic");
 
             builder.HasOne(e => e.LastUpdatedByUser)

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Filtering/Configuration/FilterHostingTypeEntityTypeConfiguration.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Filtering/Configuration/FilterHostingTypeEntityTypeConfiguration.cs
@@ -17,7 +17,7 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Filtering.Configuration
                     temp.HasPeriodEnd("SysEndTime");
                 }));
 
-            builder.HasKey(fht => fht.FilterHostingTypeId);
+            builder.HasKey(fht => fht.Id);
 
             builder.Property(e => e.LastUpdated).HasDefaultValue(DateTime.UtcNow);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Filtering/Models/Filter.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Filtering/Models/Filter.cs
@@ -6,8 +6,7 @@ using NHSD.GPIT.BuyingCatalogue.EntityFramework.Users.Models;
 
 namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Filtering.Models
 {
-    [Serializable]
-    public partial class Filter : IAudited
+    public sealed class Filter : IAudited
     {
         public Filter()
         {
@@ -31,15 +30,13 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Filtering.Models
 
         public DateTime LastUpdated { get; set; }
 
-        public DateTime? LastPublished { get; set; }
-
         public int? LastUpdatedBy { get; set; }
 
         public AspNetUser LastUpdatedByUser { get; set; }
 
-        public virtual Organisation Organisation { get; set; }
+        public Organisation Organisation { get; set; }
 
-        public virtual Framework Framework { get; set; }
+        public Framework Framework { get; set; }
 
         public ICollection<FilterCapability> FilterCapabilities { get; set; }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Filtering/Models/FilterCapability.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Filtering/Models/FilterCapability.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
-using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Users.Models;
 
 namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Filtering.Models
 {
-    [Serializable]
     public sealed class FilterCapability : IAudited
     {
         public int FilterId { get; set; }

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Filtering/Models/FilterClientApplicationType.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Filtering/Models/FilterClientApplicationType.cs
@@ -4,12 +4,11 @@ using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions;
 
 namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Filtering.Models
 {
-    [Serializable]
     public sealed class FilterClientApplicationType : IAudited
     {
-        public int FilterId { get; set; }
+        public int Id { get; set; }
 
-        public int FilterClientApplicationTypeId { get; set; }
+        public int FilterId { get; set; }
 
         public DateTime LastUpdated { get; set; }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Filtering/Models/FilterEpic.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Filtering/Models/FilterEpic.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
-using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Users.Models;
 
 namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Filtering.Models
 {
-    [Serializable]
     public sealed class FilterEpic : IAudited
     {
         public int FilterId { get; set; }

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Filtering/Models/FilterHostingType.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Filtering/Models/FilterHostingType.cs
@@ -4,12 +4,11 @@ using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions;
 
 namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Filtering.Models
 {
-    [Serializable]
     public sealed class FilterHostingType : IAudited
     {
         public int FilterId { get; set; }
 
-        public int FilterHostingTypeId { get; set; }
+        public int Id { get; set; }
 
         public DateTime LastUpdated { get; set; }
 


### PR DESCRIPTION
Renames Id columns in
* FilterClientApplicationTypes
* FilterHostingTypes

Removes `LastPublished` from Filters as there are no plans to allow filters to be published or unpublished.
Removes `SerializableAttribute` from Filter classes as these won't be cloned

Changes the Cascade behaviour defined via the Entity Configuration to `DeleteBehavior.NoAction` since we don't typically do hard deletes for Organisations or Users, minus the one rare case for the ICB migration.