### PR TITLE
Use Microsoft.Build.Sql SDK for building sqlproj

### DIFF
--- a/NHSD.GPIT.BuyingCatalogue.Database.sln
+++ b/NHSD.GPIT.BuyingCatalogue.Database.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.33122.133
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NHSD.GPITBuyingCatalogue.Database", "database\NHSD.GPITBuyingCatalogue.Database\NHSD.GPITBuyingCatalogue.Database.sqlproj", "{3A93AFA0-D505-46F6-9B6C-A66C23907991}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NHSD.GPITBuyingCatalogue.Database.Deployment", "database\NHSD.GPITBuyingCatalogue.Database.Deployment\NHSD.GPITBuyingCatalogue.Database.Deployment.csproj", "{C23EFD96-B271-4775-A973-419E86EB8A24}"
+EndProject
+Project("{00D1A9C2-B5F0-4AF3-8072-F6C62B433612}") = "NHSD.GPITBuyingCatalogue.Database", "database\NHSD.GPITBuyingCatalogue.Database\NHSD.GPITBuyingCatalogue.Database.sqlproj", "{DEEA1B1A-AEC7-46F2-A786-4C0E9A391958}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,14 +13,16 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{3A93AFA0-D505-46F6-9B6C-A66C23907991}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3A93AFA0-D505-46F6-9B6C-A66C23907991}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3A93AFA0-D505-46F6-9B6C-A66C23907991}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3A93AFA0-D505-46F6-9B6C-A66C23907991}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C23EFD96-B271-4775-A973-419E86EB8A24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C23EFD96-B271-4775-A973-419E86EB8A24}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C23EFD96-B271-4775-A973-419E86EB8A24}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C23EFD96-B271-4775-A973-419E86EB8A24}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DEEA1B1A-AEC7-46F2-A786-4C0E9A391958}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DEEA1B1A-AEC7-46F2-A786-4C0E9A391958}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DEEA1B1A-AEC7-46F2-A786-4C0E9A391958}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{DEEA1B1A-AEC7-46F2-A786-4C0E9A391958}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DEEA1B1A-AEC7-46F2-A786-4C0E9A391958}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DEEA1B1A-AEC7-46F2-A786-4C0E9A391958}.Release|Any CPU.Deploy.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ Afterwards, open the solution in Visual Studio and run/debug NHSD.GPIT.BuyingCat
 
 ## Troubleshooting
 
