### PR TITLE
Remove redundant help content

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionsDashboard/BeforeYouStart.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionsDashboard/BeforeYouStart.cshtml
@@ -27,13 +27,6 @@
 
             <h2>Need help?</h2>
             <p>
-                We've developed a
-                <a href="https://gpitbjss.atlassian.net/wiki/spaces/BG/pages/1931116641/Executing+a+procurement+a+step+by+step+guide"
-                   target="_blank">step-by-step guide to the procurement process
-                (opens in a new tab)</a>.
-            </p>
-
-            <p>
                 For help using the Buying Catalogue, contact the National and Commercial Procurement Hub:
             </p>
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/AmendOrder.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/AmendOrder.cshtml
@@ -21,30 +21,25 @@
         <nhs-page-title title="@ViewBag.Title"
                         caption="Order @Model.CallOffId"
                         advice="Before amending an order, familiarise yourself with what you can and cannot change."/>
-    
+
         <vc:nhs-do-list title="You can"
                         items="@Model.DoItems"/>
 
         <vc:nhs-dont-list title="You cannot"
                           items="@Model.DontItems"/>
-        
+
         <form method="post">
             <nhs-submit-button text="Amend order"/>
-            
+
             <p>
                 <a href="@Url.Action(
                              nameof(DashboardController.Index),
                              typeof(DashboardController).ControllerName())">Cancel</a>
             </p>
         </form>
-        
+
         <div class="nhsuk-u-margin-top-6">
             <h2>Need help?</h2>
-            <p>
-                We've developed a
-                <a href="https://gpitbjss.atlassian.net/wiki/spaces/BG/pages/1931116641/Executing+a+procurement+a+step+by+step+guide"
-                   target="_blank">step-by-step guide to the procurement process (opens in a new tab)</a>.
-            </p>
             <p>
                 For help using the Buying Catalogue, contact the National and Commercial Procurement Hub:
             </p>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/ReadyToStart.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/ReadyToStart.cshtml
@@ -34,13 +34,6 @@
 
             <h2>Need help?</h2>
             <p>
-                We've developed a
-                <a href="https://gpitbjss.atlassian.net/wiki/spaces/BG/pages/1931116641/Executing+a+procurement+a+step+by+step+guide"
-                   target="_blank">step-by-step guide to the procurement process
-                (opens in a new tab)</a>.
-            </p>
-
-            <p>
                 For help using the Buying Catalogue, contact the National Commercial and Procurement Hub:
             </p>
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/OrderTriage/Incomplete40k.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/OrderTriage/Incomplete40k.cshtml
@@ -28,16 +28,6 @@
             <h2>Need help?</h2>
 
             <p>
-                We've developed a
-                <a href="https://gpitbjss.atlassian.net/wiki/spaces/BG/pages/1931116641/Executing+a+procurement+a+step+by+step+guide"
-                   target="_blank">step-by-step guide to the procurement process</a>
-                (opens in a new tab) and have
-                <a href="https://gpitbjss.atlassian.net/wiki/spaces/BG/pages/1846870055/Direct+Award"
-                   target="_blank">more information about executing a Direct Award procedure</a>
-                (opens in a new tab).
-            </p>
-
-            <p>
                 For help using the Buying Catalogue, contact the National Commercial and Procurement Hub:
             </p>
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/OrderTriage/Incomplete40kTo250k.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/OrderTriage/Incomplete40kTo250k.cshtml
@@ -29,16 +29,6 @@
             <h2>Need help?</h2>
 
             <p>
-                We've developed a
-                <a href="https://gpitbjss.atlassian.net/wiki/spaces/BG/pages/1931116641/Executing+a+procurement+a+step+by+step+guide"
-                   target="_blank">step-by-step guide to the procurement process</a>
-                (opens in a new tab) and have
-                <a href="https://gpitbjss.atlassian.net/wiki/spaces/BG/pages/1846968344/Further+Competition+-+On+Catalogue"
-                   target="_blank">more information about executing an On-Catalogue Competition procedure</a>
-                (opens in a new tab).
-            </p>
-
-            <p>
                 For help using the Buying Catalogue, contact the National Commercial and Procurement Hub:
             </p>
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/OrderTriage/IncompleteOver250k.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/OrderTriage/IncompleteOver250k.cshtml
@@ -29,16 +29,6 @@
             <h2>Need help?</h2>
 
             <p>
-                We've developed a
-                <a href="https://gpitbjss.atlassian.net/wiki/spaces/BG/pages/1931116641/Executing+a+procurement+a+step+by+step+guide"
-                   target="_blank">step-by-step guide to the procurement process</a>
-                (opens in a new tab) and have
-                <a href="https://gpitbjss.atlassian.net/wiki/spaces/BG/pages/1846902822/Further+Competition+-+Off+Catalogue"
-                   target="_blank">more information about executing an Off-Catalogue Competition procedure</a>
-                (opens in a new tab).
-            </p>
-
-            <p>
                 For help using the Buying Catalogue, contact the National Commercial and Procurement Hub:
             </p>
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/OrderTriage/NotSure.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/OrderTriage/NotSure.cshtml
@@ -47,13 +47,6 @@
 
             <h2>Need help?</h2>
             <p>
-                We've developed a
-                <a href="https://gpitbjss.atlassian.net/wiki/spaces/BG/pages/1931116641/Executing+a+procurement+a+step+by+step+guide"
-                   target="_blank">step-by-step guide to the procurement process</a>
-                (opens in a new tab).
-            </p>
-
-            <p>
                 For help using the Buying Catalogue, contact the National Commercial and Procurement Hub:
             </p>
 


### PR DESCRIPTION
Removes content from the following pages:

- Competitions: Before you start your competition guidance
- Order journey: all triage pages before starting an order
- Order journey: Amend Order page for a completed order.