### PR TITLE
OrderWrapper is only valid when the requested order revision exists.

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/OrderWrapper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Orders/OrderWrapper.cs
@@ -18,6 +18,7 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders
             rolledUpLazy = new Lazy<Order>((Order)null);
         }
 
+        [Obsolete("Only used in tests - we should look to remove this")]
         public OrderWrapper(Order order)
         {
             Order = order;
@@ -92,6 +93,22 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders
         public Order Previous => previousLazy.Value;
 
         public Order RolledUp => rolledUpLazy.Value;
+
+        public static OrderWrapper Create(IEnumerable<Order> orders, CallOffId requestedCallOffId)
+        {
+            var wrapper = new OrderWrapper(orders);
+            if (wrapper.Order == null)
+            {
+                throw new InvalidOperationException($"Order not found {requestedCallOffId}");
+            }
+
+            if (wrapper.Order.CallOffId != requestedCallOffId)
+            {
+                throw new InvalidOperationException($"Latest order does not match {requestedCallOffId}");
+            }
+
+            return wrapper;
+        }
 
         public IEnumerable<string> AddedRecipientsOdsCodes()
         {

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/OrderService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Orders/OrderService.cs
@@ -83,7 +83,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
                     && o.OrderingParty.InternalIdentifier == internalOrgId)
                 .ToListAsync();
 
-            return new OrderWrapper(orders);
+            return OrderWrapper.Create(orders, callOffId);
         }
 
         public async Task<OrderWrapper> GetOrderWithCatalogueItemAndPrices(CallOffId callOffId, string internalOrgId)
@@ -107,7 +107,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
                     && o.OrderingParty.InternalIdentifier == internalOrgId)
                 .ToListAsync();
 
-            return new OrderWrapper(orders);
+            return OrderWrapper.Create(orders, callOffId);
         }
 
         public async Task<OrderWrapper> GetOrderWithOrderItems(CallOffId callOffId, string internalOrgId)
@@ -132,7 +132,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
                     && o.OrderingParty.InternalIdentifier == internalOrgId)
                 .ToListAsync();
 
-            return new OrderWrapper(orders);
+            return OrderWrapper.Create(orders, callOffId);
         }
 
         public async Task<OrderWrapper> GetOrderWithOrderItemsForFunding(CallOffId callOffId, string internalOrgId)
@@ -157,7 +157,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
                     && o.OrderingParty.InternalIdentifier == internalOrgId)
                 .ToListAsync();
 
-            return new OrderWrapper(orders);
+            return OrderWrapper.Create(orders, callOffId);
         }
 
         public async Task<OrderWrapper> GetOrderWithSupplier(CallOffId callOffId, string internalOrgId)
@@ -170,7 +170,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
                     && o.OrderingParty.InternalIdentifier == internalOrgId)
                 .ToListAsync();
 
-            return new OrderWrapper(orders);
+            return OrderWrapper.Create(orders, callOffId);
         }
 
         [ExcludeFromCodeCoverage(Justification = "Method uses Temporal tables which the In-Memory provider doesn't support.")]
@@ -206,7 +206,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
                 }
             }
 
-            return new OrderWrapper(orders);
+            return OrderWrapper.Create(orders, callOffId);
         }
 
         public async Task<OrderWrapper> GetOrderForTaskListStatuses(CallOffId callOffId, string internalOrgId)
@@ -238,7 +238,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
                     && x.OrderingParty.InternalIdentifier == internalOrgId)
                 .ToListAsync();
 
-            return new OrderWrapper(orders);
+            return OrderWrapper.Create(orders, callOffId);
         }
 
         public async Task<List<Order>> GetOrders(int organisationId)
@@ -344,7 +344,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
 
         public async Task<Order> AmendOrder(string internalOrgId, CallOffId callOffId)
         {
-            var orderWrapper = new OrderWrapper(await OrdersForSummary(callOffId, internalOrgId));
+            var orderWrapper = OrderWrapper.Create(await OrdersForSummary(callOffId, internalOrgId), callOffId);
             var order = orderWrapper.Order;
 
             var amendment = order.BuildAmendment(await dbContext.NextRevision(order.OrderNumber));
@@ -499,7 +499,9 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Orders
             order.IsTerminated = true;
             order.OrderTermination = new OrderTermination()
             {
-                OrderId = order.Id, DateOfTermination = dateOfTermination, Reason = reason,
+                OrderId = order.Id,
+                DateOfTermination = dateOfTermination,
+                Reason = reason,
             };
         }
 


### PR DESCRIPTION
The current behaviour, if you tamper with the url to an order (as in order number) that doesn't exist, means that you will most likely see the standard error screen.

![image](https://github.com/nhs-digital-gp-it-futures/GPITBuyingCatalogue/assets/63051516/97101625-def5-42d4-9d94-cebb5e22e826)

This PR changes how `OrderWrapper` is used so that we have the same behaviour if you tamper with the url to an order revision that doesn't exist. The `OrderWrapper` is only valid when the requested order revision exists.