### PR TITLE
Bug: Null Service name when validator is called during Solutions & Services -> Remove Service journey

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/CatalogueItems/ICatalogueItemService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/CatalogueItems/ICatalogueItemService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 
 namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.CatalogueItems;
@@ -6,4 +7,6 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.CatalogueItems;
 public interface ICatalogueItemService
 {
     Task<string> GetCatalogueItemName(CatalogueItemId catalogueItemId);
+
+    Task<CatalogueItem> GetCatalogueItem(CatalogueItemId catalogueItemId);
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/CatalogueItems/CatalogueItemService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/CatalogueItems/CatalogueItemService.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.CatalogueItems;
 
@@ -18,4 +19,7 @@ public class CatalogueItemService : ICatalogueItemService
 
     public async Task<string> GetCatalogueItemName(CatalogueItemId catalogueItemId)
         => (await dbContext.CatalogueItems.FirstOrDefaultAsync(x => x.Id == catalogueItemId))?.Name;
+
+    public async Task<CatalogueItem> GetCatalogueItem(CatalogueItemId catalogueItemId)
+        => await dbContext.CatalogueItems.AsNoTracking().FirstOrDefaultAsync(x => x.Id == catalogueItemId);
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/SolutionSelection/CatalogueSolutionsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/SolutionSelection/CatalogueSolutionsController.cs
@@ -8,6 +8,7 @@ using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.AdditionalServices;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.CatalogueItems;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Contracts;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Routing;
@@ -25,6 +26,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.SolutionSele
         private const string SelectViewName = "SelectSolution";
 
         private readonly IAdditionalServicesService additionalServicesService;
+        private readonly ICatalogueItemService catalogueItemService;
         private readonly IOrderItemService orderItemService;
         private readonly IOrderService orderService;
         private readonly ISolutionsService solutionsService;
@@ -32,12 +34,15 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.SolutionSele
 
         public CatalogueSolutionsController(
             IAdditionalServicesService additionalServicesService,
+            ICatalogueItemService catalogueItemService,
             IOrderItemService orderItemService,
             IOrderService orderService,
             ISolutionsService solutionsService,
             IContractsService contractsService)
         {
             this.additionalServicesService = additionalServicesService ?? throw new ArgumentNullException(nameof(additionalServicesService));
+            this.catalogueItemService =
+                catalogueItemService ?? throw new ArgumentNullException(nameof(catalogueItemService));
             this.orderItemService = orderItemService ?? throw new ArgumentNullException(nameof(orderItemService));
             this.orderService = orderService ?? throw new ArgumentNullException(nameof(orderService));
             this.solutionsService = solutionsService ?? throw new ArgumentNullException(nameof(solutionsService));
@@ -175,11 +180,11 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.SolutionSele
 
             if (solution.CatalogueItemId == catalogueItemId)
             {
-            return RedirectToAction(
-                nameof(TaskListController.TaskList),
-                typeof(TaskListController).ControllerName(),
-                new { internalOrgId, callOffId });
-        }
+                return RedirectToAction(
+                    nameof(TaskListController.TaskList),
+                    typeof(TaskListController).ControllerName(),
+                    new { internalOrgId, callOffId });
+            }
 
             return RedirectToAction(
                 nameof(ConfirmSolutionChanges),
@@ -388,10 +393,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.SolutionSele
                 new { internalOrgId, callOffId, source = RoutingSource.EditSolution });
         }
 
-        [HttpGet("remove-service")]
+        [HttpGet("remove-service/{catalogueItemId}")]
         public async Task<IActionResult> RemoveService(string internalOrgId, CallOffId callOffId, CatalogueItemId catalogueItemId)
         {
-            var service = await solutionsService.GetSolutionThin(catalogueItemId);
+            var service = await catalogueItemService.GetCatalogueItem(catalogueItemId);
             var model = new RemoveServiceModel(service)
             {
                 BackLink = Url.Action(
@@ -403,7 +408,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.SolutionSele
             return View(model);
         }
 
-        [HttpPost("remove-service")]
+        [HttpPost("remove-service/{catalogueItemId}")]
         public async Task<IActionResult> RemoveService(string internalOrgId, CallOffId callOffId, CatalogueItemId catalogueItemId, RemoveServiceModel model)
         {
             if (!ModelState.IsValid)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Validators/SolutionSelection/RemoveService/RemoveServiceModelValidator.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Validators/SolutionSelection/RemoveService/RemoveServiceModelValidator.cs
@@ -1,7 +1,7 @@
 ﻿using FluentValidation;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.Shared;
 
-namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Validators.SolutionSelection.CatalogueSolutions
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Validators.SolutionSelection.RemoveService
 {
     public class RemoveServiceModelValidator : AbstractValidator<RemoveServiceModel>
     {
@@ -10,7 +10,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Validators.SolutionSelec
         public RemoveServiceModelValidator()
         {
             RuleFor(x => x.ConfirmRemoveService)
-                .NotEmpty()
+                .Must(x => x.HasValue)
                 .WithMessage(x => string.Format(NoSelectionMadeErrorMessage, x.ServiceName));
         }
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Shared/RemoveService.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Shared/RemoveService.cshtml
@@ -10,7 +10,7 @@
 
 <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
-        <nhs-validation-summary RadioId="RemoveServiceConfirmation" />
+        <nhs-validation-summary RadioId="ConfirmRemoveService" />
         <nhs-page-title title="@ViewBag.Title"
                         caption="@Model.ServiceName"
                         advice="Confirm you want to remove this @Model.ServiceType from your order." />
@@ -23,7 +23,7 @@
             <input type="hidden" asp-for="@Model.ServiceName" />
             <input type="hidden" asp-for="@Model.ServiceType" />
             <input type="hidden" asp-for="BackLink" />
-            <nhs-fieldset-form-label asp-for="ConfirmRemoveService" label-text="Remove @Model.ServiceName">
+            <nhs-fieldset-form-label asp-for="@Model" label-text="Remove @Model.ServiceName">
                 <nhs-radio-buttons asp-for="ConfirmRemoveService"
                                    values="@Model.RemoveServiceOptions.Cast<object>()"
                                    value-name="Value"

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/TaskList/TaskList.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/TaskList/TaskList.cshtml
@@ -61,7 +61,7 @@
                                 <img src="~/images/circle-info-solid.svg" aria-hidden="true" width="20px"/><p>You cannot change your Catalogue Solution when amending an order.</p>
                             }
                         </nhs-card-footer>
-                        
+
                     </nhs-card-v2>
                 }
             </div>
@@ -85,7 +85,7 @@
                                     {
                                         <vc:nhs-delete-button url="@Url.Action(nameof(CatalogueSolutionsController.RemoveService),
                                                                             typeof(CatalogueSolutionsController).ControllerName(),
-                                                                            new { Model.InternalOrgId, Model.CallOffId, service.CatalogueItemId })"
+                                                                            new { Model.InternalOrgId, Model.CallOffId, catalogueItemId = service.CatalogueItemId })"
                                         text="Remove @service.CatalogueItem.Name" />
                                         <hr class="nhsuk-section-break nhsuk-section-break--m nhsuk-section-break--visible">
                                     }
@@ -128,7 +128,7 @@
             </div>
         }
 
