### PR TITLE
Terraform: Add DNS resource

### DIFF
--- a/NHSD.GPIT.BuyingCatalogue.sln
+++ b/NHSD.GPIT.BuyingCatalogue.sln
@@ -47,51 +47,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NHSD.GPIT.BuyingCatalogue.U
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests", "tests\NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests\NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests.csproj", "{0BBE4303-14C5-47A5-8BF3-EEA63AF819B3}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "terraform", "terraform", "{E9D972A0-C13A-445B-A3B0-F6DBE3F0A84D}"
-	ProjectSection(SolutionItems) = preProject
-		terraform\.terraform.lock.hcl = terraform\.terraform.lock.hcl
-		terraform\locals.tf = terraform\locals.tf
-		terraform\main.tf = terraform\main.tf
-		terraform\output.tf = terraform\output.tf
-		terraform\resource_groups.tf = terraform\resource_groups.tf
-		terraform\sql_dbs.tf = terraform\sql_dbs.tf
-		terraform\variables.tf = terraform\variables.tf
-		terraform\webapp.tf = terraform\webapp.tf
-		terraform\webapp_bindings.tf = terraform\webapp_bindings.tf
-		terraform\z_imported_secrets.tf = terraform\z_imported_secrets.tf
-		terraform\z_imported_secrets_core.tf = terraform\z_imported_secrets_core.tf
-	EndProjectSection
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "modules", "modules", "{635A7165-F71B-4806-8DE4-2B2CF246F12A}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "bc_sql_dbs_webapp", "bc_sql_dbs_webapp", "{FBF6B284-D5E7-4690-B04B-86B0106915BC}"
-	ProjectSection(SolutionItems) = preProject
-		terraform\modules\bc_sql_dbs_webapp\main.tf = terraform\modules\bc_sql_dbs_webapp\main.tf
-		terraform\modules\bc_sql_dbs_webapp\output.tf = terraform\modules\bc_sql_dbs_webapp\output.tf
-		terraform\modules\bc_sql_dbs_webapp\variables.tf = terraform\modules\bc_sql_dbs_webapp\variables.tf
-	EndProjectSection
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "bc_storage_account", "bc_storage_account", "{69A02FB9-73B1-408E-8015-E246775F6698}"
-	ProjectSection(SolutionItems) = preProject
-		terraform\modules\bc_storage_account\main.tf = terraform\modules\bc_storage_account\main.tf
-		terraform\modules\bc_storage_account\output.tf = terraform\modules\bc_storage_account\output.tf
-		terraform\modules\bc_storage_account\storage_containers.tf = terraform\modules\bc_storage_account\storage_containers.tf
-		terraform\modules\bc_storage_account\storage_network_rules.tf = terraform\modules\bc_storage_account\storage_network_rules.tf
-		terraform\modules\bc_storage_account\storage_secrets.tf = terraform\modules\bc_storage_account\storage_secrets.tf
-		terraform\modules\bc_storage_account\variables.tf = terraform\modules\bc_storage_account\variables.tf
-	EndProjectSection
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "bc_webapp_pri", "bc_webapp_pri", "{5E0DEF34-769A-41AD-BC53-9B42B536CE45}"
-	ProjectSection(SolutionItems) = preProject
-		terraform\modules\bc_webapp_pri\import_acr.tf = terraform\modules\bc_webapp_pri\import_acr.tf
-		terraform\modules\bc_webapp_pri\import_sql.tf = terraform\modules\bc_webapp_pri\import_sql.tf
-		terraform\modules\bc_webapp_pri\keyvault_access.tf = terraform\modules\bc_webapp_pri\keyvault_access.tf
-		terraform\modules\bc_webapp_pri\main.tf = terraform\modules\bc_webapp_pri\main.tf
-		terraform\modules\bc_webapp_pri\output.tf = terraform\modules\bc_webapp_pri\output.tf
-		terraform\modules\bc_webapp_pri\variables.tf = terraform\modules\bc_webapp_pri\variables.tf
-		terraform\modules\bc_webapp_pri\z_imported_secrets_core.tf = terraform\modules\bc_webapp_pri\z_imported_secrets_core.tf
-	EndProjectSection
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Dictionaries", "Dictionaries", "{9874F3E6-3B8A-4D8A-83B8-64DEBBAE7A5A}"
 	ProjectSection(SolutionItems) = preProject
 		Dictionaries\en_GB-large.aff = Dictionaries\en_GB-large.aff
