### PR TITLE
Bugfix: Set ASP.NET Core port to 80

### DIFF
--- a/terraform/webapp/modules/bc_webapp_pri/deployment_slot.tf
+++ b/terraform/webapp/modules/bc_webapp_pri/deployment_slot.tf
@@ -7,6 +7,7 @@ resource "azurerm_linux_web_app_slot" "slot" {
     # Main Settings
     WEBSITES_ENABLE_APP_SERVICE_STORAGE = false
     ASPNETCORE_ENVIRONMENT              = var.aspnet_environment
+    ASPNETCORE_HTTP_PORTS               = "80"
 
     APPINSIGHTS_INSTRUMENTATIONKEY = var.instrumentation_key
 

--- a/terraform/webapp/modules/bc_webapp_pri/main.tf
+++ b/terraform/webapp/modules/bc_webapp_pri/main.tf
@@ -21,6 +21,7 @@ resource "azurerm_linux_web_app" "webapp" {
     # Main Settings
     WEBSITES_ENABLE_APP_SERVICE_STORAGE = false
     ASPNETCORE_ENVIRONMENT              = var.aspnet_environment
+    ASPNETCORE_HTTP_PORTS               = "80"
 
     APPINSIGHTS_INSTRUMENTATIONKEY = var.instrumentation_key
 


### PR DESCRIPTION
Breaking change in .NET 8: Containers use port 8080 by default now rather than port 80

https://learn.microsoft.com/en-us/dotnet/core/compatibility/containers/8.0/aspnet-port