### PR TITLE
Ordering PDFs: Add to emails and conditionally toggle signature block

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.Framework/Settings/OrderMessageSettings.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Framework/Settings/OrderMessageSettings.cs
@@ -8,8 +8,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Framework.Settings
     {
         public string SingleCsvTemplateId { get; set; }
 
-        public string DualCsvTemplateId { get; set; }
-
         public string UserTemplateId { get; set; }
 
         public string UserAssociatedServiceTemplateId { get; set; }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/OrderService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/OrderService.cs
@@ -27,8 +27,8 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
         public const string OrganisationNameToken = "organisation_name";
         public const string FullOrderCsvToken = "full_order_csv";
         public const string OrderIdToken = "order_id";
-        public const string OrderSummaryLinkToken = "order_summary_link";
         public const string OrderSummaryCsv = "order_summary_csv";
+        public const string OrderSummaryPdf = "order_summary_pdf";
 
         private readonly BuyingCatalogueDbContext dbContext;
         private readonly ICsvService csvService;
@@ -385,6 +385,10 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
             var order = (await GetOrderThin(callOffId, internalOrgId)).Order;
             order.Complete();
 
+            dbContext.Entry(order).State = EntityState.Modified;
+
+            await dbContext.SaveChangesAsync();
+
             await SendEmailsAndSave(order, callOffId, userId);
         }
 
@@ -485,6 +489,8 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
             fullOrderStream.Position = 0;
             var fullOrderBytes = fullOrderStream.ToArray();
 
+            var pdfStream = await pdfService.CreateOrderSummaryPdf(order);
+
             var adminTokens = new Dictionary<string, dynamic>
             {
                 { OrganisationNameToken, order.OrderingParty.Name },
@@ -499,10 +505,10 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
                 { OrderSummaryCsv, NotificationClient.PrepareUpload(fullOrderBytes, true) },
             };
 
-            dbContext.Entry(order).State = EntityState.Modified;
-            await dbContext.SaveChangesAsync();
-
-            _ = await pdfService.CreateOrderSummaryPdf(order);
+            if (order.OrderStatus is OrderStatus.Completed)
+            {
+                userTokens.Add(OrderSummaryPdf, NotificationClient.PrepareUpload(pdfStream.ToArray()));
+            }
 
             var userEmail = dbContext.Users.First(x => x.Id == userId).Email;
 

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/OrderService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/OrderService.cs
@@ -500,6 +500,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
             };
 
             dbContext.Entry(order).State = EntityState.Modified;
+            await dbContext.SaveChangesAsync();
 
             _ = await pdfService.CreateOrderSummaryPdf(order);
 
@@ -507,8 +508,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
 
             await Task.WhenAll(
                 emailService.SendEmailAsync(orderMessageSettings.Recipient.Address, templateId, adminTokens),
-                emailService.SendEmailAsync(userEmail, GetUserTemplateId(order), userTokens),
-                dbContext.SaveChangesAsync());
+                emailService.SendEmailAsync(userEmail, GetUserTemplateId(order), userTokens));
         }
 
         private string GetUserTemplateId(Order order)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Controllers/CompetitionImportServiceRecipientsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Controllers/CompetitionImportServiceRecipientsController.cs
@@ -167,13 +167,11 @@ public class CompetitionImportServiceRecipientsController : Controller
         var validOdsCodes = GetValidOdsCodes(cachedRecipients, organisationServiceRecipients);
         await importService.Clear(cacheKey);
         return RedirectToAction(
-            nameof(CompetitionRecipientsController.Index),
+            nameof(CompetitionRecipientsController.ConfirmRecipients),
             typeof(CompetitionRecipientsController).ControllerName(),
             new
             {
-                internalOrgId,
-                competitionId,
-                importedRecipients = string.Join(',', validOdsCodes),
+                internalOrgId, competitionId, recipientIds = string.Join(',', validOdsCodes), hasImported = true,
             });
     }
 