@@ -198,10 +153,6 @@ Global
 		{8605DC87-313F-4238-9617-604151EEBE82} = {D1172DF2-850A-4CCD-949F-8CB9AE7A2DE8}
 		{C518EAC3-32B1-4F6C-BA6D-AAC887A649EB} = {D1172DF2-850A-4CCD-949F-8CB9AE7A2DE8}
 		{0BBE4303-14C5-47A5-8BF3-EEA63AF819B3} = {D1172DF2-850A-4CCD-949F-8CB9AE7A2DE8}
-		{635A7165-F71B-4806-8DE4-2B2CF246F12A} = {E9D972A0-C13A-445B-A3B0-F6DBE3F0A84D}
-		{FBF6B284-D5E7-4690-B04B-86B0106915BC} = {635A7165-F71B-4806-8DE4-2B2CF246F12A}
-		{69A02FB9-73B1-408E-8015-E246775F6698} = {635A7165-F71B-4806-8DE4-2B2CF246F12A}
-		{5E0DEF34-769A-41AD-BC53-9B42B536CE45} = {635A7165-F71B-4806-8DE4-2B2CF246F12A}
 		{C0E6F77D-A380-4196-B4B8-C859092393DC} = {885B7CFA-DB1B-4D95-9943-CDDDDCBED5A3}
 		{ADE6425F-36C9-4183-81EF-BB1A186F2D7B} = {885B7CFA-DB1B-4D95-9943-CDDDDCBED5A3}
 		{0A9411BA-8BEC-4472-B21E-79077727F99E} = {D1172DF2-850A-4CCD-949F-8CB9AE7A2DE8}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,14 +172,10 @@ jobs:
       vmImage: 'ubuntu-latest'
 
     steps:
-      - task: CopyFiles@2
-        displayName: Build Artifact - Terraform
-        inputs:
-          SourceFolder: 'terraform/webapp'
-          Contents: '**'
-          TargetFolder: '$(build.artifactStagingDirectory)/terraform/webapp'
-          CleanTargetFolder: false
-          OverWrite: true
-
-      - publish: $(build.artifactStagingDirectory)/terraform/webapp
+      - publish: terraform/webapp
+        displayName: Publish Terraform - WebApp
         artifact: build-artifact
+
+      - publish: terraform/core
+        displayName: Publish Terraform - Core
+        artifact: core-terraform

--- a/terraform/core/main.tf
+++ b/terraform/core/main.tf
@@ -1,0 +1,11 @@
+resource "azurerm_resource_group" "general" {
+  name     = "${var.project}-${var.environment}-core-rg"
+  location = "uksouth"
+}
+
+module "global-dns" {
+  source              = "./modules/dns"
+  domain_name         = var.domain_name
+  environment         = var.environment
+  resource_group_name = azurerm_resource_group.general.name
+}

--- a/terraform/core/modules/dns/main.tf
+++ b/terraform/core/modules/dns/main.tf
@@ -1,0 +1,7 @@
+resource "azurerm_dns_zone" "dns-zone" {
+  name                = var.domain_name
+  resource_group_name = var.resource_group_name
+  tags = {
+    environment = var.environment
+  }
+}

--- a/terraform/core/modules/dns/outputs.tf
+++ b/terraform/core/modules/dns/outputs.tf
@@ -1,0 +1,4 @@
+output "zone-id" {
+  description = "The DNS Zone ID"
+  value       = azurerm_dns_zone.dns-zone.id
+}

--- a/terraform/core/modules/dns/variables.tf
+++ b/terraform/core/modules/dns/variables.tf
@@ -1,0 +1,11 @@
+variable "domain_name" {
+  type = string
+}
+
+variable "resource_group_name" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}

--- a/terraform/core/outputs.tf
+++ b/terraform/core/outputs.tf
@@ -1,0 +1,3 @@
+output "dns-zone-id" {
+  value = module.global-dns.zone-id
+}

