### PR TITLE
Add robots.txt file

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/wwwroot/robots.txt
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/wwwroot/robots.txt
@@ -1,0 +1,4 @@
+User-Agent: *
+Allow: /$
+Allow: /catalogue-solutions
+Disallow: /


### PR DESCRIPTION
Allows scraping of the home page and Browse Catalogue Solutions pages/sub-pages.

Disallows scraping of all other pages/URLs.