@@ -193,11 +191,11 @@ public class CompetitionImportServiceRecipientsController : Controller
         await importService.Clear(cacheKey);
 
         return RedirectToAction(
-            nameof(CompetitionRecipientsController.Index),
+            nameof(CompetitionRecipientsController.ConfirmRecipients),
             typeof(CompetitionRecipientsController).ControllerName(),
             new
             {
-                internalOrgId, competitionId, importedRecipients = string.Join(',', validOdsCodes),
+                internalOrgId, competitionId, recipientIds = string.Join(',', validOdsCodes), hasImported = true,
             });
     }
 
@@ -224,7 +222,7 @@ public class CompetitionImportServiceRecipientsController : Controller
         importService.Clear(new(User.UserId(), internalOrgId, CompetitionCacheKey, competitionId));
 
         return RedirectToAction(
-            nameof(CompetitionRecipientsController.Index),
+            nameof(CompetitionRecipientsController.UploadOrSelectServiceRecipients),
             typeof(CompetitionRecipientsController).ControllerName(),
             new { internalOrgId, competitionId });
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Controllers/CompetitionRecipientsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Controllers/CompetitionRecipientsController.cs
@@ -137,7 +137,8 @@ public class CompetitionRecipientsController : Controller
     public async Task<IActionResult> ConfirmRecipients(
         string internalOrgId,
         int competitionId,
-        string recipientIds)
+        string recipientIds,
+        bool? hasImported = null)
     {
         var organisation = await organisationsService.GetOrganisationByInternalIdentifier(internalOrgId);
         var competition = await competitionsService.GetCompetition(internalOrgId, competitionId);
@@ -150,7 +151,12 @@ public class CompetitionRecipientsController : Controller
 
         var model = new ConfirmChangesModel(organisation)
         {
-            BackLink = Url.Action(nameof(Index), new { internalOrgId, competitionId, recipientIds }),
+            BackLink = hasImported.GetValueOrDefault()
+                ? Url.Action(
+                    nameof(CompetitionImportServiceRecipientsController.Index),
+                    typeof(CompetitionImportServiceRecipientsController).ControllerName(),
+                    new { internalOrgId, competitionId })
+                : Url.Action(nameof(Index), new { internalOrgId, competitionId, recipientIds }),
             Caption = competition.Name,
             Selected = recipients.Select(
                     x => new ServiceRecipientModel { Name = x.Name, OdsCode = x.OrgId, Location = x.Location })

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/OrderController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/OrderController.cs
@@ -158,19 +158,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers
             var orderWrapper = await orderService.GetOrderForSummary(callOffId, internalOrgId);
             if (!orderWrapper.CanComplete())
             {
-                ModelState.AddModelError(ErrorKey, ErrorMessage);
-                var hasSubsequentRevisions = await orderService.HasSubsequentRevisions(callOffId);
-
-                var defaultPlan = await implementationPlanService.GetDefaultImplementationPlan();
-
-                var model = new SummaryModel(orderWrapper, internalOrgId, hasSubsequentRevisions, defaultPlan)
-                {
-                    BackLink = GetBackLink(internalOrgId, callOffId, orderWrapper.Order),
-                    Title = GetTitle(orderWrapper),
-                    AdviceText = GetAdvice(orderWrapper, !hasSubsequentRevisions),
-                };
-
-                return View(model);
+                return RedirectToAction(nameof(Summary), new { internalOrgId, callOffId });
             }
 
             await orderService.CompleteOrder(

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/SolutionSelection/ImportServiceRecipientsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/SolutionSelection/ImportServiceRecipientsController.cs
@@ -164,11 +164,11 @@ public class ImportServiceRecipientsController : Controller
         var validOdsCodes = GetValidOdsCodes(cachedRecipients, organisationServiceRecipients);
         await importService.Clear(cacheKey);
         return RedirectToAction(
-            nameof(ServiceRecipientsController.SelectServiceRecipients),
+            nameof(ServiceRecipientsController.ConfirmChanges),
             typeof(ServiceRecipientsController).ControllerName(),
             new
             {
-                internalOrgId, callOffId, importedRecipients = string.Join(',', validOdsCodes),
+                internalOrgId, callOffId, recipientIds = string.Join(',', validOdsCodes), hasImported = true,
             });
     }
 
@@ -177,8 +177,7 @@ public class ImportServiceRecipientsController : Controller
         string internalOrgId,
         CallOffId callOffId,
         CatalogueItemId catalogueItemId,
-        ValidateNamesModel model,
-        ServiceRecipientImportMode? importMode = ServiceRecipientImportMode.Edit)
+        ValidateNamesModel model)
     {
         var cacheKey = new ServiceRecipientCacheKey(User.UserId(), internalOrgId, callOffId);
         var cachedRecipients = await importService.GetCached(cacheKey);
@@ -190,11 +189,11 @@ public class ImportServiceRecipientsController : Controller
         await importService.Clear(cacheKey);
 
         return RedirectToAction(
-            nameof(ServiceRecipientsController.SelectServiceRecipients),
+            nameof(ServiceRecipientsController.ConfirmChanges),
             typeof(ServiceRecipientsController).ControllerName(),
             new
             {
-                internalOrgId, callOffId, catalogueItemId, importedRecipients = string.Join(',', validOdsCodes),
+                internalOrgId, callOffId, catalogueItemId, recipientIds = string.Join(',', validOdsCodes), hasImported = true,
             });
     }
 