--- a/terraform/core/provider.tf
+++ b/terraform/core/provider.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "4.2.0"
+    }
+  }
+
+  backend "azurerm" {}
+}
+
+provider "azurerm" {
+  subscription_id = var.subscription_id
+  features {}
+}

--- a/terraform/core/terraform.deploy.tfvars
+++ b/terraform/core/terraform.deploy.tfvars
@@ -1,0 +1,4 @@
+domain_name     = "$(tf_domain_name)"
+environment     = "$(tf_environment)"
+subscription_id = "$(tf_subscription_id)"
+project         = "gpitfutures"

--- a/terraform/core/variables.tf
+++ b/terraform/core/variables.tf
@@ -1,0 +1,17 @@
+variable "domain_name" {
+  type = string
+}
+
+variable "project" {
+  type = string
+}
+
+variable "environment" {
+  type    = string
+  default = "dynamic"
+}
+
+variable "subscription_id" {
+  type      = string
+  sensitive = true
+}

--- a/terraform/webapp/app_gateway_ingress.tf
+++ b/terraform/webapp/app_gateway_ingress.tf
@@ -7,7 +7,6 @@ module "appgateway" {
   ag_capacity                = local.shortenv != "preprod" && local.shortenv != "production" ? "1" : "2"
   ag_subnet_id               = azurerm_subnet.gateway.id
   core_env                   = local.core_env
-  core_url                   = var.coreurl
   ssl_cert_name              = var.certname
   ssl_cert_secret_id         = trimsuffix(data.azurerm_key_vault_secret.ssl_cert.id, data.azurerm_key_vault_secret.ssl_cert.version)
   managed_id_principal_id    = azurerm_user_assigned_identity.managed_id.principal_id

--- a/terraform/webapp/dns.tf
+++ b/terraform/webapp/dns.tf
@@ -1,0 +1,31 @@
+locals {
+  dns_resource_group_name = "${var.project}-dynamic-core-rg"
+  dns_resource_name = replace(var.app_url, "${var.environment}.", "")
+
+  cname_target = local.core_env == "dev" ? module.webapp.webapp_default_site_hostname : module.appgateway.appgateway_pip_fqdn
+}
+
+resource "azurerm_dns_cname_record" "alias" {
+  count               = local.core_env == "dev" || local.environment_identifier == "preprod" ? 1 : 0
+  name                = var.environment
+  zone_name           = local.dns_resource_name
+  resource_group_name = local.dns_resource_group_name
+  ttl                 = 3600
+  record              = local.cname_target
+
+  depends_on = [module.webapp]
+}
+
+resource "azurerm_dns_txt_record" "verification" {
+  count               = local.core_env == "dev" || local.environment_identifier == "preprod" ? 1 : 0
+  name                = "asuid"
+  zone_name           = local.dns_resource_name
+  resource_group_name = local.dns_resource_group_name
+  ttl                 = 3600
+
+  record {
+    value = module.webapp.webapp_verification_id
+  }
+
+  depends_on = [module.webapp]
+}

--- a/terraform/webapp/modules/bc_app_gateway_ingress/output.tf
+++ b/terraform/webapp/modules/bc_app_gateway_ingress/output.tf
@@ -13,7 +13,3 @@ output "appgateway_pip_ipaddress" {
     description = "The Application Gateway Public IP Address"
     value = var.core_env != "dev" ? azurerm_public_ip.pip_app_gateway[0].ip_address : null
 }
-
-output "appgateway_site_URL" {
-    value = var.core_url
-}

--- a/terraform/webapp/modules/bc_app_gateway_ingress/variables.tf
+++ b/terraform/webapp/modules/bc_app_gateway_ingress/variables.tf
@@ -16,15 +16,12 @@ variable "ag_capacity" {
 variable "ag_subnet_id" {
   type = string
 }
-variable "core_url" {
-  type = string
-}
 variable "ssl_cert_name" {
   type = string
 }
 variable "ssl_cert_secret_id" {
   type = string
-}   
+}
 variable "dns_name" {
   type = string
 }


### PR DESCRIPTION
This migrates the existing development DNS to Terraform.

It also removes the redundant `core_url` variable as this serves no purpose.