### PR TITLE
Bugfix: Filter by Additional Services

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Solutions/SolutionsFilterService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Solutions/SolutionsFilterService.cs
@@ -226,7 +226,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Solutions
                     .Include(i => i.Solution)
                     .ThenInclude(
                         s => s.AdditionalServices
-                            .Where(adit => AllowedPublicationStatuses.Contains(adit.CatalogueItem.PublishedStatus) || itemPredicate.Invoke(adit.CatalogueItem)))
+                            .Where(adit => AllowedPublicationStatuses.Contains(adit.CatalogueItem.PublishedStatus) && itemPredicate.Invoke(adit.CatalogueItem)))
                     .ThenInclude(adit => adit.CatalogueItem)
                     .ThenInclude(ci => ci.CatalogueItemCapabilities)
                     .ThenInclude(cic => cic.Capability)
@@ -240,7 +240,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Solutions
                             i.CatalogueItemType == CatalogueItemType.Solution
                             && AllowedPublicationStatuses.Contains(i.PublishedStatus)
                             && i.Supplier.IsActive
-                            && itemPredicate.Invoke(i)),
+                            && (itemPredicate.Invoke(i) || i.Solution.AdditionalServices.Any(y => itemPredicate.Invoke(y.CatalogueItem)))),
                 capabilitiesAndCount);
         }
 


### PR DESCRIPTION
The Browse page has a bug which prevents results for an additional service that implements a capability or epic if the owning solution does not also implement the capability or epic.

This bugfix tweaks the logic of the `Where` clause to ensure results contain either
1. A solution that matches the criteria
2. A solution where any additional service matches the criteria