@@ -202,13 +201,11 @@ public class ImportServiceRecipientsController : Controller
     public async Task<IActionResult> DownloadTemplate(
         string internalOrgId,
         CallOffId callOffId,
-        CatalogueItemId catalogueItemId,
-        ServiceRecipientImportMode? importMode = ServiceRecipientImportMode.Edit)
+        CatalogueItemId catalogueItemId)
     {
         _ = internalOrgId;
         _ = callOffId;
         _ = catalogueItemId;
-        _ = importMode;
 
         using var stream = new MemoryStream();
         await importService.CreateServiceRecipientTemplate(stream);
@@ -221,13 +218,12 @@ public class ImportServiceRecipientsController : Controller
     public IActionResult CancelImport(
         string internalOrgId,
         CallOffId callOffId,
-        CatalogueItemId catalogueItemId,
-        ServiceRecipientImportMode? importMode = ServiceRecipientImportMode.Edit)
+        CatalogueItemId catalogueItemId)
     {
         importService.Clear(new(User.UserId(), internalOrgId, callOffId, catalogueItemId));
 
         return RedirectToAction(
-            nameof(ServiceRecipientsController.SelectServiceRecipients),
+            nameof(ServiceRecipientsController.UploadOrSelectServiceRecipients),
             typeof(ServiceRecipientsController).ControllerName(),
             new { internalOrgId, callOffId, catalogueItemId });
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/SolutionSelection/ServiceRecipientsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/SolutionSelection/ServiceRecipientsController.cs
@@ -226,7 +226,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.SolutionSele
             string internalOrgId,
             CallOffId callOffId,
             string recipientIds,
-            string selectedRecipientId)
+            string selectedRecipientId,
+            bool? hasImported = null)
         {
             var wrapper = await orderService.GetOrderWithOrderItems(callOffId, internalOrgId);
             var orderType = wrapper.Order.OrderType;
@@ -260,9 +261,17 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.SolutionSele
                 Advice = title.Advice,
                 OrderType = orderType,
                 BackLink = orderType.MergerOrSplit
-                    ? Url.Action(nameof(SelectRecipientForPracticeReorganisation), new { internalOrgId, callOffId, recipientIds, selectedRecipientId })
-                    : Url.Action(nameof(SelectServiceRecipients), new { internalOrgId, callOffId, recipientIds }),
-                AddRemoveRecipientsLink = Url.Action(nameof(SelectServiceRecipients), new { internalOrgId, callOffId, recipientIds }),
+                    ? Url.Action(
+                        nameof(SelectRecipientForPracticeReorganisation),
+                        new { internalOrgId, callOffId, recipientIds, selectedRecipientId })
+                    : hasImported.GetValueOrDefault()
+                        ? Url.Action(
+                            nameof(ImportServiceRecipientsController.Index),
+                            typeof(ImportServiceRecipientsController).ControllerName(),
+                            new { internalOrgId, callOffId })
+                        : Url.Action(nameof(SelectServiceRecipients), new { internalOrgId, callOffId, recipientIds }),
+                AddRemoveRecipientsLink =
+                    Url.Action(nameof(SelectServiceRecipients), new { internalOrgId, callOffId, recipientIds }),
                 Selected = selectedRecipients,
                 PracticeReorganisationRecipient = practiceReorganisation,
                 PreviouslySelected = MapToModel(previousRecipients, false),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/SolutionSelection/ServiceRecipientsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/SolutionSelection/ServiceRecipientsController.cs
@@ -119,10 +119,15 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.SolutionSele
                     Caption = $"Order {callOffId}",
                     Advice = title.Advice,
                     BackLink =
-                        Url.Action(
-                            nameof(UploadOrSelectServiceRecipients),
-                            typeof(ServiceRecipientsController).ControllerName(),
-                            new { internalOrgId, callOffId }),
+                        wrapper.Order.OrderType.MergerOrSplit
+                            ? Url.Action(
+                                nameof(OrderController.Order),
+                                typeof(OrderController).ControllerName(),
+                                new { internalOrgId, callOffId })
+                            : Url.Action(
+                                nameof(UploadOrSelectServiceRecipients),
+                                typeof(ServiceRecipientsController).ControllerName(),
+                                new { internalOrgId, callOffId }),
                     HasImportedRecipients = !string.IsNullOrWhiteSpace(importedRecipients),
                     SelectAtLeast = wrapper.Order.OrderType.MergerOrSplit
                         ? 2

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/Orders/OrderModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/Orders/OrderModel.cs
@@ -83,6 +83,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.Orders
             LastUpdatedByUserName = order.LastUpdatedByUser.FullName;
             LastUpdated = order.LastUpdated;
             ShowSelectFrameworkPage = string.IsNullOrWhiteSpace(order.SelectedFrameworkId);
+            IsMergerOrSplit = order.OrderType.MergerOrSplit;
             Descriptions = BuildDescriptions(order.OrderType, order.IsAmendment, IsCompetitionOrder);
         }
 
