### PR TITLE
Styling bugfix and flaky test fix

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/Layouts/_PlainHeaderLayout.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/Layouts/_PlainHeaderLayout.cshtml
@@ -6,6 +6,17 @@
 <html lang="en">
 <head>
     <partial name="Partials/_HeadIncludes" />
+
+    <style>
+        @@media (max-width: 40.0525em) {
+            .nhsuk-header__container {
+                padding-bottom: 20px;
+                border-bottom: 1px solid rgba(255, 255, 255, .2);
+                display: flex;
+                justify-content: space-between;
+            }
+        }
+    </style>
 </head>
 <body>
     <a class="nhsuk-skip-link" href="#maincontent">Skip to main content</a>

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Orders/SupplierServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Orders/SupplierServiceTests.cs
@@ -391,7 +391,12 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Orders
             var associatedService = associatedServices.First();
             var supplier = suppliers.First();
 
-            solution.CatalogueItem.SupplierServiceAssociations.Add(new(solution.CatalogueItemId, associatedService.CatalogueItemId));
+            solution.CatalogueItem.SupplierServiceAssociations =
+                new List<SupplierServiceAssociation>
+                {
+                    new(solution.CatalogueItemId, associatedService.CatalogueItemId),
+                };
+
             solution.CatalogueItem.Supplier = supplier;
             associatedService.CatalogueItem.Supplier = supplier;
             associatedService.PracticeReorganisationType = orderType.ToPracticeReorganisationType;


### PR DESCRIPTION
Fixes the following responsiveness issue on the login page

On the left is the current live system, following the recent frontend library update. On the right is the custom style applied to the PlainHeader layout.
![image](https://github.com/user-attachments/assets/cf66a3aa-a424-4165-877d-eb947f8f5d97)

Additionally fixes (hopefully) a flaky test that intermittently fails