### PR TITLE
Feature/23404 Manually input Catalogue Item ID

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Models/CreateSolutionModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Models/CreateSolutionModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 
 namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models
 {
@@ -13,5 +14,7 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models
         public bool IsPilotSolution { get; set; }
 
         public int UserId { get; set; }
+
+        public CatalogueItemId Id { get; set; }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Solutions/ISolutionsService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Solutions/ISolutionsService.cs
@@ -10,6 +10,8 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions
 {
     public interface ISolutionsService
     {
+        Task<CatalogueItem> GetSolution(CatalogueItemId solutionId);
+
         Task<CatalogueItem> GetSolutionThin(CatalogueItemId solutionId);
 
         Task<CatalogueItem> GetSolutionWithBasicInformation(CatalogueItemId solutionId);

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Solutions/SolutionsService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Solutions/SolutionsService.cs
@@ -26,6 +26,10 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Solutions
             this.dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         }
 
+        public Task<CatalogueItem> GetSolution(CatalogueItemId solutionId) =>
+            dbContext.CatalogueItems.AsNoTracking()
+                .FirstOrDefaultAsync(ci => ci.Id == solutionId);
+
         public Task<CatalogueItem> GetSolutionThin(CatalogueItemId solutionId) =>
             dbContext.CatalogueItems.AsNoTracking()
             .Include(ci => ci.Supplier)
@@ -507,6 +511,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Solutions
 
             var catalogueItem = new CatalogueItem
             {
+                Id = model.Id,
                 CatalogueItemType = CatalogueItemType.Solution,
                 Solution =
                         new Solution

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AddCatalogueSolutionController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/AddCatalogueSolutionController.cs
@@ -55,6 +55,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
 
             var catalogueItemId = await solutionsService.AddCatalogueSolution(new CreateSolutionModel
             {
+                Id = model.SolutionId.GetValueOrDefault(),
                 Frameworks = model.Frameworks,
                 Name = model.SolutionName,
                 SupplierId = model.SupplierId!.Value,

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/CatalogueSolutionsModels/SolutionModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/CatalogueSolutionsModels/SolutionModel.cs
@@ -16,14 +16,32 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.CatalogueSolutions
 
         public SolutionModel(CatalogueItem catalogueItem)
         {
-            SolutionId = catalogueItem.Id;
+            SolutionIdDisplay = catalogueItem.Id.ToString();
             SupplierId = catalogueItem.SupplierId;
             SolutionName = catalogueItem.Name;
             SolutionDisplayName = catalogueItem.Name;
             IsPilotSolution = catalogueItem.Solution.IsPilotSolution;
+            IsEdit = true;
         }
 
-        public CatalogueItemId? SolutionId { get; set; }
+        public bool IsEdit { get; set; }
+
+        public string SolutionIdDisplay { get; set; }
+
+        public CatalogueItemId? SolutionId
+        {
+            get
+            {
+                try
+                {
+                    return CatalogueItemId.ParseExact(SolutionIdDisplay);
+                }
+                catch
+                {
+                    return default;
+                }
+            }
+        }
 
         public string SolutionName { get; set; }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Validators/SolutionModelValidator.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Validators/SolutionModelValidator.cs
@@ -12,7 +12,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Validators
         public const string SolutionIdSupplierMismatchErrorMessage = "The supplier ID does not match the supplier you’ve selected";
         public const string DuplicateSolutionIdErrorMessage = "A solution with that ID already exists. Try a different ID";
         public const string SolutionIdFormatErrorMessage = "Solution ID must be in the correct format, for example 10000-001";
-
+        public const int MaxItemIdLength = 3;
         private readonly ISolutionsService solutionsService;
 
         public SolutionModelValidator(
@@ -39,6 +39,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Validators
 
             RuleFor(s => s.SolutionId)
                 .NotNull()
+                .WithMessage(SolutionIdFormatErrorMessage)
+                .Must(x => x.GetValueOrDefault().ItemId.Length <= MaxItemIdLength)
                 .WithMessage(SolutionIdFormatErrorMessage)
                 .Must((model, id) => model.SupplierId == id.GetValueOrDefault().SupplierId)
                 .WithMessage(SolutionIdSupplierMismatchErrorMessage)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/Details.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/Details.cshtml
@@ -18,14 +18,36 @@
             <input type="hidden" asp-for="BackLinkText" />
             <input type="hidden" asp-for="Heading" />
             <input type="hidden" asp-for="Description" />
-            <input type="hidden" asp-for="SolutionId" />
+            
+            @if(Model.IsEdit)
+            {
+                <nhs-summary-list>
+                    <nhs-summary-list-row label-text="Supplier name and ID">
+                        <p>
+                            @Model.SupplierId
+                        </p>
+                    </nhs-summary-list-row>
+                    <nhs-summary-list-row label-text="Solution ID">
+                        <p>
+                            @Model.SolutionIdDisplay
+                        </p>
+                    </nhs-summary-list-row>
+                </nhs-summary-list>
+            }
+            else
+            {
+                <nhs-select asp-for="SupplierId"
+                            asp-items="@Model.SuppliersSelectList"
+                            label-text="Supplier name and ID" />
+                
+                <nhs-input asp-for="SolutionIdDisplay"
+                           label-hint="Solution IDs are made up of the supplier ID and a 3-digit number unique to this solution, for example, 10000-001."
+                           label-text="Solution ID" />
+            }
+            
             <input type="hidden" asp-for="SolutionDisplayName" />
             <nhs-input asp-for="SolutionName"
                        label-text="Solution name" />
-
-            <nhs-select asp-for="SupplierId"
-                        asp-items="@Model.SuppliersSelectList"
-                        label-text="Supplier name" />
 
             <nhs-fieldset-form-label asp-for="@Model"
                                      label-text="Frameworks"

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/CatalogueSolutionsControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/CatalogueSolutionsControllerTests.cs
@@ -454,7 +454,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             var expected = new SolutionModel
             {
                 Frameworks = new List<FrameworkModel> { frameworkModel },
-                SolutionId = solutionId,
+                SolutionIdDisplay = solution.ToString(),
             };
 
             catalogueItem.Id = solutionId;

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Validators/SolutionModelValidatorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Validators/SolutionModelValidatorTests.cs
@@ -2,6 +2,7 @@
 using AutoFixture.Xunit2;
 using FluentValidation.TestHelper;
 using Moq;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Models;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions;
 using NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.AutoFixtureCustomisations;
@@ -103,7 +104,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Validators
             SolutionModel model,
             SolutionModelValidator validator)
         {
-            model.SolutionId = null;
+            model.SolutionIdDisplay = null;
 
             mockSolutionsService.Setup(s => s.CatalogueSolutionExistsWithName(model.SolutionName, default))
                 .ReturnsAsync(true);


### PR DESCRIPTION
Using string display parameter to allow binding and prevent default invalid type Error messages. Then validate against CatalogueItemId. Potentially investigate Custom Model Binding as an alternative.