@@ -120,12 +121,14 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.Orders
 
         public bool ShowSelectFrameworkPage { get; set; }
 
+        public bool IsMergerOrSplit { get; set; }
+
         private ReadOnlyDictionary<OrderSummaryField, string> Descriptions { get; }
 
         public string StatusDescription(OrderSummaryField field)
         {
-            return Descriptions.ContainsKey(field)
-                ? Descriptions[field]
+            return Descriptions.TryGetValue(field, out var description)
+                ? description
                 : string.Empty;
         }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/Order.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/Order.cshtml
@@ -58,7 +58,11 @@
                 <nhs-task-list-section label-text="@Model.SolutionsAndServicesSectionLabel">
                     <nhs-task-list-item label-text="Service Recipients"
                                         label-hint="@Model.StatusDescription(OrderSummaryField.ServiceRecipients)"
-                                        url="@Url.Action(nameof(ServiceRecipientsController.UploadOrSelectServiceRecipients), typeof(ServiceRecipientsController).ControllerName(), new { Model.InternalOrgId, Model.CallOffId })"
+                                        url="@Url.Action(Model.IsMergerOrSplit
+                                                 ? nameof(ServiceRecipientsController.SelectServiceRecipients)
+                                                 : nameof(ServiceRecipientsController.UploadOrSelectServiceRecipients),
+                                                 typeof(ServiceRecipientsController).ControllerName(),
+                                                 new { Model.InternalOrgId, Model.CallOffId })"
                                         status="@Model.Progress.ServiceRecipients"/>
 
                     <nhs-task-list-item label-text="Solutions and services"

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Models/Shared/ServiceRecipientModels/ImportServiceRecipients/ValidateNamesModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Models/Shared/ServiceRecipientModels/ImportServiceRecipients/ValidateNamesModel.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.ServiceRecipients;
 
 namespace NHSD.GPIT.BuyingCatalogue.WebApp.Models.Shared.ServiceRecipientModels.ImportServiceRecipients;
 
 public class ValidateNamesModel : NavBaseModel
 {
+    [ExcludeFromCodeCoverage]
     public ValidateNamesModel()
     {
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Models/Shared/ServiceRecipientModels/ImportServiceRecipients/ValidateNamesModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Models/Shared/ServiceRecipientModels/ImportServiceRecipients/ValidateNamesModel.cs
@@ -11,17 +11,12 @@ public class ValidateNamesModel : NavBaseModel
     }
 
     public ValidateNamesModel(
-        IEnumerable<(string Expected, string Actual, string OdsCode)> mismatchedNames,
-        ServiceRecipientImportMode? importMode = null)
+        IEnumerable<(string Expected, string Actual, string OdsCode)> mismatchedNames)
     {
-        ImportMode = importMode;
-
         NameDiscrepancies = mismatchedNames.Select(p => new ServiceRecipientNameDiscrepancy(p.Expected, p.Actual, p.OdsCode)).ToList();
     }
 
     public string CancelLink { get; set; }