-        
+
         <div id="AssociatedServiceDetails" class="nhsuk-u-margin-bottom-9">
             <h2>Associated Services</h2>
 
@@ -169,7 +169,7 @@
                             <p>No Associated Services have been added to this order yet.</p>
                         }
                     </nhs-card-content>
-                    
+
                     @if (!Model.OrderType.MergerOrSplit)
                     {
                         <nhs-card-footer>
@@ -194,7 +194,7 @@
                             }
                         </nhs-card-footer>
                     }
-                }                
+                }
             </nhs-card-v2>
         </div>
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/CatalogueItems/CatalogueItemServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/CatalogueItems/CatalogueItemServiceTests.cs
@@ -1,0 +1,61 @@
+﻿using System.Threading.Tasks;
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using AutoFixture.Idioms;
+using AutoFixture.Xunit2;
+using FluentAssertions;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+using NHSD.GPIT.BuyingCatalogue.Services.CatalogueItems;
+using NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.AutoFixtureCustomisations;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.CatalogueItems;
+
+public static class CatalogueItemServiceTests
+{
+    [Fact]
+    public static void Constructors_VerifyGuardClauses()
+    {
+        var fixture = new Fixture().Customize(new AutoMoqCustomization());
+        var assertion = new GuardClauseAssertion(fixture);
+        var constructors = typeof(CatalogueItemService).GetConstructors();
+
+        assertion.Verify(constructors);
+    }
+
+    [Theory]
+    [InMemoryDbAutoData]
+    public static async Task GetCatalogueItemName_ReturnsCatalogueItemName(
+        CatalogueItem catalogueItem,
+        [Frozen] BuyingCatalogueDbContext context,
+        CatalogueItemService service)
+    {
+        context.CatalogueItems.Add(catalogueItem);
+
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+
+        var catalogueItemName = await service.GetCatalogueItemName(catalogueItem.Id);
+
+        catalogueItemName.Should().Be(catalogueItem.Name);
+    }
+
+    [Theory]
+    [InMemoryDbAutoData]
+    public static async Task GetCatalogueItem_ReturnsCatalogueItem(
+        CatalogueItem catalogueItem,
+        [Frozen] BuyingCatalogueDbContext context,
+        CatalogueItemService service)
+    {
+        context.CatalogueItems.Add(catalogueItem);
+
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+
+        var result = await service.GetCatalogueItem(catalogueItem.Id);
+
+        result.Id.Should().Be(catalogueItem.Id);
+        result.Name.Should().Be(catalogueItem.Name);
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/SolutionSelection/RemoveService/RemoveServiceModelValidatorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/SolutionSelection/RemoveService/RemoveServiceModelValidatorTests.cs
@@ -3,6 +3,7 @@ using NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.AutoFixtureCustomisations;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.AssociatedServices;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.Shared;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Validators.SolutionSelection.CatalogueSolutions;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Validators.SolutionSelection.RemoveService;
 using Xunit;
 
 namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Validators.SolutionSelection.RemoveService


### PR DESCRIPTION
There seems to be a quirk of FluentValidation and TagBuilders which means that validators are being called on GET operations which result in an exception where any model data is expected to be not null in the validator

Rather than using `NotNull`, a `Must` for `HasValue` on a nullable boolean prevents the validator from attempting to construct a message at the wrong time.

We'll need to look into why the validators are being called. I've tracked it down to `GenerateRadioButton` which is when the validator is then called. Potentially a quirk of ASP.NET Core