### PR TITLE
Terraform: Link rewrite on App Gateway request rules

### DIFF
--- a/terraform/webapp/modules/bc_app_gateway_ingress/main.tf
+++ b/terraform/webapp/modules/bc_app_gateway_ingress/main.tf
@@ -68,6 +68,7 @@ resource "azurerm_application_gateway" "app_gateway" {
     rule_type                   = "Basic"
     http_listener_name          = "${var.ag_name_fragment}-appgateway-httplstn"
     redirect_configuration_name = "${var.ag_name_fragment}-appgateway-http-redirect"
+    rewrite_rule_set_name       = "${var.ag_name_fragment}-appgateway-rewrite-rules"
     priority                    = 10010
   }
 
@@ -80,11 +81,12 @@ resource "azurerm_application_gateway" "app_gateway" {
   }
 
   request_routing_rule {
-    name                       = "${var.ag_name_fragment}-appgateway-rqrt-https"
-    rule_type                  = "Basic"
-    http_listener_name         = "${var.ag_name_fragment}-appgateway-httpslstn"
-    backend_address_pool_name  = "${var.ag_name_fragment}-appgateway-beap"
-    backend_http_settings_name = "${var.ag_name_fragment}-appgateway-be-htst"
+    name                        = "${var.ag_name_fragment}-appgateway-rqrt-https"
+    rule_type                   = "Basic"
+    http_listener_name          = "${var.ag_name_fragment}-appgateway-httpslstn"
+    backend_address_pool_name   = "${var.ag_name_fragment}-appgateway-beap"
+    backend_http_settings_name  = "${var.ag_name_fragment}-appgateway-be-htst"
+    rewrite_rule_set_name       = "${var.ag_name_fragment}-appgateway-rewrite-rules"
     priority                    = 10020
   }
 


### PR DESCRIPTION
Relating to the recent live issue, the rewrite rule that rewrites the App Service URL to the public domain name became disassociated with the App Gateway routing rule.

Not sure how this worked in the first place since the infrastructure provisioning predates my time on the project and, based on the Terraform history, the App Gateway Rewrite rule has never been associated with the Routing rule via Terraform.