-
-    public ServiceRecipientImportMode? ImportMode { get; set; }
 
     public IList<ServiceRecipientNameDiscrepancy> NameDiscrepancies { get; set; }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
@@ -596,73 +596,76 @@
                         }
                     </div>
 
-                    <div style="page-break-after: always"></div>
+                    @if (Model.Order.OrderStatus is OrderStatus.Completed)
+                    {
+                        <div style="page-break-after: always"></div>
 
-                    <div class="nhsuk-grid-row">
-                        <div class="nhsuk-grid-column-full">
-                            <nhs-page-title title="Signatures"
-                                            caption="Order @Model.Order.CallOffId" />
+                        <div class="nhsuk-grid-row">
+                            <div class="nhsuk-grid-column-full">
+                                <nhs-page-title title="Signatures"
+                                                caption="Order @Model.Order.CallOffId"/>
+                            </div>
                         </div>
-                    </div>
-                    <p>Both parties are entering into a Call-off Agreement in accordance with the provisions of the framework being procured from.</p>
-                    <p>The supplier will provide the solution and any services included in this Call-off Order Form for the duration identified. They must do this subject to the Call-off Terms and the information provided in this Call-off Order Form.</p>
-                    <p>No amendments to the Call-off Terms will be valid unless documented in a relevant template. A template will only be valid if it has been attached to this Call-off Order Form prior to it being signed by both parties.</p>
-                    <div class="nhsuk-grid-row">
-                        <div class="nhsuk-grid-column-one-half">
-                            <h4>
-                                On behalf of the buyer
-                                <span class="nhsuk-caption-m nhsuk-caption--bottom">@Model.Order.OrderingParty.Name (@Model.Order.OrderingParty.ExternalIdentifier)</span>
-                            </h4>
+                        <p>Both parties are entering into a Call-off Agreement in accordance with the provisions of the framework being procured from.</p>
+                        <p>The supplier will provide the solution and any services included in this Call-off Order Form for the duration identified. They must do this subject to the Call-off Terms and the information provided in this Call-off Order Form.</p>
+                        <p>No amendments to the Call-off Terms will be valid unless documented in a relevant template. A template will only be valid if it has been attached to this Call-off Order Form prior to it being signed by both parties.</p>
+                        <div class="nhsuk-grid-row">
+                            <div class="nhsuk-grid-column-one-half">
+                                <h4>
+                                    On behalf of the buyer
+                                    <span class="nhsuk-caption-m nhsuk-caption--bottom">@Model.Order.OrderingParty.Name (@Model.Order.OrderingParty.ExternalIdentifier)</span>
+                                </h4>
+                            </div>
+                            <div class="nhsuk-grid-column-one-half">
+                                <h4>
+                                    On behalf of the supplier
+                                    <span class="nhsuk-caption-m nhsuk-caption--bottom">@(Model.Order.Supplier?.Name ?? "")</span>
+                                </h4>
+                            </div>
                         </div>
-                        <div class="nhsuk-grid-column-one-half">
-                            <h4>
-                                On behalf of the supplier
-                                <span class="nhsuk-caption-m nhsuk-caption--bottom">@(Model.Order.Supplier?.Name ?? "")</span>
-                            </h4>
+                        <div class="nhsuk-grid-row">
+                            <div class="nhsuk-grid-column-one-half">
+                                <table>
+                                    <tr class="signature">
+                                        <td>Name:</td>
+                                        <td></td>
+                                    </tr>
+                                    <tr class="signature">
+                                        <td>Job Role:</td>
+                                        <td></td>
+                                    </tr>
+                                    <tr class="signature">
+                                        <td>Signature:</td>
+                                        <td></td>
+                                    </tr>
+                                    <tr class="signature">
+                                        <td>Date:</td>
+                                        <td></td>
+                                    </tr>
+                                </table>
+                            </div>
+                            <div class="nhsuk-grid-column-one-half">
+                                <table>
+                                    <tr class="signature">
+                                        <td>Name:</td>
+                                        <td></td>
+                                    </tr>
+                                    <tr class="signature">
+                                        <td>Job Role:</td>
+                                        <td></td>
+                                    </tr>
+                                    <tr class="signature">
+                                        <td>Signature:</td>
+                                        <td></td>
+                                    </tr>
+                                    <tr class="signature">
+                                        <td>Date:</td>
+                                        <td></td>
+                                    </tr>
+                                </table>
+                            </div>
                         </div>
-                    </div>
-                    <div class="nhsuk-grid-row">
-                        <div class="nhsuk-grid-column-one-half">
-                            <table>
-                                <tr class="signature">
-                                    <td>Name:</td>
-                                    <td></td>
-                                </tr>
-                                <tr class="signature">
-                                    <td>Job Role:</td>
-                                    <td></td>
-                                </tr>
-                                <tr class="signature">
-                                    <td>Signature:</td>
-                                    <td></td>
-                                </tr>
-                                <tr class="signature">
-                                    <td>Date:</td>
-                                    <td></td>
-                                </tr>
-                            </table>
-                        </div>
-                        <div class="nhsuk-grid-column-one-half">
-                            <table>
-                                <tr class="signature">
-                                    <td>Name:</td>
-                                    <td></td>
-                                </tr>
-                                <tr class="signature">
-                                    <td>Job Role:</td>
-                                    <td></td>
-                                </tr>
-                                <tr class="signature">
-                                    <td>Signature:</td>
-                                    <td></td>
-                                </tr>
-                                <tr class="signature">
-                                    <td>Date:</td>
-                                    <td></td>
-                                </tr>
-                            </table>
-                        </div>
-                    </div>
+                    }
                 </div>
             </div>
         </main>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
