### PR TITLE
Bugfix: Update the additional service ID generation

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/CatalogueItemId.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/CatalogueItemId.cs
@@ -107,13 +107,14 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
 
         public CatalogueItemId NextAdditionalServiceId()
         {
-            var catalogueItemId = ItemId[..ItemId.IndexOf('A')];
-            var additionalServiceId = ItemId[(ItemId.IndexOf('A') + 1)..];
+            var itemIdSpan = ItemId.AsSpan();
+            var catalogueItemId = itemIdSpan[..itemIdSpan.IndexOf('A')];
+            var additionalServiceId = itemIdSpan[(itemIdSpan.IndexOf('A') + 1)..];
 
             if (!int.TryParse(additionalServiceId, out var itemId))
                 throw new FormatException();
 
-            var newItemId = $"{catalogueItemId}A{itemId + 1:D2}";
+            var newItemId = $"{catalogueItemId}A{itemId + 1:D3}";
             return new CatalogueItemId(SupplierId, newItemId);
         }
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/ValueGenerators/CatalogueItemIdValueGenerator.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/ValueGenerators/CatalogueItemIdValueGenerator.cs
@@ -20,7 +20,7 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.ValueGenerators
         public override async ValueTask<CatalogueItemId> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default)
         {
             if (entry.Entity is not CatalogueItem catalogueItem)
-                throw new ArgumentException($"Entity must be of type {typeof(CatalogueItem).Name}", nameof(entry));
+                throw new ArgumentException($"Entity must be of type {nameof(CatalogueItem)}", nameof(entry));
 
             if (catalogueItem.Id != default)
                 return catalogueItem.Id;
@@ -35,7 +35,7 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.ValueGenerators
 
             var incrementedCatalogueItemId = catalogueItem.CatalogueItemType switch
             {
-                CatalogueItemType.AdditionalService => (latestCatalogueItem?.Id ?? new CatalogueItemId(catalogueItem.SupplierId, $"{catalogueItem.AdditionalService.SolutionId.ItemId}A00")).NextAdditionalServiceId(),
+                CatalogueItemType.AdditionalService => (latestCatalogueItem?.Id ?? new CatalogueItemId(catalogueItem.SupplierId, $"{catalogueItem.AdditionalService.SolutionId.ItemId}A000")).NextAdditionalServiceId(),
                 CatalogueItemType.AssociatedService => (latestCatalogueItem?.Id ?? new CatalogueItemId(catalogueItem.SupplierId, "S-000")).NextAssociatedServiceId(),
                 CatalogueItemType.Solution or _ => (latestCatalogueItem?.Id ?? new CatalogueItemId(catalogueItem.SupplierId, "000")).NextSolutionId(),
             };

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/ValueGenerators/CatalogueItemIdValueGenerator.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/ValueGenerators/CatalogueItemIdValueGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,6 +18,7 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.ValueGenerators
         public override CatalogueItemId Next(EntityEntry entry)
             => NextAsync(entry).AsTask().GetAwaiter().GetResult();
 
+        [ExcludeFromCodeCoverage(Justification = "Not all code paths can be tested due to a reliance on internal Microsoft APIs")]
         public override async ValueTask<CatalogueItemId> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default)
         {
             if (entry.Entity is not CatalogueItem catalogueItem)

--- a/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/ValueGenerators/CatalogueItemIdValueGeneratorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/ValueGenerators/CatalogueItemIdValueGeneratorTests.cs
@@ -68,7 +68,7 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests.ValueGenerators
 
             var additionalService = AddAdditionalService(supplier, solution, context);
 
-            additionalService.Id.Should().Be(new CatalogueItemId(additionalService.SupplierId, $"{solution.Id.ItemId}A01"));
+            additionalService.Id.Should().Be(new CatalogueItemId(additionalService.SupplierId, $"{solution.Id.ItemId}A001"));
         }
 
         [Theory]
@@ -87,8 +87,8 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests.ValueGenerators
             var firstAdditionalService = AddAdditionalService(firstSupplier, firstSolution, context);
             var secondAdditionalService = AddAdditionalService(secondSupplier, secondSolution, context);
 
-            firstAdditionalService.Id.Should().Be(new CatalogueItemId(firstAdditionalService.SupplierId, $"{firstSolution.Id.ItemId}A01"));
-            secondAdditionalService.Id.Should().Be(new CatalogueItemId(secondAdditionalService.SupplierId, $"{secondSolution.Id.ItemId}A01"));
+            firstAdditionalService.Id.Should().Be(new CatalogueItemId(firstAdditionalService.SupplierId, $"{firstSolution.Id.ItemId}A001"));
+            secondAdditionalService.Id.Should().Be(new CatalogueItemId(secondAdditionalService.SupplierId, $"{secondSolution.Id.ItemId}A001"));
         }
 
         [Theory]
@@ -106,8 +106,8 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests.ValueGenerators
             var firstAdditionalService = AddAdditionalService(supplier, firstSolution, context);
             var secondAdditionalService = AddAdditionalService(supplier, secondSolution, context);
 
-            firstAdditionalService.Id.Should().Be(new CatalogueItemId(firstAdditionalService.SupplierId, $"{firstSolution.Id.ItemId}A01"));
-            secondAdditionalService.Id.Should().Be(new CatalogueItemId(secondAdditionalService.SupplierId, $"{secondSolution.Id.ItemId}A01"));
+            firstAdditionalService.Id.Should().Be(new CatalogueItemId(firstAdditionalService.SupplierId, $"{firstSolution.Id.ItemId}A001"));
+            secondAdditionalService.Id.Should().Be(new CatalogueItemId(secondAdditionalService.SupplierId, $"{secondSolution.Id.ItemId}A001"));
         }
 
         [Theory]
@@ -124,8 +124,8 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests.ValueGenerators
             var firstAdditionalService = AddAdditionalService(supplier, solution, context);
             var secondAdditionalService = AddAdditionalService(supplier, solution, context);
 
-            firstAdditionalService.Id.Should().Be(new CatalogueItemId(firstAdditionalService.SupplierId, $"{solution.Id.ItemId}A01"));
-            secondAdditionalService.Id.Should().Be(new CatalogueItemId(secondAdditionalService.SupplierId, $"{solution.Id.ItemId}A02"));
+            firstAdditionalService.Id.Should().Be(new CatalogueItemId(firstAdditionalService.SupplierId, $"{solution.Id.ItemId}A001"));
+            secondAdditionalService.Id.Should().Be(new CatalogueItemId(secondAdditionalService.SupplierId, $"{solution.Id.ItemId}A002"));
         }
 
         [Theory]


### PR DESCRIPTION
Additional Services should have a 3 digit ID whereas currently there are a handful of services in live that have 1 alphanumeric and 2 digits.

Remains as a draft for now as I need to prepare a SQL post deploy script that'll repair the invalid IDs