### PR TITLE
The .nhsuk-icon styles need to be different for buttons and the suggestion search

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/wwwroot/scss/_custom.scss
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/wwwroot/scss/_custom.scss
@@ -29,8 +29,14 @@
   padding-top: 8px;
 }
 
-.suggestion-search-search__submit .nhsuk-icon,
 .nhsuk-button .nhsuk-icon {
+    fill: #ffffff;
+    height: 28px;
+    width: 28px;
+    float: left;
+}
+
+.suggestion-search-search__submit .nhsuk-icon {
     fill: #ffffff;
     height: 38px;
     width: 38px;


### PR DESCRIPTION
Fix styling regression. 

Restores the previous styling for `.nhsuk-button .nhsuk-icon`
![image](https://github.com/nhs-digital-gp-it-futures/GPITBuyingCatalogue/assets/63051516/f4b04e87-9169-4496-9a77-fbb4dd5db19b)

And apply the new styling just to `.suggestion-search-search__submit .nhsuk-icon`
![image](https://github.com/nhs-digital-gp-it-futures/GPITBuyingCatalogue/assets/63051516/895c8314-697e-449d-bfce-5f46578e58f8)