@@ -615,16 +615,6 @@
                                     On behalf of the buyer
                                     <span class="nhsuk-caption-m nhsuk-caption--bottom">@Model.Order.OrderingParty.Name (@Model.Order.OrderingParty.ExternalIdentifier)</span>
                                 </h4>
-                            </div>
-                            <div class="nhsuk-grid-column-one-half">
-                                <h4>
-                                    On behalf of the supplier
-                                    <span class="nhsuk-caption-m nhsuk-caption--bottom">@(Model.Order.Supplier?.Name ?? "")</span>
-                                </h4>
-                            </div>
-                        </div>
-                        <div class="nhsuk-grid-row">
-                            <div class="nhsuk-grid-column-one-half">
                                 <table>
                                     <tr class="signature">
                                         <td>Name:</td>
@@ -645,6 +635,10 @@
                                 </table>
                             </div>
                             <div class="nhsuk-grid-column-one-half">
+                                <h4>
+                                    On behalf of the supplier
+                                    <span class="nhsuk-caption-m nhsuk-caption--bottom">@(Model.Order.Supplier?.Name ?? "")</span>
+                                </h4>
                                 <table>
                                     <tr class="signature">
                                         <td>Name:</td>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/appsettings.json
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/appsettings.json
@@ -19,11 +19,10 @@
   },
   "orderMessage": {
     "singleCsvTemplateId": "924d9381-790b-40b8-ae56-bbf5c4334d8c",
-    "dualCsvTemplateId": "5d9036f4-0bce-48e0-b15d-95bbc7f506c2",
     "orderTerminatedAdminTemplateId": "dcb9d484-87d5-4759-94f0-5576f285f25c",
-    "userTemplateId": "8bae2d80-19dc-4cb6-b126-3b1a2ee05766",
-    "userAssociatedServiceTemplateId": "bd70f6c0-9ff4-4e07-b6a5-22eaecb92b9a",
-    "userAmendTemplateId": "658998ab-1711-4c5b-87a5-a2b7d401a23e",
+    "userTemplateId": "8cdb558f-c144-4305-ba3f-c4e96d1d7a1d",
+    "userAssociatedServiceTemplateId": "8eb2b283-33ee-483d-9283-db9cc1010a2d",
+    "userAmendTemplateId": "556ebb52-22e6-4b4f-a263-4ffc63bb56ba",
     "orderTerminatedUserTemplateId": "baca8065-b078-449d-9b9b-95820d16e2ff",
     "Recipient": {
       "Address": "test.buying.catalogue@nhs.net"

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Orders/OrderServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Orders/OrderServiceTests.cs
@@ -579,7 +579,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Orders
                 mockPdfService.Object,
                 settings);
 
-            var expectedOrderSummaryLink = NotificationClient.PrepareUpload(pdfData.ToArray());
+            var expectedOrderSummaryPdf = NotificationClient.PrepareUpload(pdfData.ToArray());
             var expectedOrderSummaryCsv = NotificationClient.PrepareUpload(new MemoryStream().ToArray(), true);
 
             await service.CompleteOrder(order.CallOffId, order.OrderingParty.InternalIdentifier, user.Id);
@@ -588,13 +588,15 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Orders
             mockEmailService.VerifyAll();
 
             userTokens.Should().NotBeNull();
-            userTokens.Should().HaveCount(2);
+            userTokens.Should().HaveCount(3);
 
             var orderId = userTokens.Should().ContainKey(OrderService.OrderIdToken).WhoseValue as string;
             var orderSummaryCsv = userTokens.Should().ContainKey(OrderService.OrderSummaryCsv).WhoseValue as JObject;
+            var orderSummaryPdf = userTokens.Should().ContainKey(OrderService.OrderSummaryPdf).WhoseValue as JObject;
 
             orderId.Should().Be($"{order.CallOffId}");
             orderSummaryCsv.Should().BeEquivalentTo(expectedOrderSummaryCsv);
+            orderSummaryPdf.Should().BeEquivalentTo(expectedOrderSummaryPdf);
         }
 
         [Theory]

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Competitions/Controllers/CompetitionImportServiceRecipientsControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Competitions/Controllers/CompetitionImportServiceRecipientsControllerTests.cs
@@ -322,12 +322,12 @@ public static class CompetitionImportServiceRecipientsControllerTests
         [Frozen] Mock<IOdsService> odsService,
         CompetitionImportServiceRecipientsController controller)
     {
-        var importedRecipients = serviceRecipients.Take(2)
+        var recipientIds = serviceRecipients.Take(2)
             .Select(r => new ServiceRecipientImportModel { Organisation = r.Name, OdsCode = r.OrgId, })
             .ToList();
 
         importService.Setup(s => s.GetCached(It.IsAny<ServiceRecipientCacheKey>()))
-            .ReturnsAsync(importedRecipients);
+            .ReturnsAsync(recipientIds);
 
         odsService.Setup(s => s.GetServiceRecipientsByParentInternalIdentifier(internalOrgId))
             .ReturnsAsync(serviceRecipients);
@@ -339,7 +339,7 @@ public static class CompetitionImportServiceRecipientsControllerTests
         odsService.VerifyAll();
 
         result.Should().NotBeNull();
-        result.ActionName.Should().Be(nameof(CompetitionRecipientsController.Index));
+        result.ActionName.Should().Be(nameof(CompetitionRecipientsController.ConfirmRecipients));
         result.ControllerName.Should().Be(typeof(CompetitionRecipientsController).ControllerName());
         result.RouteValues.Should()
             .BeEquivalentTo(
@@ -347,7 +347,8 @@ public static class CompetitionImportServiceRecipientsControllerTests
                 {
                     { nameof(internalOrgId), internalOrgId },
                     { nameof(competitionId), competitionId },
-                    { nameof(importedRecipients), string.Join(',', importedRecipients.Select(s => s.OdsCode)) },
+                    { nameof(recipientIds), string.Join(',', recipientIds.Select(s => s.OdsCode)) },
+                    { "hasImported", true },
                 });
     }
 