+### Cannot build SQL Project in Visual Studio
+
+The database SQL Project has been migrated to Microsoft's [Microsoft.Build.Sql](https://github.com/microsoft/DacFx/tree/main/src/Microsoft.Build.Sql) SDK to enable .NET Core support for the database project.
+
+As a consequence, building in Visual Studio isn't currently supported. To build the database solution `dotnet build` must be used instead.
+
+Alternatively, the preexisting `docker-compose` approach will continue to work as normal.
+
+See [the following PR](https://github.com/nhs-digital-gp-it-futures/GPITBuyingCatalogue/pull/1134) for more information on the Microsoft.Build.Sql migration.
+
 ### SQL Server is running but there is no database
 
 The `dacpac` deployment takes a few seconds to initialize and complete so it is not unusual for there to be a slight delay between SQL server initializing and the database being ready for use; upon completion `<DB Name> database setup complete` is logged to the console.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -159,7 +159,7 @@ jobs:
     displayName: Copy DACPAC
     inputs:
       SourceFolder: 'database/NHSD.GPITBuyingCatalogue.Database'
-      Contents: '**/NHSD.GPITBuyingCatalogue.Database.dacpac'
+      Contents: '**/*.dacpac'
       TargetFolder: '$(build.artifactStagingDirectory)/dacpacs'
       CleanTargetFolder: false
       OverWrite: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,7 +63,9 @@ jobs:
     displayName: 'Run dotnet restore'
     inputs:
       command: restore
-      projects: 'NHSD.GPIT.BuyingCatalogue.sln'
+      projects: |
+        NHSD.GPIT.BuyingCatalogue.sln
+        NHSD.GPIT.BuyingCatalogue.Database.sln
       feedsToUse: config
       nugetConfigPath: 'NuGet.config'
       arguments: '-v n'
@@ -87,7 +89,9 @@ jobs:
     displayName: 'Run dotnet build'
     inputs:
       command: build
-      projects: 'NHSD.GPIT.BuyingCatalogue.sln'
+      projects: |
+        NHSD.GPIT.BuyingCatalogue.sln
+        NHSD.GPIT.BuyingCatalogue.Database.sln
       arguments: '--no-restore --configuration $(buildConfiguration)'
 
   - task: gulp@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,9 +39,8 @@ jobs:
     name: echovar
 
 - job: dockerBuildAndPush
-  displayName: Run all tests and build & push docker containers to the ACR
+  displayName: Build and Package
   variables:
-    dacpacTag: dacpac-$[ dependencies.version.outputs['setVersionStep.semVer'] ]
     semVer: $[ dependencies.version.outputs['setVersionStep.semVer'] ]
     ${{ if eq(variables['Build.SourceBranchName'], 'main') }}:
       latestTag: latest
@@ -68,7 +67,6 @@ jobs:
         NHSD.GPIT.BuyingCatalogue.Database.sln
       feedsToUse: config
       nugetConfigPath: 'NuGet.config'
-      arguments: '-v n'
 
   - task: NodeTool@0
     displayName: 'Install Node.js'
@@ -106,7 +104,7 @@ jobs:
     inputs:
       command: test
       projects: '**/*UnitTests.csproj'
-      arguments: '-v n --no-build --configuration $(buildConfiguration) --collect:"XPlat Code Coverage" -- xunit.parallelizeTestCollections=true'
+      arguments: '--no-build --configuration $(buildConfiguration) --collect:"XPlat Code Coverage" -- xunit.parallelizeTestCollections=true'
       publishTestResults: false
 
   - task: CmdLine@2
@@ -157,45 +155,22 @@ jobs:
         mkdir $(Build.ArtifactStagingDirectory)/code
         $release | Out-File $(Build.ArtifactStagingDirectory)/code/release.txt
 
+  - task: CopyFiles@2
+    displayName: Copy DACPAC
+    inputs:
+      SourceFolder: 'database/NHSD.GPITBuyingCatalogue.Database'
+      Contents: '**/NHSD.GPITBuyingCatalogue.Database.dacpac'
+      TargetFolder: '$(build.artifactStagingDirectory)/dacpacs'
+      CleanTargetFolder: false
+      OverWrite: true
+      flattenFolders: true 
+
   - publish: $(build.artifactStagingDirectory)/code
+    displayName: Publish Code Version
     artifact: code-version
 
-- job: buildDatabaseDacpacs
-  displayName: Build all Dacpacs and push
-  variables:
-    semVer: $[ dependencies.version.outputs['setVersionStep.semVer'] ]
-    ${{ if eq(variables['Build.SourceBranchName'], 'main') }}:
-      latestTag: latest
-    ${{ if ne(variables['Build.SourceBranchName'], 'main') }}:
-      latestTag: latestbuild
-
-  dependsOn: dockerBuildAndPush
-  pool:
-    vmImage: 'ubuntu-latest'
-
-  steps:
-  - task: Docker@2
-    displayName: 'Docker: Build Dacpacs'
-    condition: succeeded()
-    inputs:
-      containerRegistry: 'gpitfuturesdevacr'
-      repository: 'nhsd/buying-catalogue/nhsdgpitbuyingcataloguewebapp'
-      command: 'build'
-      Dockerfile: 'database/**/NHSD.GPITBuyingCatalogue.Database.Deployment/Docker/Dockerfile.Pipeline'
-      buildContext: './'
-      tags: |
-        $(semVer)
-        $(latestTag)
-
-  - pwsh: |
-      $id=docker images --filter "label=dacpac=true" -q | Select-Object -First 1
-      docker create --name dacpaccontainer $id      
-      mkdir $(Build.ArtifactStagingDirectory)/dacpacs
-      docker cp dacpaccontainer:/deploy-db/. $(Build.ArtifactStagingDirectory)/dacpacs
-      docker rm dacpaccontainer
-    displayName: 'Copy DACPACs'
-
   - publish: $(build.artifactStagingDirectory)/dacpacs
+    displayName: Publish DACPAC
     artifact: dacpacs
 
 - job: createBuildArtifact

--- a/database/NHSD.GPITBuyingCatalogue.Database/NHSD.GPITBuyingCatalogue.Database.sqlproj
+++ b/database/NHSD.GPITBuyingCatalogue.Database/NHSD.GPITBuyingCatalogue.Database.sqlproj
@@ -106,6 +106,8 @@
   <ItemGroup>
     <Build Include="**/*.sql" />
     <None Include="PostDeployment/**/*.sql" />
+    <Build Remove="obj/**/*.sql" />
+    <Build Remove="bin/**/*.sql" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="PostDeployment\" />
@@ -146,11 +148,17 @@
     <Folder Include="PostDeployment\OdsOrganisationsSeedData\" />
     <Folder Include="PostDeployment\OrderSeedData\" />
     <Folder Include="PostDeployment\ProdLikeData\" />
-    <Folder Include="obj\" />
-    <Folder Include="obj\Debug\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SqlServer.Dacpacs.Azure.Master" Version="160.0.0" />
+    <PackageReference Include="Microsoft.SqlServer.Dacpacs.Azure.Master" Version="160.0.0">
+      <GeneratePathProperty>true</GeneratePathProperty>
+      <DacpacName>master</DacpacName>
+    </PackageReference>
+    <ArtifactReference Include="$(PkgMicrosoft_SqlServer_Dacpacs_Azure_Master)/tools/master.dacpac">
+      <HintPath>$(PkgMicrosoft_SqlServer_Dacpacs_Azure_Master)/tools/master.dacpac</HintPath>
+      <SuppressMissingDependenciesErrors>False</SuppressMissingDependenciesErrors>
+      <DatabaseVariableLiteralValue>master</DatabaseVariableLiteralValue>
+    </ArtifactReference>
   </ItemGroup>
   <PropertyGroup>
     <PreBuildEvent>

--- a/database/NHSD.GPITBuyingCatalogue.Database/NHSD.GPITBuyingCatalogue.Database.sqlproj
+++ b/database/NHSD.GPITBuyingCatalogue.Database/NHSD.GPITBuyingCatalogue.Database.sqlproj
@@ -117,6 +117,9 @@
     <Folder Include="Catalogue\Tables\" />
     <Folder Include="Catalogue\TemporalTables\" />
     <Folder Include="Catalogue\Types\" />
+    <Folder Include="Competitions\" />
+    <Folder Include="Competitions\Tables\" />
+    <Folder Include="Competitions\TemporalTables\" />
     <Folder Include="Filtering\" />
     <Folder Include="Filtering\Tables\" />
     <Folder Include="Filtering\TemporalTables\" />
@@ -148,6 +151,8 @@
     <Folder Include="PostDeployment\OdsOrganisationsSeedData\" />
     <Folder Include="PostDeployment\OrderSeedData\" />
     <Folder Include="PostDeployment\ProdLikeData\" />
+    <Folder Include="PostDeployment\TestData\" />
+    <Folder Include="PostDeployment\TestData\Competitions\" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SqlServer.Dacpacs.Azure.Master" Version="160.0.0">

--- a/database/NHSD.GPITBuyingCatalogue.Database/NHSD.GPITBuyingCatalogue.Database.sqlproj
+++ b/database/NHSD.GPITBuyingCatalogue.Database/NHSD.GPITBuyingCatalogue.Database.sqlproj
@@ -1,31 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Sdk Name="Microsoft.Build.Sql" Version="0.1.10-preview" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <Name>NHSD.GPITBuyingCatalogue.Database</Name>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectVersion>4.1</ProjectVersion>
     <ProjectGuid>{deea1b1a-aec7-46f2-a786-4c0e9a391958}</ProjectGuid>
     <DSP>Microsoft.Data.Tools.Schema.Sql.SqlAzureV12DatabaseSchemaProvider</DSP>
     <OutputType>Database</OutputType>
-    <RootPath>
-    </RootPath>
     <RootNamespace>NSHD.GPITBuyingCatalogue.Database</RootNamespace>
     <AssemblyName>NSHD.GPITBuyingCatalogue.Database</AssemblyName>
     <ModelCollation>1033,CI</ModelCollation>
     <DefaultFileStructure>BySchemaType</DefaultFileStructure>
     <DeployToDatabase>True</DeployToDatabase>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <TargetLanguage>CS</TargetLanguage>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <SqlServerVerification>False</SqlServerVerification>
     <IncludeCompositeObjects>True</IncludeCompositeObjects>
     <TargetDatabaseSet>True</TargetDatabaseSet>
     <EnableFullTextSearch>False</EnableFullTextSearch>
-    <TargetFrameworkProfile />
     <DefaultCollation>SQL_Latin1_General_CP1_CI_AS</DefaultCollation>
     <DefaultFilegroup>PRIMARY</DefaultFilegroup>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>bin\Release\</OutputPath>
@@ -59,225 +54,6 @@
   <PropertyGroup>
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
   </PropertyGroup>
-  <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
-    <!-- Default to the v11.0 targets path if the targets file for the current VS version is not found -->
-    <SSDTExists Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets')">True</SSDTExists>
-    <VisualStudioVersion Condition="'$(SSDTExists)' == ''">11.0</VisualStudioVersion>
-  </PropertyGroup>
-  <Import Condition="'$(SQLDBExtensionsRefPath)' != ''" Project="$(SQLDBExtensionsRefPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
-  <Import Condition="'$(SQLDBExtensionsRefPath)' == ''" Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
-  <ItemGroup>
-    <Folder Include="Competitions\Stored Procedures" />
-    <Folder Include="OdsOrganisations\Functions\" />
-    <Folder Include="Properties" />
-    <Folder Include="Security\" />
-    <Folder Include="Security\Users" />
-    <Folder Include="Security\Logins" />
-    <Folder Include="Security\Roles" />
-    <Folder Include="PostDeployment\IntegrationTests" />
-    <Folder Include="PostDeployment\ProdLikeData" />
-    <Folder Include="PreDeployment" />
-    <Folder Include="Ordering" />
-    <Folder Include="Ordering\Tables" />
-    <Folder Include="Ordering\Views" />
-    <Folder Include="Catalogue" />
-    <Folder Include="Catalogue\Tables" />
-    <Folder Include="Users" />
-    <Folder Include="Users\Tables" />
-    <Folder Include="Organisations" />
-    <Folder Include="Organisations\Tables" />
-    <Folder Include="Cache" />
-    <Folder Include="Import" />
-    <Folder Include="Publish" />
-    <Folder Include="Import\Functions" />
-    <Folder Include="Import\Stored Procedures" />
-    <Folder Include="Publish\Stored Procedures" />
-    <Folder Include="Import\Types" />
-    <Folder Include="Organisations\TemporalTables" />
-    <Folder Include="Catalogue\TemporalTables" />
-    <Folder Include="Ordering\TemporalTables" />
-    <Folder Include="Users\TemporalTables" />
-    <Folder Include="PostDeployment\OrderSeedData" />
-    <Folder Include="Catalogue\Types" />
-    <Folder Include="Catalogue\Stored Procedures" />
-    <Folder Include="Security\Schemas\" />
-    <Folder Include="OdsOrganisations\" />
-    <Folder Include="OdsOrganisations\Tables\" />
-    <Folder Include="PostDeployment\OdsOrganisationsSeedData\" />
-    <Folder Include="Filtering\TemporalTables\" />
-    <Folder Include="Filtering\Tables\" />
-  </ItemGroup>
-  <ItemGroup>
-    <Build Include="Competitions\TemporalTables\Competitions_History.sql" />
-    <Build Include="Security\Users\NHSD.sql" />
-    <Build Include="Security\Logins\NHSD.sql" />
-    <Build Include="Filtering\Tables\FilterCapabilities.sql" />
-    <Build Include="Filtering\Tables\FilterClientApplicationTypes.sql" />
-    <Build Include="Filtering\Tables\FilterEpics.sql" />
-    <Build Include="Filtering\Tables\FilterHostingTypes.sql" />
-    <Build Include="Filtering\Tables\Filters.sql" />
-    <Build Include="Filtering\TemporalTables\FilterCapabilities_History.sql" />
-    <Build Include="Filtering\TemporalTables\FilterClientApplicationTypes_History.sql" />
-    <Build Include="Filtering\TemporalTables\FilterEpics_History.sql" />
-    <Build Include="Filtering\TemporalTables\FilterHostingTypes_History.sql" />
-    <Build Include="Filtering\TemporalTables\Filters_History.sql" />
-    <None Include="PostDeployment\CreateIntegratedCareBoards.sql" />
-    <None Include="PostDeployment\TestData\InsertFilters.sql" />
-    <None Include="PostDeployment\TestData\Competitions\InsertCompetitions.sql" />
-    <None Include="PostDeployment\IntegrationTests\ClearData.sql" />
-    <None Include="PostDeployment\IntegrationTests\DropRole.sql" />
-    <None Include="PostDeployment\IntegrationTests\DropUserAndLogin.sql" />
-    <None Include="PostDeployment\IntegrationTests\PostDeployment.sql" />
-    <None Include="PostDeployment\IntegrationTests\RestoreUserAndLogin.sql" />
-    <Build Include="Security\Roles\Importer.sql" />
-    <Build Include="Security\Roles\Publisher.sql" />
-    <Build Include="Security\Roles\Api.sql" />
-    <None Include="PostDeployment\InsertCapabilityStatuses.sql" />
-    <None Include="PostDeployment\InsertProvisioningTypes.sql" />
-    <None Include="PostDeployment\InsertTimeUnits.sql" />
-    <None Include="PostDeployment\InsertCataloguePriceTypes.sql" />
-    <None Include="PostDeployment\InsertPricingUnits.sql" />
-    <None Include="PostDeployment\InsertAdditionalServices.sql" />
-    <PreDeploy Include="PreDeployment\PreDeployment.sql" />
-    <None Include="PostDeployment\CreateTestUsers.sql" />
-    <None Include="PostDeployment\CreateCommissioningSupportUnits.sql" />
-    <None Include="PostDeployment\CreateExecutiveAgency.sql" />
-    <None Include="PostDeployment\CreateExecutiveAgencyUser.sql" />
-    <Build Include="Ordering\Tables\Contacts.sql" />
-    <Build Include="Ordering\Tables\DefaultDeliveryDates.sql" />
-    <Build Include="Ordering\Tables\OrderItemRecipients.sql" />
-    <Build Include="Ordering\Tables\OrderItems.sql" />
-    <Build Include="Ordering\Tables\Orders.sql" />
-    <Build Include="Ordering\Tables\OrderTriageValues.sql" />
-    <Build Include="Ordering\Tables\OrderStatus.sql" />
-    <Build Include="Ordering\Tables\ServiceRecipients.sql" />
-    <Build Include="Ordering\Views\ServiceInstanceItems.sql" />
-    <None Include="PostDeployment\InsertOrderStatuses.sql" />
-    <Build Include="Catalogue\Tables\AdditionalServices.sql" />
-    <Build Include="Catalogue\Tables\AssociatedServices.sql" />
-    <Build Include="Catalogue\Tables\Capabilities.sql" />
-    <Build Include="Catalogue\Tables\CapabilityCategories.sql" />
-    <Build Include="Catalogue\Tables\CapabilityStatus.sql" />
-    <Build Include="Catalogue\Tables\CatalogueItems.sql" />
-    <Build Include="Catalogue\Tables\CatalogueItemCapabilities.sql" />
-    <Build Include="Catalogue\Tables\CatalogueItemCapabilityStatus.sql" />
-    <Build Include="Catalogue\Tables\CatalogueItemEpics.sql" />
-    <Build Include="Catalogue\Tables\CatalogueItemEpicStatus.sql" />
-    <Build Include="Catalogue\Tables\CatalogueItemTypes.sql" />
-    <Build Include="Catalogue\Tables\CataloguePrices.sql" />
-    <Build Include="Catalogue\Tables\CataloguePriceTypes.sql" />
-    <Build Include="Catalogue\Tables\CompliancyLevels.sql" />
-    <Build Include="Catalogue\Tables\Epics.sql" />
-    <Build Include="Catalogue\Tables\Frameworks.sql" />
-    <Build Include="Catalogue\Tables\FrameworkCapabilities.sql" />
-    <Build Include="Catalogue\Tables\FrameworkSolutions.sql" />
-    <Build Include="Catalogue\Tables\MarketingContacts.sql" />
-    <Build Include="Catalogue\Tables\PricingUnits.sql" />
-    <Build Include="Catalogue\Tables\ProvisioningTypes.sql" />
-    <Build Include="Catalogue\Tables\PublicationStatus.sql" />
-    <Build Include="Catalogue\Tables\Solutions.sql" />
-    <Build Include="Catalogue\Tables\Suppliers.sql" />
-    <Build Include="Catalogue\Tables\SupplierContacts.sql" />
-    <Build Include="Catalogue\Tables\SupplierServiceAssociations.sql" />
-    <Build Include="Catalogue\Tables\TimeUnits.sql" />
-    <Build Include="Users\Tables\AspNetRoleClaims.sql" />
-    <Build Include="Users\Tables\AspNetRoles.sql" />
-    <Build Include="Users\Tables\AspNetUserClaims.sql" />
-    <Build Include="Users\Tables\AspNetUserLogins.sql" />
-    <Build Include="Users\Tables\AspNetUserRoles.sql" />
-    <Build Include="Users\Tables\AspNetUsers.sql" />
-    <Build Include="Users\Tables\AspNetUserTokens.sql" />
-    <Build Include="Organisations\Tables\Organisations.sql" />
-    <Build Include="Organisations\Tables\RelatedOrganisations.sql" />
-    <Build Include="Cache\SessionData.sql" />
-    <Build Include="Users\Tables\DataProtectionKeys.sql" />
-    <Build Include="Import\Functions\GetSupplierId.sql" />
-    <Build Include="Import\Stored Procedures\ImportAdditionalService.sql" />
-    <Build Include="Import\Stored Procedures\ImportAssociatedService.sql" />
-    <Build Include="Import\Stored Procedures\ImportSolution.sql" />
-    <Build Include="Publish\Stored Procedures\PublishCatalogueItem.sql" />
-    <Build Include="Import\Types\AdditionalServices.sql" />
-    <Build Include="Import\Types\AssociatedCatalogueItems.sql" />
-    <Build Include="Import\Types\AssociatedServices.sql" />
-    <Build Include="Import\Types\SolutionCapability.sql" />
-    <Build Include="Import\Types\Solutions.sql" />
-    <Build Include="Catalogue\Tables\CatalogueItemContacts.sql" />
-    <Build Include="Catalogue\Tables\Standards.sql" />
-    <Build Include="Catalogue\Tables\StandardsCapabilities.sql" />
-    <Build Include="Catalogue\Tables\SlaContacts.sql" />
-    <Build Include="Catalogue\Tables\ServiceLevelAgreements.sql" />
-    <Build Include="Catalogue\Tables\ServiceAvailabilityTimes.sql" />
-    <Build Include="Catalogue\Tables\SlaServiceLevels.sql" />
-    <Build Include="Catalogue\Tables\StandardTypes.sql" />
-    <Build Include="Catalogue\Tables\WorkOffPlans.sql" />
-    <Build Include="Organisations\TemporalTables\Organisations_History.sql" />
-    <Build Include="Organisations\TemporalTables\RelatedOrganisations_History.sql" />
-    <Build Include="Catalogue\TemporalTables\AdditionalServices_History.sql" />
-    <Build Include="Catalogue\TemporalTables\AssociatedServices_History.sql" />
-    <Build Include="Catalogue\TemporalTables\Capabilities_History.sql" />
-    <Build Include="Catalogue\TemporalTables\CapabilityCategories_History.sql" />
-    <Build Include="Catalogue\TemporalTables\CatalogueItemCapabilities_History.sql" />
-    <Build Include="Catalogue\TemporalTables\CatalogueItemCapabilityStatus_History.sql" />
-    <Build Include="Catalogue\TemporalTables\CatalogueItemContacts_History.sql" />
-    <Build Include="Catalogue\TemporalTables\CatalogueItemEpics_History.sql" />
-    <Build Include="Catalogue\TemporalTables\CatalogueItemEpicStatus_History.sql" />
-    <Build Include="Catalogue\TemporalTables\CatalogueItems_History.sql" />
-    <Build Include="Catalogue\TemporalTables\CataloguePrices_History.sql" />
-    <Build Include="Catalogue\TemporalTables\Epics_History.sql" />
-    <Build Include="Catalogue\TemporalTables\FrameworkCapabilities_History.sql" />
-    <Build Include="Catalogue\TemporalTables\Frameworks_History.sql" />
-    <Build Include="Catalogue\TemporalTables\FrameworkSolutions_History.sql" />
-    <Build Include="Catalogue\TemporalTables\MarketingContacts_History.sql" />
-    <Build Include="Catalogue\TemporalTables\PricingUnits_History.sql" />
-    <Build Include="Catalogue\TemporalTables\ServiceAvailabilityTimes_History.sql" />
-    <Build Include="Catalogue\TemporalTables\ServiceLevelAgreements_History.sql" />
-    <Build Include="Catalogue\TemporalTables\SlaContacts_History.sql" />
-    <Build Include="Catalogue\TemporalTables\SlaServiceLevels_History.sql" />
-    <Build Include="Catalogue\TemporalTables\Solutions_History.sql" />
-    <Build Include="Catalogue\TemporalTables\Standards_History.sql" />
-    <Build Include="Catalogue\TemporalTables\StandardsCapabilities_History.sql" />
-    <Build Include="Catalogue\TemporalTables\SupplierContacts_History.sql" />
-    <Build Include="Catalogue\TemporalTables\Suppliers_History.sql" />
-    <Build Include="Catalogue\TemporalTables\SupplierServiceAssociations.sql" />
-    <Build Include="Catalogue\TemporalTables\WorkOffPlans_History.sql" />
-    <Build Include="Ordering\TemporalTables\Contacts_History.sql" />
-    <Build Include="Ordering\TemporalTables\DefaultDevlieryDates_History.sql" />
-    <Build Include="Ordering\TemporalTables\OrderItemRecipients_History.sql" />
-    <Build Include="Ordering\TemporalTables\OrderItems_History.sql" />
-    <Build Include="Ordering\TemporalTables\Orders_History.sql" />
-    <Build Include="Ordering\TemporalTables\ServiceRecipients_History.sql" />
-    <Build Include="Users\TemporalTables\AspNetUserClaims_History.sql" />
-    <Build Include="Users\TemporalTables\AspNetUsers_History.sql" />
-    <Build Include="Import\Functions\GetLastPublishedDate.sql" />
-    <Build Include="Organisations\Tables\OrganisationTypes.sql" />
-    <Build Include="Organisations\Tables\GpPracticeSize.sql" />
-    <Build Include="Ordering\Tables\OrderItemPriceTiers.sql" />
-    <Build Include="Ordering\TemporalTables\OrderItemPriceTiers_History.sql" />
-    <Build Include="Ordering\Tables\OrderItemFunding.sql" />
-    <Build Include="Ordering\TemporalTables\OrderItemFunding_History.sql" />
-    <Build Include="Ordering\Tables\OrderItemPrices.sql" />
-    <Build Include="Ordering\TemporalTables\OrderItemPrices_History.sql" />
-    <Build Include="Catalogue\Tables\CataloguePriceCalculationTypes.sql" />
-    <Build Include="Catalogue\Tables\CataloguePriceQuantityCalculationTypes.sql" />
-    <Build Include="Ordering\Tables\OrderItemFundingTypes.sql" />
-    <Build Include="Catalogue\Tables\CataloguePriceTiers.sql" />
-    <Build Include="Catalogue\TemporalTables\CataloguePriceTiers_History.sql" />
-    <Build Include="Ordering\Tables\ImplementationPlans.sql" />
-    <Build Include="Ordering\TemporalTables\ImplementationPlans_HIstory.sql" />
-    <Build Include="Ordering\Tables\ImplementationPlanMilestones.sql" />
-    <Build Include="Ordering\TemporalTables\ImplementationPlanMilestones_History.sql" />
-    <Build Include="Ordering\Tables\ImplementationPlanAcceptanceCriteria.sql" />
-    <Build Include="Ordering\TemporalTables\ImplementationPlanAcceptanceCriteria_History.sql" />
-    <Build Include="Ordering\Tables\ContractFlags.sql" />
-    <Build Include="Ordering\TemporalTables\ContractFlags_History.sql" />
-    <None Include="PostDeployment\InsertOrderTriageValues.sql" />
-    <Build Include="Users\Tables\EmailDomains.sql" />
-    <Build Include="Catalogue\Types\CapabilityIds.sql" />
-    <Build Include="Catalogue\Types\EpicIds.sql" />
-    <Build Include="Catalogue\Stored Procedures\FilterCatalogueItems.sql" />
-    <Build Include="Ordering\Tables\OrderDeletionApprovals.sql" />
-  </ItemGroup>
   <ItemGroup>
     <SqlCmdVariable Include="CREATE_EA_USER">
       <DefaultValue>True</DefaultValue>
@@ -325,102 +101,56 @@
     </SqlCmdVariable>
   </ItemGroup>
   <ItemGroup>
-    <None Include="PostDeployment\InsertEpics.sql" />
-    <None Include="PostDeployment\InsertCapabilities.sql" />
-    <None Include="PostDeployment\InsertFrameworks.sql" />
-    <None Include="PostDeployment\InsertSolutions.sql" />
-    <None Include="PostDeployment\InsertSuppliers.sql" />
-    <None Include="PostDeployment\DropImport.sql" />
-    <None Include="PostDeployment\DropPublish.sql" />
-    <None Include="PostDeployment\InsertCatalogueItemTypes.sql" />
-    <None Include="PostDeployment\InsertCapabilityCategories.sql" />
-    <None Include="PostDeployment\InsertCompliancyLevels.sql" />
-    <None Include="PostDeployment\InsertPublicationStatuses.sql" />
-    <None Include="PostDeployment\InsertSolutionCapabilityStatuses.sql" />
-    <None Include="PostDeployment\InsertSolutionEpicStatuses.sql" />
-    <None Include="PostDeployment\ProdLikeData\MergeSuppliers.sql" />
-    <None Include="PostDeployment\ProdLikeData\MergeCatalogueItems.sql" />
-    <None Include="PostDeployment\ProdLikeData\MergeSolutions.sql" />
-    <None Include="PostDeployment\ProdLikeData\MergeAdditionalServices.sql" />
-    <None Include="PostDeployment\ProdLikeData\MergeAssociatedServices.sql" />
-    <None Include="PostDeployment\ProdLikeData\MergeMarketingContacts.sql" />
-    <None Include="PostDeployment\ProdLikeData\MergeCatalogueItemEpics.sql" />
-    <None Include="PostDeployment\ProdLikeData\MergeCatalogueItemCapabilities.sql" />
-    <None Include="PostDeployment\ProdLikeData\MergeFrameworkSolutions.sql" />
-    <None Include="PostDeployment\ProdLikeData\MergeCataloguePrices.sql" />
-    <None Include="PostDeployment\InsertAssociatedServices.sql" />
-    <None Include="PostDeployment\InsertStandards.sql" />
-    <None Include="PostDeployment\InsertStandardsCapabilities.sql" />
-    <None Include="PostDeployment\InsertStandardTypes.sql" />
-    <None Include="PostDeployment\InsertRelatedOrganisations.sql" />
-    <None Include="PostDeployment\InsertOrganisationTypes.sql" />
-    <None Include="PostDeployment\OrderSeedData\InsertTestOrderSeedData.sql" />
-    <None Include="PostDeployment\InsertCataloguePriceCalculationTypes.sql" />
-    <None Include="PostDeployment\InsertCataloguePriceQuantityCalculationTypes.sql" />
-    <None Include="PostDeployment\InsertSupplierServiceAssociations.sql" />
-    <None Include="PostDeployment\InsertOrderItemFundingTypes.sql" />
-    <None Include="PostDeployment\InsertDefaultImplementationPlan.sql" />
-    <None Include="PostDeployment\InsertAllowedEmailDomains.sql" />
-  </ItemGroup>
-  <ItemGroup>
     <PostDeploy Include="PostDeployment\PostDeployment.sql" />
   </ItemGroup>
   <ItemGroup>
-    <RefactorLog Include="NHSD.GPITBuyingCatalogue.Database.refactorlog" />
+    <Build Include="**/*.sql" />
+    <None Include="PostDeployment/**/*.sql" />
   </ItemGroup>
   <ItemGroup>
-    <ArtifactReference Include="$(DacPacRootPath)\Extensions\Microsoft\SQLDB\Extensions\SqlServer\AzureV12\SqlSchemas\master.dacpac">
-      <HintPath>$(DacPacRootPath)\Extensions\Microsoft\SQLDB\Extensions\SqlServer\AzureV12\SqlSchemas\master.dacpac</HintPath>
-      <SuppressMissingDependenciesErrors>False</SuppressMissingDependenciesErrors>
-      <DatabaseVariableLiteralValue>master</DatabaseVariableLiteralValue>
-    </ArtifactReference>
+    <Folder Include="PostDeployment\" />
+    <Folder Include="Cache\" />
+    <Folder Include="Catalogue\" />
+    <Folder Include="Catalogue\Stored Procedures\" />
+    <Folder Include="Catalogue\Tables\" />
+    <Folder Include="Catalogue\TemporalTables\" />
+    <Folder Include="Catalogue\Types\" />
+    <Folder Include="Filtering\" />
+    <Folder Include="Filtering\Tables\" />
+    <Folder Include="Filtering\TemporalTables\" />
+    <Folder Include="Import\" />
+    <Folder Include="Import\Functions\" />
+    <Folder Include="Import\Stored Procedures\" />
+    <Folder Include="Import\Types\" />
+    <Folder Include="OdsOrganisations\" />
+    <Folder Include="OdsOrganisations\Tables\" />
+    <Folder Include="Ordering\" />
+    <Folder Include="Ordering\Tables\" />
+    <Folder Include="Ordering\TemporalTables\" />
+    <Folder Include="Ordering\Views\" />
+    <Folder Include="Organisations\" />
+    <Folder Include="Organisations\Tables\" />
+    <Folder Include="Organisations\TemporalTables\" />
+    <Folder Include="PreDeployment\" />
+    <Folder Include="Publish\" />
+    <Folder Include="Publish\Stored Procedures\" />
+    <Folder Include="Security\" />
+    <Folder Include="Security\Logins\" />
+    <Folder Include="Security\Roles\" />
+    <Folder Include="Security\Schemas\" />
+    <Folder Include="Security\Users\" />
+    <Folder Include="Users\" />
+    <Folder Include="Users\Tables\" />
+    <Folder Include="Users\TemporalTables\" />
+    <Folder Include="PostDeployment\IntegrationTests\" />
+    <Folder Include="PostDeployment\OdsOrganisationsSeedData\" />
+    <Folder Include="PostDeployment\OrderSeedData\" />
+    <Folder Include="PostDeployment\ProdLikeData\" />
+    <Folder Include="obj\" />
+    <Folder Include="obj\Debug\" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="PostDeployment\InsertRoles.sql" />
-  </ItemGroup>
-  <ItemGroup>
-    <Build Include="OdsOrganisations\Tables\OdsOrganisations.sql" />
-    <Build Include="OdsOrganisations\Tables\OrganisationRelationships.sql" />
-    <Build Include="OdsOrganisations\Tables\RelationshipTypes.sql" />
-    <Build Include="OdsOrganisations\Tables\OrganisationRoles.sql" />
-    <Build Include="OdsOrganisations\Tables\RoleTypes.sql" />
-    <Build Include="OdsOrganisations\Tables\Journal.sql" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="PostDeployment\OdsOrganisationsSeedData\InsertOdsOrganisations.sql" />
-    <None Include="PostDeployment\OdsOrganisationsSeedData\InsertOrganisationRelationships.sql" />
-    <None Include="PostDeployment\OdsOrganisationsSeedData\InsertOrganisationRoles.sql" />
-    <None Include="PostDeployment\OdsOrganisationsSeedData\InsertRelationshipTypes.sql" />
-    <None Include="PostDeployment\OdsOrganisationsSeedData\InsertRoleTypes.sql" />
-  </ItemGroup>
-  <ItemGroup>
-    <Build Include="Security\Schemas\import.sql" />
-    <Build Include="Security\Schemas\publish.sql" />
-    <Build Include="Security\Schemas\ordering.sql" />
-    <Build Include="Security\Schemas\filtering.sql" />
-    <Build Include="Security\Schemas\users.sql" />
-    <Build Include="Security\Schemas\organisations.sql" />
-    <Build Include="Security\Schemas\cache.sql" />
-    <Build Include="Security\Schemas\auditing.sql" />
-    <Build Include="Security\Schemas\catalogue.sql" />
-    <Build Include="Security\Schemas\ods_organisations.sql" />
-    <Build Include="Security\Schemas\competitions.sql" />
-  </ItemGroup>
-  <ItemGroup>
-    <Build Include="Competitions\Tables\Competitions.sql" />
-  </ItemGroup>
-  <ItemGroup>
-    <Build Include="Filtering\Tables\FilterCapabilities.sql" />
-    <Build Include="Filtering\Tables\FilterClientApplicationTypes.sql" />
-    <Build Include="Filtering\Tables\FilterEpics.sql" />
-    <Build Include="Filtering\Tables\FilterHostingTypes.sql" />
-    <Build Include="Filtering\Tables\Filters.sql" />
-    
-    <Build Include="Filtering\TemporalTables\FilterCapabilities_History.sql" />
-    <Build Include="Filtering\TemporalTables\FilterClientApplicationTypes_History.sql" />
-    <Build Include="Filtering\TemporalTables\FilterEpics_History.sql" />
-    <Build Include="Filtering\TemporalTables\FilterHostingTypes_History.sql" />
-    <Build Include="Filtering\TemporalTables\Filters_History.sql" />
+    <PackageReference Include="Microsoft.SqlServer.Dacpacs.Azure.Master" Version="160.0.0" />
   </ItemGroup>
   <PropertyGroup>
     <PreBuildEvent>


### PR DESCRIPTION
Updates the sqlproject to use the newer [Microsoft.Build.Sql SDK](https://github.com/microsoft/DacFx/tree/main/src/Microsoft.Build.Sql) in order to create a DACPAC file with PostDeployment capabilities.

This will make it easier to add tables etc since glob patterns are now supported in the sqlproj. However, the caveat is that Visual Studio can't be used to build the database project because of the `PackageReference` element which is required to reference the Azure `master.dacpac` schema. This is because Visual Studio is unable to restore NuGet packages for a SQL project using the sqlproj format. `dotnet build` and running via `docker-compose` will continue to function as normal.

See [here](https://github.com/microsoft/DacFx/issues/80) regarding the lack of support for Visual Studio.

Unfortunately Microsoft's documentation is lackluster in regards to the `Folder Include`. For example, [here](https://github.com/microsoft/DacFx/blob/main/src/Microsoft.Build.Sql/docs/Converting-Existing.md#default-sql-files-included-in-build) they say the SDK uses glob patterns to detect files, much like a C# project, but I found that not to be the case and had to add the glob patterns myself while excluding bin & obj. In specifying glob patterns manually, it seems to generate the `Folder Include` elements in order to resolve bullet point 4 in the preceding link

> Even though build will honor the default globbing pattern, .sql files that are not included explicitly will not be displayed inside Solution Explorer in SSDT. Support for this will be added in a future release of SSDT.