@@ -362,12 +363,12 @@ public static class CompetitionImportServiceRecipientsControllerTests
         [Frozen] Mock<IOdsService> odsService,
         CompetitionImportServiceRecipientsController controller)
     {
-        var importedRecipients = serviceRecipients
+        var recipientIds = serviceRecipients
             .Select(r => new ServiceRecipientImportModel { Organisation = r.Name, OdsCode = r.OrgId, })
             .ToList();
 
-        importedRecipients.First().OdsCode = "MISMATCH";
-        importedRecipients.Skip(1).First().Organisation = "MISMATCH";
+        recipientIds.First().OdsCode = "MISMATCH";
+        recipientIds.Skip(1).First().Organisation = "MISMATCH";
 
         var firstServiceRecipient = serviceRecipients.First();
 
@@ -380,7 +381,7 @@ public static class CompetitionImportServiceRecipientsControllerTests
             mismatchedNames);
 
         importService.Setup(s => s.GetCached(It.IsAny<ServiceRecipientCacheKey>()))
-            .ReturnsAsync(importedRecipients);
+            .ReturnsAsync(recipientIds);
 
         competitionsService.Setup(s => s.GetCompetitionName(It.IsAny<string>(), competition.Id))
             .ReturnsAsync(competition.Name);
@@ -395,7 +396,7 @@ public static class CompetitionImportServiceRecipientsControllerTests
         odsService.VerifyAll();
 
         result.Should().NotBeNull();
-        result.ActionName.Should().Be(nameof(CompetitionRecipientsController.Index));
+        result.ActionName.Should().Be(nameof(CompetitionRecipientsController.ConfirmRecipients));
         result.ControllerName.Should().Be(typeof(CompetitionRecipientsController).ControllerName());
         result.RouteValues.Should()
             .BeEquivalentTo(
@@ -403,7 +404,8 @@ public static class CompetitionImportServiceRecipientsControllerTests
                 {
                     { nameof(internalOrgId), internalOrgId },
                     { "competitionId", competition.Id },
-                    { nameof(importedRecipients), string.Join(',', importedRecipients.Skip(1).Select(x => x.OdsCode)) },
+                    { nameof(recipientIds), string.Join(',', recipientIds.Skip(1).Select(x => x.OdsCode)) },
+                    { "hasImported", true },
                 });
     }
 
@@ -421,7 +423,7 @@ public static class CompetitionImportServiceRecipientsControllerTests
         importService.VerifyAll();
 
         result.Should().NotBeNull();
-        result.ActionName.Should().Be(nameof(CompetitionRecipientsController.Index));
+        result.ActionName.Should().Be(nameof(CompetitionRecipientsController.UploadOrSelectServiceRecipients));
         result.ControllerName.Should().Be(typeof(CompetitionRecipientsController).ControllerName());
         result.RouteValues.Should()
             .BeEquivalentTo(

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/OrderControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/OrderControllerTests.cs
@@ -169,15 +169,11 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Orders.Controllers
                 .Setup(s => s.GetOrderForSummary(order.CallOffId, internalOrgId))
                 .ReturnsAsync(new OrderWrapper(order));
 
-            var result = await controller.SummaryComplete(
+            var result = (await controller.SummaryComplete(
                 internalOrgId,
-                order.CallOffId);
+                order.CallOffId)).As<RedirectToActionResult>();
 
-            var modelState = result.Should().BeOfType<ViewResult>().Subject.ViewData.ModelState;
-
-            modelState.ValidationState.Should().Be(ModelValidationState.Invalid);
-            modelState.Keys.First().Should().Be(OrderController.ErrorKey);
-            modelState.Values.First().Errors.First().ErrorMessage.Should().Be(OrderController.ErrorMessage);
+            result.ActionName.Should().Be(nameof(controller.Summary));
         }
 
         [Theory]

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SolutionSelection/ImportServiceRecipientsControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SolutionSelection/ImportServiceRecipientsControllerTests.cs
@@ -352,8 +352,6 @@ public static class ImportServiceRecipientsControllerTests
         [Frozen] Mock<IOdsService> odsService,
         ImportServiceRecipientsController controller)
     {
-        const ServiceRecipientImportMode importMode = ServiceRecipientImportMode.Edit;
-
         var recipientIds = serviceRecipients
             .Select(r => new ServiceRecipientImportModel { Organisation = r.Name, OdsCode = r.OrgId, })
             .ToList();


### PR DESCRIPTION
* Re-introduce Order PDFs to Order Complete email
* Hide signature block from PDF for non-completed orders
* Redirect the user from the Recipient Import to the Confirm Recipients page