### PR TITLE
Bugfix: Alignment for Associated Services across Order and Competition journeys

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Competitions/ICompetitionsService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Competitions/ICompetitionsService.cs
@@ -56,11 +56,17 @@ public interface ICompetitionsService
 
     Task RemoveNonPriceElements(string internalOrgId, int competitionId);
 
-    Task SetAssociatedServices(
+    Task AddAssociatedServices(
         string internalOrgId,
         int competitionId,
         CatalogueItemId solutionId,
         IEnumerable<CatalogueItemId> associatedServices);
+
+    Task RemoveAssociatedService(
+        string internalOrgId,
+        int competitionId,
+        CatalogueItemId solutionId,
+        CatalogueItemId serviceId);
 
     Task SetCompetitionRecipients(int competitionId, IEnumerable<string> odsCodes);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Competitions/CompetitionsService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Competitions/CompetitionsService.cs
@@ -572,7 +572,7 @@ public class CompetitionsService : ICompetitionsService
             await dbContext.SaveChangesAsync();
     }
 
-    public async Task SetAssociatedServices(
+    public async Task AddAssociatedServices(
         string internalOrgId,
         int competitionId,
         CatalogueItemId solutionId,
@@ -591,27 +591,38 @@ public class CompetitionsService : ICompetitionsService
         var solution = competition.CompetitionSolutions.FirstOrDefault(x => x.SolutionId == solutionId);
         if (solution == null) return;
 
-        var existingAssociatedServices = solution.SolutionServices.Where(
-            x => !x.IsRequired && x.Service.CatalogueItemType is CatalogueItemType.AssociatedService);
-
-        var selectedAssociatedServices = associatedServices.ToList();
-
-        var toAdd = selectedAssociatedServices.Where(x => existingAssociatedServices.All(y => y.ServiceId != x))
-            .Select(x => new SolutionService(competitionId, solutionId, x, false))
+        var selectedAssociatedServices = associatedServices.Select(x => new SolutionService(competitionId, solutionId, x, false))
             .ToList();
 
-        var toRemove = existingAssociatedServices.Where(x => !selectedAssociatedServices.Contains(x.ServiceId))
-            .ToList();
+        selectedAssociatedServices.ForEach(x => solution.SolutionServices.Add(x));
 
-        var pricesToRemove = toRemove.Where(x => x.Price != null).Select(x => x.Price).ToList();
-        if (pricesToRemove.Count != 0)
-            dbContext.RemoveRange(pricesToRemove);
+        await dbContext.SaveChangesAsync();
+    }
 
-        toRemove.ForEach(x => solution.SolutionServices.Remove(x));
-        toAdd.ForEach(x => solution.SolutionServices.Add(x));
+    public async Task RemoveAssociatedService(
+        string internalOrgId,
+        int competitionId,
+        CatalogueItemId solutionId,
+        CatalogueItemId serviceId)
+    {
+        var competition = await dbContext.Competitions.Include(x => x.CompetitionSolutions)
+            .ThenInclude(x => x.SolutionServices)
+            .ThenInclude(x => x.Service)
+            .Include(competition => competition.CompetitionSolutions)
+            .ThenInclude(competitionSolution => competitionSolution.SolutionServices)
+            .ThenInclude(solutionService => solutionService.Price)
+            .FirstOrDefaultAsync(x => x.Organisation.InternalIdentifier == internalOrgId && x.Id == competitionId);
 
-        if (dbContext.ChangeTracker.HasChanges())
-            await dbContext.SaveChangesAsync();
+        var solution = competition.CompetitionSolutions.FirstOrDefault(x => x.SolutionId == solutionId);
+        var associatedService = solution?.GetAssociatedServices().FirstOrDefault(x => x.ServiceId == serviceId);
+        if (associatedService == null) return;
+
+        if (associatedService.Price is not null)
+            dbContext.RemoveRange(associatedService.Price);
+
+        solution.SolutionServices.Remove(associatedService);
+
+        await dbContext.SaveChangesAsync();
     }
 
     public async Task<int> AddCompetition(int organisationId, int filterId, string frameworkId, string name, string description)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Controllers/CompetitionHubController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Controllers/CompetitionHubController.cs
@@ -88,6 +88,8 @@ public class CompetitionHubController : Controller
     {
         var competition = await competitionsService.GetCompetitionWithSolutionsHub(internalOrgId, competitionId);
         var solution = competition.CompetitionSolutions.FirstOrDefault(x => x.SolutionId == solutionId);
+        if (solution is null) return BadRequest();
+
         var associatedServices = await associatedServicesService.GetPublishedAssociatedServicesForSolution(solutionId, PracticeReorganisationTypeEnum.None);
         var selectedAssociatedServices = solution.GetAssociatedServices();
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Controllers/CompetitionHubController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Controllers/CompetitionHubController.cs
@@ -89,10 +89,12 @@ public class CompetitionHubController : Controller
         var competition = await competitionsService.GetCompetitionWithSolutionsHub(internalOrgId, competitionId);
         var solution = competition.CompetitionSolutions.FirstOrDefault(x => x.SolutionId == solutionId);
         var associatedServices = await associatedServicesService.GetPublishedAssociatedServicesForSolution(solutionId, PracticeReorganisationTypeEnum.None);
+        var selectedAssociatedServices = solution.GetAssociatedServices();
 
         var model = new CompetitionSolutionHubModel(internalOrgId, solution, competition)
         {
             BackLink = Url.Action(nameof(Index), new { internalOrgId, competitionId }),
+            AssociatedServicesRemaining = associatedServices.Any(x => selectedAssociatedServices.All(y => x.Id != y.ServiceId)),
             AssociatedServicesAvailable = associatedServices.Any(),
             AssociatedServicesUrl = Url.Action(
                 nameof(SelectAssociatedServices),
@@ -395,117 +397,51 @@ public class CompetitionHubController : Controller
             .Select(x => x.CatalogueItemId)
             .ToArray() ?? Array.Empty<CatalogueItemId>();
 
-        var competition = await competitionsService.GetCompetitionWithSolutionsHub(internalOrgId, competitionId);
-        var solution = competition.CompetitionSolutions.First(x => x.SolutionId == solutionId);
-        var existingServices = solution.GetAssociatedServices();
-
-        if (existingServices.Any(x => !serviceIds.Contains(x.ServiceId)))
-        {
-            return RedirectToAction(
-                nameof(ConfirmAssociatedServiceChanges),
-                new { internalOrgId, competitionId, solutionId, serviceIds = string.Join(',', serviceIds) });
-        }
-
-        await competitionsService.SetAssociatedServices(internalOrgId, competitionId, solutionId, serviceIds);
+        await competitionsService.AddAssociatedServices(internalOrgId, competitionId, solutionId, serviceIds);
 
         return RedirectToAction(nameof(Hub), new { internalOrgId, competitionId, solutionId });
     }
 
-    [HttpGet("{solutionId}/associated-services/confirm")]
-    public async Task<IActionResult> ConfirmAssociatedServiceChanges(
+    [HttpGet("{solutionId}/associated-services/{serviceId}/remove")]
+    public async Task<IActionResult> RemoveAssociatedService(
         string internalOrgId,
         int competitionId,
         CatalogueItemId solutionId,
-        string serviceIds)
+        CatalogueItemId serviceId)
     {
         var competition = await competitionsService.GetCompetitionWithSolutionsHub(internalOrgId, competitionId);
-        var solution = competition.CompetitionSolutions.FirstOrDefault(x => x.SolutionId == solutionId);
+        var solution = competition?.CompetitionSolutions.FirstOrDefault(x => x.SolutionId == solutionId);
         if (solution == null) return BadRequest();
 
-        var associatedServices =
-            await associatedServicesService.GetPublishedAssociatedServicesForSolution(solutionId, PracticeReorganisationTypeEnum.None);
+        var service = solution.GetAssociatedServices().FirstOrDefault(x => x.ServiceId == serviceId);
+        if (service == null) return BadRequest();
 
-        var existingServiceIds = solution.GetAssociatedServices()
-            .Select(x => x.ServiceId)
-            .ToList();
-
-        var selectedServiceIds = serviceIds?.Split(',')
-            .Select(CatalogueItemId.ParseExact)
-            .ToArray() ?? Array.Empty<CatalogueItemId>();
-
-        var toAdd = selectedServiceIds
-            .Where(x => !existingServiceIds.Contains(x))
-            .Select(
-                x => new ServiceModel
-                {
-                    CatalogueItemId = x,
-                    Description = associatedServices.FirstOrDefault(s => s.Id == x)?.Name,
-                });
-
-        var toRemove = existingServiceIds
-            .Where(x => !selectedServiceIds.Contains(x))
-            .Select(
-                x => new ServiceModel
-                {
-                    CatalogueItemId = x,
-                    Description = associatedServices.FirstOrDefault(s => s.Id == x)?.Name,
-                });
-
-        var model = new ConfirmServiceChangesModel(internalOrgId, CatalogueItemType.AssociatedService)
+        var model = new RemoveServiceModel(service.Service)
         {
-            BackLink = Url.Action(
-                nameof(SelectAssociatedServices),
-                new { internalOrgId, competitionId, solutionId }),
-            ToAdd = toAdd.ToList(),
-            ToRemove = toRemove.ToList(),
-            Caption = solution.Solution.CatalogueItem.Name,
+            BackLink = Url.Action(nameof(Hub), new { internalOrgId, competitionId, solutionId }),
             EntityType = "Competition",
         };
 
-        return View("Services/ConfirmChanges", model);
+        return View("Services/RemoveService", model);
     }
 
-    [HttpPost("{solutionId}/associated-services/confirm")]
-    public async Task<IActionResult> ConfirmAssociatedServiceChanges(
+    [HttpPost("{solutionId}/associated-services/{serviceId}/remove")]
+    public async Task<IActionResult> RemoveAssociatedService(
         string internalOrgId,
         int competitionId,
         CatalogueItemId solutionId,
-        ConfirmServiceChangesModel model)
+        CatalogueItemId serviceId,
+        RemoveServiceModel model)
     {
         if (!ModelState.IsValid)
+            return View("Services/RemoveService", model);
+
+        if (model.ConfirmRemoveService.GetValueOrDefault())
         {
-            return View("Services/ConfirmChanges", model);
+            await competitionsService.RemoveAssociatedService(internalOrgId, competitionId, solutionId, serviceId);
         }
 
-        if (model.ConfirmChanges is false)
-        {
-            return RedirectToAction(
-                nameof(Hub),
-                new { internalOrgId, competitionId, solutionId });
-        }
-
-        var competition = await competitionsService.GetCompetitionWithSolutionsHub(internalOrgId, competitionId);
-        var solution = competition.CompetitionSolutions.FirstOrDefault(x => x.SolutionId == solutionId);
-        if (solution == null) return BadRequest();
-
-        var associatedServices = solution.GetAssociatedServices();
-        var associatedServiceIds = associatedServices.Select(x => x.ServiceId);
-
-        var servicesToAdd = model.ToAdd?.Select(x => x.CatalogueItemId) ?? Enumerable.Empty<CatalogueItemId>();
-        var serviceToRemove = model.ToRemove?.Select(x => x.CatalogueItemId) ?? Enumerable.Empty<CatalogueItemId>();
-
-        var serviceIds = associatedServiceIds.Concat(servicesToAdd)
-            .Except(serviceToRemove);
-
-        await competitionsService.SetAssociatedServices(
-            internalOrgId,
-            competitionId,
-            solutionId,
-            serviceIds);
-
-        return RedirectToAction(
-            nameof(Hub),
-            new { internalOrgId, competitionId, solutionId });
+        return RedirectToAction(nameof(Hub), new { internalOrgId, competitionId, solutionId });
     }
 
     internal async Task<IEnumerable<ServiceRecipientDto>> GetRecipientQuantities(

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Models/PricingModels/CompetitionSolutionHubModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Models/PricingModels/CompetitionSolutionHubModel.cs
@@ -60,9 +60,9 @@ public class CompetitionSolutionHubModel : NavBaseModel
 
     public bool AssociatedServicesAvailable { get; set; }
 
-    public string AssociatedServicesUrl { get; set; }
+    public bool AssociatedServicesRemaining { get; set; }
 
-    public string AssociatedServicesActionText => $"{(AssociatedServices?.Any() ?? false ? "Change" : "Add")} Associated Services";
+    public string AssociatedServicesUrl { get; set; }
 
     public List<CatalogueItemHubModel> CatalogueItems { get; set; }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionHub/Hub.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionHub/Hub.cshtml
@@ -65,15 +65,22 @@
                         }
                     </nhs-card-content>
                     <nhs-card-footer>
-                        <p class="nhsuk-body-m">
-                            <a class="nhsuk-link nhsuk-link--no-visited-state" href="@Model.AssociatedServicesUrl">
-                                <img src="~/images/plus-icon.svg" width="23px" aria-hidden="true" /> @Model.AssociatedServicesActionText
-                            </a>
-                        </p>
+                        @if (Model.AssociatedServicesRemaining)
+                        {
+                            <p class="nhsuk-body-m">
+                                <a class="nhsuk-link nhsuk-link--no-visited-state" href="@Model.AssociatedServicesUrl">
+                                    <img src="~/images/plus-icon.svg" width="23px" aria-hidden="true"/> Add Associated Services
+                                </a>
+                            </p>
+                        }
+                        else
+                        {
+                            <img src="~/images/circle-info-solid.svg" aria-hidden="true" width="20px" /><p>All the Associated Services available for this Catalogue Solution have already been added.</p>
+                        }
                     </nhs-card-footer>
                 </nhs-card-v2>
 
-                
+
             </div>
         }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionHub/Hub.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionHub/Hub.cshtml
@@ -58,9 +58,7 @@
                             <p>You can add Associated Services to help implement your solution, for example training or data migration.</p>
                             @foreach (var item in associatedServices)
                             {
-                                <div class="nhsuk-u-margin-bottom-9">
-                                    <partial name="HubCatalogueItem" model="@Model.GetCatalogueItem(item.CatalogueItemId)"/>
-                                </div>
+                                <partial name="HubCatalogueItem" model="@Model.GetCatalogueItem(item.CatalogueItemId)"/>
                             }
                         }
                     </nhs-card-content>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionHub/HubCatalogueItem.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionHub/HubCatalogueItem.cshtml
@@ -60,6 +60,16 @@
     </nhs-table-row-container>
 </nhs-table>
 
+@if (Model.CatalogueItemType is CatalogueItemType.AssociatedService)
+{
+    <vc:nhs-delete-button url="@Url.Action(
+                                   nameof(CompetitionHubController.RemoveAssociatedService),
+                                   typeof(CompetitionHubController).ControllerName(),
+                                   new { Model.InternalOrgId, Model.CompetitionId, Model.SolutionId, serviceId = Model.CatalogueItemId })"
+                          text="Remove @Model.CatalogueItemName" />
+    <hr class="nhsuk-section-break nhsuk-section-break--m nhsuk-section-break--visible">
+}
+
 @if (Model.PriceProgress is TaskProgress.Completed && Model.QuantityProgress is TaskProgress.Completed)
 {
     <nhs-summary-list>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/SolutionSelection/AdditionalServicesController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/SolutionSelection/AdditionalServicesController.cs
@@ -111,9 +111,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.SolutionSele
                 ? Url.Action(nameof(TaskListController.TaskList), typeof(TaskListController).ControllerName(), new { internalOrgId, callOffId })
                 : Url.Action(nameof(OrderController.Order), typeof(OrderController).ControllerName(), new { internalOrgId, callOffId });
 
-            return new SelectServicesModel(
-                wrapper.Previous?.GetServices(catalogueItemType) ?? Enumerable.Empty<CatalogueItem>(),
-                order.GetServices(catalogueItemType),
+            var currentItems = order.GetServices(catalogueItemType) ?? Enumerable.Empty<CatalogueItem>();
+
+            return new SelectAdditionalServicesModel(
+                currentItems.ToList(),
                 additionalServices)
             {
                 BackLink = backLink,

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/SolutionSelection/CatalogueSolutionsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/SolutionSelection/CatalogueSolutionsController.cs
@@ -412,7 +412,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.SolutionSele
                     new { internalOrgId, callOffId }),
             };
 
-            return View(model);
+            return View("Services/RemoveService", model);
         }
 
         [HttpPost("remove-service/{catalogueItemId}")]
@@ -420,7 +420,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.SolutionSele
         {
             if (!ModelState.IsValid)
             {
-                return View(model);
+                return View("Services/RemoveService", model);
             }
 
             if (model.ConfirmRemoveService ?? false)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/AdditionalServices/SelectAdditionalServices.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/AdditionalServices/SelectAdditionalServices.cshtml
@@ -1,5 +1,5 @@
 ﻿@using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers;
-@model NHSD.GPIT.BuyingCatalogue.WebApp.Models.Shared.Services.SelectServicesModel
+@model NHSD.GPIT.BuyingCatalogue.WebApp.Models.Shared.Services.SelectAdditionalServicesModel
 @{
     ViewBag.Title = "Add Additional Services";
 
@@ -9,8 +9,6 @@
     var advice = Model.IsAmendment && !Model.Services.Any()
         ? "All the Additional Services available with this Catalogue Solution have already been added to this order."
         : "Select the Additional Services that you want to add to your order.";
-
-    Model.Services.RemoveAll(x => x.IsSelected);
 }
 
 <partial name="Partials/_BackLink" model="Model" />
@@ -22,7 +20,7 @@
         <nhs-page-title title="@ViewBag.Title"
                         caption="@Model.SolutionName"
                         advice="@advice"/>
-        
+
         <form method="post" autocomplete="off">
             @if (Model.Services.Any())
             {
@@ -57,12 +55,12 @@
                     </div>
                 }
             }
-            
+
             @if (Model.ExistingServices.Any())
             {
                 <div id="existing-services" class="nhsuk-u-margin-top-9">
                     <h3>Additional Services already added</h3>
-                    
+
                     <ul>
                         @foreach (var (service, i) in Model.ExistingServices.Select((x, i) => (x, i)))
                         {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/TaskList/TaskList.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/TaskList/TaskList.cshtml
@@ -83,7 +83,7 @@
                                         nameof(AdditionalServicesController.SelectAdditionalServices),
                                         typeof(AdditionalServicesController).ControllerName(),
                                         new { Model.InternalOrgId, Model.CallOffId })">
-                                        <img src="~/images/plus-icon.svg" width="23px" aria-hidden="true" />Add an Additional Service
+                                        <img src="~/images/plus-icon.svg" width="23px" aria-hidden="true" />Add Additional Services
                                 </a>
                             </p>
                         }
@@ -153,7 +153,7 @@
                                 nameof(AssociatedServicesController.SelectAssociatedServices),
                                 typeof(AssociatedServicesController).ControllerName(),
                                 new { Model.InternalOrgId, Model.CallOffId, source = RoutingSource.TaskList })">
-                                <img src="~/images/plus-icon.svg" width="23px" aria-hidden="true" />Add an Associated Service
+                                <img src="~/images/plus-icon.svg" width="23px" aria-hidden="true" />Add Associated Services
                             </a>
                         </p>
                     }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Models/Shared/Services/RemoveServiceModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Models/Shared/Services/RemoveServiceModel.cs
@@ -2,9 +2,8 @@
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Extensions;
 using NHSD.GPIT.BuyingCatalogue.Framework.Models;
-using NHSD.GPIT.BuyingCatalogue.WebApp.Models;
 
-namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.Shared
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.Models.Shared.Services
 {
     public class RemoveServiceModel : NavBaseModel
     {
@@ -28,6 +27,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection
         public string ServiceType { get; set; }
 
         public string ServiceName { get; set; }
+
+        public string EntityType { get; set; } = "Order";
 
         public bool? ConfirmRemoveService { get; set; }
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Models/Shared/Services/SelectAdditionalServicesModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Models/Shared/Services/SelectAdditionalServicesModel.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.Models.Shared.Services;
+
+public class SelectAdditionalServicesModel : SelectServicesModel
+{
+    public SelectAdditionalServicesModel()
+        : base()
+    {
+    }
+
+    public SelectAdditionalServicesModel(
+        ICollection<CatalogueItem> excludedServices,
+        ICollection<CatalogueItem> allServices)
+        : base(excludedServices, allServices)
+    {
+        ExistingServices = excludedServices.Select(x => x.Name).ToList();
+    }
+
+    public List<string> ExistingServices { get; set; } = Enumerable.Empty<string>().ToList();
+}

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Models/Shared/Services/SelectServicesModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Models/Shared/Services/SelectServicesModel.cs
@@ -12,34 +12,20 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Models.Shared.Services
         }
 
         public SelectServicesModel(
-            IEnumerable<CatalogueItem> currentServices,
+            IEnumerable<CatalogueItem> excludedServices,
             IEnumerable<CatalogueItem> allServices)
         {
-            var currentServiceIds = currentServices.Select(x => x.Id).ToList();
+            var previousServiceIds = excludedServices.Select(x => x.Id).ToList();
 
             Services = allServices
+                .Where(x => !previousServiceIds.Contains(x.Id))
                 .Select(
                     x => new ServiceModel
                     {
                         CatalogueItemId = x.Id,
                         Description = x.Name,
-                        IsSelected = currentServiceIds.Contains(x.Id),
                     })
                 .ToList();
-        }
-
-        public SelectServicesModel(
-            IEnumerable<CatalogueItem> previousServices,
-            IEnumerable<CatalogueItem> currentServices,
-            IEnumerable<CatalogueItem> allServices)
-            : this(currentServices, allServices)
-        {
-            var enumeratedServices = previousServices.ToList();
-
-            var previousServiceIds = enumeratedServices.Select(x => x.Id).ToList();
-
-            Services = Services.Where(x => !previousServiceIds.Contains(x.CatalogueItemId)).ToList();
-            ExistingServices = enumeratedServices.Select(x => x.Name).ToList();
         }
 
         public string EntityType { get; set; } = "Order";
@@ -53,8 +39,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Models.Shared.Services
         public string SolutionName { get; set; }
 
         public CatalogueItemId? SolutionId { get; set; }
-
-        public List<string> ExistingServices { get; set; } = Enumerable.Empty<string>().ToList();
 
         public List<ServiceModel> Services { get; set; }
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Validation/Shared/RemoveServiceModelValidator.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Validation/Shared/RemoveServiceModelValidator.cs
@@ -1,7 +1,7 @@
 ﻿using FluentValidation;
-using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.Shared;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Models.Shared.Services;
 
-namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Validators.SolutionSelection.RemoveService
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.Validation.Shared
 {
     public class RemoveServiceModelValidator : AbstractValidator<RemoveServiceModel>
     {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/Services/RemoveService.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/Services/RemoveService.cshtml
@@ -1,7 +1,7 @@
-﻿@model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.Shared.RemoveServiceModel;
+﻿@model NHSD.GPIT.BuyingCatalogue.WebApp.Models.Shared.Services.RemoveServiceModel;
 
 @{
-    ViewBag.Title = "Remove Additional Service";
+    ViewBag.Title = $"Remove {Model.ServiceType}";
 }
 
 <partial name="Partials/_BackLink" model="Model" />
@@ -11,7 +11,7 @@
         <nhs-validation-summary RadioId="ConfirmRemoveService" />
         <nhs-page-title title="@ViewBag.Title"
                         caption="@Model.ServiceName"
-                        advice="Confirm you want to remove this @Model.ServiceType from your order." />
+                        advice="Confirm you want to remove this @Model.ServiceType from your @Model.EntityType.ToLowerInvariant()." />
 
         <nhs-warning-callout label-text="Removing an @Model.ServiceType">
             <p>Removing an @Model.ServiceType will also remove any quantities and prices you've previously entered for it.</p>
@@ -20,6 +20,7 @@
         <form method="post">
             <input type="hidden" asp-for="@Model.ServiceName" />
             <input type="hidden" asp-for="@Model.ServiceType" />
+            <input type="hidden" asp-for="@Model.EntityType" />
             <input type="hidden" asp-for="BackLink" />
             <nhs-fieldset-form-label asp-for="@Model" label-text="Remove @Model.ServiceName">
                 <nhs-radio-buttons asp-for="ConfirmRemoveService"

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Competitions/CompetitionsServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Competitions/CompetitionsServiceTests.cs
@@ -2038,7 +2038,74 @@ public static class CompetitionsServiceTests
 
     [Theory]
     [MockInMemoryDbAutoData]
-    public static async Task SetAssociatedServices_UpdatesAssociatedServices(
+    public static async Task AddAssociatedServices_NoExistingServices_AddsAssociatedServices(
+        Organisation organisation,
+        Supplier supplier,
+        Competition competition,
+        CompetitionSolution competitionSolution,
+        Solution solution,
+        List<AssociatedService> associatedServices,
+        [Frozen] BuyingCatalogueDbContext context,
+        CompetitionsService service)
+    {
+        supplier.CatalogueItems = null;
+
+        solution.CatalogueItem.Supplier = null;
+        solution.CatalogueItem.SupplierId = supplier.Id;
+
+        associatedServices.ForEach(
+            x =>
+            {
+                x.CatalogueItem.Supplier = null;
+                x.CatalogueItem.SupplierId = supplier.Id;
+            });
+
+        var supplierServiceAssociations = associatedServices.Select(
+            x => new SupplierServiceAssociation(solution.CatalogueItemId, x.CatalogueItemId));
+
+        competition.OrganisationId = organisation.Id;
+        competition.CompetitionSolutions = new List<CompetitionSolution> { competitionSolution };
+
+        competitionSolution.IsShortlisted = true;
+        competitionSolution.CompetitionId = competition.Id;
+        competitionSolution.SolutionId = solution.CatalogueItemId;
+        competitionSolution.SolutionServices = new List<SolutionService>();
+
+        var serviceIds = associatedServices.Select(x => x.CatalogueItemId).ToList();
+
+        context.Organisations.Add(organisation);
+        context.Suppliers.Add(supplier);
+        context.Solutions.Add(solution);
+        context.AssociatedServices.AddRange(associatedServices);
+        context.SupplierServiceAssociations.AddRange(supplierServiceAssociations);
+        context.Competitions.Add(competition);
+
+        await context.SaveChangesAsync();
+
+        context.ChangeTracker.Clear();
+
+        await service.AddAssociatedServices(
+            organisation.InternalIdentifier,
+            competition.Id,
+            solution.CatalogueItemId,
+            serviceIds);
+
+        var updatedCompetition = await context.Competitions.Include(x => x.CompetitionSolutions)
+            .ThenInclude(x => x.SolutionServices)
+            .ThenInclude(x => x.Service)
+            .FirstOrDefaultAsync(x => x.Organisation.InternalIdentifier == organisation.InternalIdentifier && x.Id == competition.Id);
+
+        var updatedCompetitionSolution =
+            updatedCompetition.CompetitionSolutions.First(x => x.SolutionId == solution.CatalogueItemId);
+
+        var solutionServices = updatedCompetitionSolution.SolutionServices.ToList();
+
+        solutionServices.Should().HaveCount(associatedServices.Count);
+    }
+
+    [Theory]
+    [MockInMemoryDbAutoData]
+    public static async Task AddAssociatedServices_ExistingService_DoesNotRemoveExistingService(
         Organisation organisation,
         Supplier supplier,
         Competition competition,
@@ -2089,7 +2156,7 @@ public static class CompetitionsServiceTests
 
         context.ChangeTracker.Clear();
 
-        await service.SetAssociatedServices(
+        await service.AddAssociatedServices(
             organisation.InternalIdentifier,
             competition.Id,
             solution.CatalogueItemId,
@@ -2105,7 +2172,78 @@ public static class CompetitionsServiceTests
 
         var solutionServices = updatedCompetitionSolution.SolutionServices.ToList();
 
-        solutionServices.Should().HaveCount(serviceIds.Count);
+        solutionServices.Should().HaveCount(associatedServices.Count);
+        solutionServices.Should().Contain(x => x.ServiceId == existingService.CatalogueItemId);
+    }
+
+    [Theory]
+    [MockInMemoryDbAutoData]
+    public static async Task RemoveAssociatedService_ValidService_RemovesService(
+        Organisation organisation,
+        Supplier supplier,
+        Competition competition,
+        CompetitionSolution competitionSolution,
+        Solution solution,
+        List<AssociatedService> associatedServices,
+        [Frozen] BuyingCatalogueDbContext context,
+        CompetitionsService service)
+    {
+        supplier.CatalogueItems = null;
+
+        solution.CatalogueItem.Supplier = null;
+        solution.CatalogueItem.SupplierId = supplier.Id;
+
+        associatedServices.ForEach(
+            x =>
+            {
+                x.CatalogueItem.Supplier = null;
+                x.CatalogueItem.SupplierId = supplier.Id;
+            });
+
+        var supplierServiceAssociations = associatedServices.Select(
+            x => new SupplierServiceAssociation(solution.CatalogueItemId, x.CatalogueItemId));
+
+        var existingService = associatedServices.First();
+
+        competition.OrganisationId = organisation.Id;
+        competition.CompetitionSolutions = new List<CompetitionSolution> { competitionSolution };
+
+        competitionSolution.IsShortlisted = true;
+        competitionSolution.CompetitionId = competition.Id;
+        competitionSolution.SolutionId = solution.CatalogueItemId;
+        competitionSolution.SolutionServices = new List<SolutionService>
+        {
+            new(competition.Id, solution.CatalogueItemId, existingService.CatalogueItemId, false),
+        };
+
+        context.Organisations.Add(organisation);
+        context.Suppliers.Add(supplier);
+        context.Solutions.Add(solution);
+        context.AssociatedServices.AddRange(associatedServices);
+        context.SupplierServiceAssociations.AddRange(supplierServiceAssociations);
+        context.Competitions.Add(competition);
+
+        await context.SaveChangesAsync();
+
+        context.ChangeTracker.Clear();
+
+        await service.RemoveAssociatedService(
+            organisation.InternalIdentifier,
+            competition.Id,
+            solution.CatalogueItemId,
+            existingService.CatalogueItemId);
+
+        var updatedCompetition = await context.Competitions.Include(x => x.CompetitionSolutions)
+            .ThenInclude(x => x.SolutionServices)
+            .ThenInclude(x => x.Service)
+            .FirstOrDefaultAsync(x => x.Organisation.InternalIdentifier == organisation.InternalIdentifier && x.Id == competition.Id);
+
+        var updatedCompetitionSolution =
+            updatedCompetition.CompetitionSolutions.First(x => x.SolutionId == solution.CatalogueItemId);
+
+        var solutionServices = updatedCompetitionSolution.SolutionServices.ToList();
+
+        solutionServices.Should().BeEmpty();
         solutionServices.Should().NotContain(x => x.ServiceId == existingService.CatalogueItemId);
     }
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Competitions/Controllers/CompetitionHubControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Competitions/Controllers/CompetitionHubControllerTests.cs
@@ -83,6 +83,48 @@ public static class CompetitionHubControllerTests
 
         var expectedModel = new CompetitionSolutionHubModel(internalOrgId, competitionSolution, competition)
         {
+            AssociatedServicesRemaining = true,
+            AssociatedServicesAvailable = associatedServices.Any(),
+        };
+
+        var result = (await controller.Hub(internalOrgId, competition.Id, solution.CatalogueItemId)).As<ViewResult>();
+
+        result.Should().NotBeNull();
+        result.Model.Should()
+            .BeEquivalentTo(
+                expectedModel,
+                opt => opt.Excluding(m => m.BackLink).Excluding(m => m.AssociatedServicesUrl));
+    }
+
+    [Theory]
+    [MockAutoData]
+    public static async Task Hub_NoAssociatedServicesRemaining_ReturnsViewWithModel(
+        string internalOrgId,
+        Competition competition,
+        CompetitionSolution competitionSolution,
+        Solution solution,
+        List<AssociatedService> associatedServices,
+        [Frozen] ICompetitionsService competitionsService,
+        [Frozen] IAssociatedServicesService associatedServicesService,
+        CompetitionHubController controller)
+    {
+        competitionSolution.Solution = solution;
+        competitionSolution.SolutionId = solution.CatalogueItemId;
+        competitionSolution.SolutionServices = associatedServices.Select(
+                x => new SolutionService(competition.Id, solution.CatalogueItemId, x.CatalogueItemId, false)
+                {
+                    Service = x.CatalogueItem,
+                })
+            .ToList();
+        competition.CompetitionSolutions = new List<CompetitionSolution> { competitionSolution };
+
+        competitionsService.GetCompetitionWithSolutionsHub(internalOrgId, competition.Id).Returns(competition);
+
+        associatedServicesService.GetPublishedAssociatedServicesForSolution(competitionSolution.SolutionId, PracticeReorganisationTypeEnum.None).Returns(associatedServices.Select(x => x.CatalogueItem).ToList());
+
+        var expectedModel = new CompetitionSolutionHubModel(internalOrgId, competitionSolution, competition)
+        {
+            AssociatedServicesRemaining = false,
             AssociatedServicesAvailable = associatedServices.Any(),
         };
 
@@ -1004,53 +1046,6 @@ public static class CompetitionHubControllerTests
 
     [Theory]
     [MockAutoData]
-    public static async Task SelectAssociatedServices_ExistingServicesNotSelected_Redirects(
-        string internalOrgId,
-        Competition competition,
-        CompetitionSolution competitionSolution,
-        List<SolutionService> solutionServices,
-        Solution solution,
-        List<AssociatedService> associatedServices,
-        AssociatedService existingService,
-        [Frozen] ICompetitionsService competitionsService,
-        [Frozen] IAssociatedServicesService associatedServicesService,
-        CompetitionHubController controller)
-    {
-        solutionServices.ForEach(
-            x =>
-            {
-                x.IsRequired = false;
-                x.Service = existingService.CatalogueItem;
-            });
-
-        competitionSolution.Solution = solution;
-        competitionSolution.SolutionId = solution.CatalogueItemId;
-        competitionSolution.SolutionServices = solutionServices;
-
-        competition.CompetitionSolutions = new List<CompetitionSolution> { competitionSolution };
-
-        competitionsService.GetCompetitionWithSolutionsHub(internalOrgId, competition.Id).Returns(competition);
-
-        associatedServicesService.GetPublishedAssociatedServicesForSolution(competitionSolution.SolutionId, PracticeReorganisationTypeEnum.None).Returns(associatedServices.Select(x => x.CatalogueItem).ToList());
-
-        var model = new SelectServicesModel(
-            solutionServices.Select(x => x.Service).ToList(),
-            associatedServices.Select(x => x.CatalogueItem).ToList())
-        {
-            EntityType = "Competition",
-            SolutionName = solution.CatalogueItem.Name,
-            InternalOrgId = internalOrgId,
-        };
-
-        var result = (await controller.SelectAssociatedServices(internalOrgId, competition.Id, solution.CatalogueItemId, model))
-            .As<RedirectToActionResult>();
-
-        result.Should().NotBeNull();
-        result.ActionName.Should().Be(nameof(controller.ConfirmAssociatedServiceChanges));
-    }
-
-    [Theory]
-    [MockAutoData]
     public static async Task SelectAssociatedServices_Valid_Redirects(
         string internalOrgId,
         Competition competition,
@@ -1098,177 +1093,143 @@ public static class CompetitionHubControllerTests
 
     [Theory]
     [MockAutoData]
-    public static async Task ConfirmAssociatedServiceChanges_InvalidSolution_ReturnsBadRequest(
+    public static async Task RemoveAssociatedService_IncorrectCompetitionId_ReturnsBadRequestResult(
+        string internalOrgId,
+        int competitionId,
+        CatalogueItemId solutionId,
+        CatalogueItemId serviceId,
+        [Frozen] ICompetitionsService competitionsService,
+        CompetitionHubController controller)
+    {
+        competitionsService.GetCompetitionWithSolutionsHub(internalOrgId, competitionId).Returns((Competition)null);
+
+        var result = await controller.RemoveAssociatedService(internalOrgId, competitionId, solutionId, serviceId);
+
+        result.Should().BeOfType<BadRequestResult>();
+    }
+
+    [Theory]
+    [MockAutoData]
+    public static async Task RemoveAssociatedService_IncorrectSolutionId_ReturnsBadRequestResult(
         string internalOrgId,
         Competition competition,
         CatalogueItemId solutionId,
-        string serviceIds,
+        CatalogueItemId serviceId,
         [Frozen] ICompetitionsService competitionsService,
         CompetitionHubController controller)
     {
         competitionsService.GetCompetitionWithSolutionsHub(internalOrgId, competition.Id).Returns(competition);
 
-        var result =
-            (await controller.ConfirmAssociatedServiceChanges(internalOrgId, competition.Id, solutionId, serviceIds))
-            .As<BadRequestResult>();
+        var result = await controller.RemoveAssociatedService(internalOrgId, competition.Id, solutionId, serviceId);
 
-        result.Should().NotBeNull();
+        result.Should().BeOfType<BadRequestResult>();
     }
 
     [Theory]
     [MockAutoData]
-    public static async Task ConfirmAssociatedServiceChanges_ReturnsViewWithModel(
+    public static async Task RemoveAssociatedService_IncorrectServiceId_ReturnsBadRequestResult(
         string internalOrgId,
         Competition competition,
         CompetitionSolution competitionSolution,
-        List<SolutionService> solutionServices,
-        Solution solution,
-        List<AssociatedService> associatedServices,
-        AssociatedService existingService,
+        CatalogueItemId serviceId,
         [Frozen] ICompetitionsService competitionsService,
-        [Frozen] IAssociatedServicesService associatedServicesService,
         CompetitionHubController controller)
     {
-        solutionServices.ForEach(
-            x =>
-            {
-                x.IsRequired = false;
-                x.Service = existingService.CatalogueItem;
-                x.ServiceId = existingService.CatalogueItemId;
-            });
-
-        competitionSolution.Solution = solution;
-        competitionSolution.SolutionId = solution.CatalogueItemId;
-        competitionSolution.SolutionServices = solutionServices;
-
         competition.CompetitionSolutions = new List<CompetitionSolution> { competitionSolution };
 
         competitionsService.GetCompetitionWithSolutionsHub(internalOrgId, competition.Id).Returns(competition);
 
-        associatedServicesService.GetPublishedAssociatedServicesForSolution(competitionSolution.SolutionId, PracticeReorganisationTypeEnum.None).Returns(associatedServices.Concat(new[] { existingService }).Select(x => x.CatalogueItem).ToList());
+        var result = await controller.RemoveAssociatedService(internalOrgId, competition.Id, competitionSolution.SolutionId, serviceId);
 
-        var expectedModel = new ConfirmServiceChangesModel(internalOrgId, CatalogueItemType.AssociatedService)
-        {
-            ToAdd = associatedServices.Select(
-                    x => new ServiceModel { CatalogueItemId = x.CatalogueItemId, Description = x.CatalogueItem.Name })
-                .ToList(),
-            ToRemove = solutionServices.Select(
-                    x => new ServiceModel { CatalogueItemId = x.ServiceId, Description = x.Service.Name })
-                .ToList(),
-            Caption = solution.CatalogueItem.Name,
-            EntityType = "Competition",
-        };
-
-        var result = (await controller.ConfirmAssociatedServiceChanges(
-            internalOrgId,
-            competition.Id,
-            solution.CatalogueItemId,
-            string.Join(',', associatedServices.Select(x => x.CatalogueItemId)))).As<ViewResult>();
-
-        result.Should().NotBeNull();
-        result.Model.Should().BeEquivalentTo(expectedModel, opt => opt.Excluding(m => m.BackLink));
+        result.Should().BeOfType<BadRequestResult>();
     }
 
     [Theory]
     [MockAutoData]
-    public static async Task ConfirmAssociatedServiceChanges_InvalidModel_ReturnsViewWithModel(
+    public static async Task RemoveAssociatedService_Valid_ReturnsViewWithModel(
+        string internalOrgId,
+        Competition competition,
+        CompetitionSolution competitionSolution,
+        SolutionService solutionService,
+        AssociatedService associatedService,
+        [Frozen] ICompetitionsService competitionsService,
+        CompetitionHubController controller)
+    {
+        solutionService.IsRequired = false;
+        solutionService.ServiceId = associatedService.CatalogueItemId;
+        solutionService.Service = associatedService.CatalogueItem;
+
+        competitionSolution.SolutionServices = new List<SolutionService> { solutionService };
+        competition.CompetitionSolutions = new List<CompetitionSolution> { competitionSolution };
+
+        competitionsService.GetCompetitionWithSolutionsHub(internalOrgId, competition.Id).Returns(competition);
+
+        var expectedModel = new RemoveServiceModel(solutionService.Service) { EntityType = "Competition" };
+
+        var result = await controller.RemoveAssociatedService(internalOrgId, competition.Id, competitionSolution.SolutionId, solutionService.ServiceId);
+
+        var viewResult = result.Should().BeOfType<ViewResult>();
+        viewResult.Subject.Model.Should().BeEquivalentTo(expectedModel, opt => opt.Excluding(m => m.BackLink));
+    }
+
+    [Theory]
+    [MockAutoData]
+    public static async Task RemoveAssociatedService_InvalidModel_ReturnsViewWithModel(
         string internalOrgId,
         int competitionId,
         CatalogueItemId solutionId,
-        ConfirmServiceChangesModel model,
+        CatalogueItemId serviceId,
+        RemoveServiceModel model,
         CompetitionHubController controller)
     {
         controller.ModelState.AddModelError("some-key", "some-error");
 
-        var result = (await controller.ConfirmAssociatedServiceChanges(internalOrgId, competitionId, solutionId, model))
-            .As<ViewResult>();
+        var result = await controller.RemoveAssociatedService(internalOrgId, competitionId, solutionId, serviceId, model);
 
-        result.Should().NotBeNull();
-        result.Model.Should().Be(model);
+        var viewResult = result.Should().BeOfType<ViewResult>();
+
+        viewResult.Subject.Model.Should().BeEquivalentTo(model);
     }
 
     [Theory]
     [MockAutoData]
-    public static async Task ConfirmAssociatedServiceChanges_ConfirmChangesFalse_Redirects(
+    public static async Task RemoveAssociatedService_Confirmed_RemovesAssociatedService(
         string internalOrgId,
         int competitionId,
         CatalogueItemId solutionId,
-        ConfirmServiceChangesModel model,
+        CatalogueItemId serviceId,
+        RemoveServiceModel model,
+        [Frozen] ICompetitionsService competitionsService,
         CompetitionHubController controller)
     {
-        model.ConfirmChanges = false;
+        model.ConfirmRemoveService = true;
 
-        var result = (await controller.ConfirmAssociatedServiceChanges(internalOrgId, competitionId, solutionId, model))
-            .As<RedirectToActionResult>();
+        var result = await controller.RemoveAssociatedService(internalOrgId, competitionId, solutionId, serviceId, model);
 
         result.Should().NotBeNull();
-        result.ActionName.Should().Be(nameof(controller.Hub));
+        await competitionsService.Received()
+            .RemoveAssociatedService(internalOrgId, competitionId, solutionId, serviceId);
     }
 
     [Theory]
-    [MockAutoData]
-    public static async Task Post_ConfirmAssociatedServiceChanges_InvalidSolution_ReturnsBadRequest(
+    [MockInlineAutoData(true)]
+    [MockInlineAutoData(false)]
+    public static async Task RemoveAssociatedService_RedirectsToHub(
+        bool confirmed,
         string internalOrgId,
-        Competition competition,
+        int competitionId,
         CatalogueItemId solutionId,
-        ConfirmServiceChangesModel model,
-        [Frozen] ICompetitionsService competitionsService,
+        CatalogueItemId serviceId,
+        RemoveServiceModel model,
         CompetitionHubController controller)
     {
-        model.ConfirmChanges = true;
+        model.ConfirmRemoveService = confirmed;
 
-        competitionsService.GetCompetitionWithSolutionsHub(internalOrgId, competition.Id).Returns(competition);
+        var result = await controller.RemoveAssociatedService(internalOrgId, competitionId, solutionId, serviceId, model);
 
-        var result =
-            (await controller.ConfirmAssociatedServiceChanges(internalOrgId, competition.Id, solutionId, model))
-            .As<BadRequestResult>();
+        var redirectResult = result.Should().BeOfType<RedirectToActionResult>();
 
-        result.Should().NotBeNull();
-    }
-
-    [Theory]
-    [MockAutoData]
-    public static async Task ConfirmAssociatedServiceChanges_Valid_Redirects(
-        string internalOrgId,
-        Competition competition,
-        CompetitionSolution competitionSolution,
-        List<SolutionService> solutionServices,
-        Solution solution,
-        List<AssociatedService> associatedServices,
-        AssociatedService existingService,
-        ConfirmServiceChangesModel model,
-        [Frozen] ICompetitionsService competitionsService,
-        [Frozen] IAssociatedServicesService associatedServicesService,
-        CompetitionHubController controller)
-    {
-        model.ConfirmChanges = true;
-
-        solutionServices.ForEach(
-            x =>
-            {
-                x.IsRequired = false;
-                x.Service = existingService.CatalogueItem;
-                x.ServiceId = existingService.CatalogueItemId;
-            });
-
-        competitionSolution.Solution = solution;
-        competitionSolution.SolutionId = solution.CatalogueItemId;
-        competitionSolution.SolutionServices = solutionServices;
-
-        competition.CompetitionSolutions = new List<CompetitionSolution> { competitionSolution };
-
-        competitionsService.GetCompetitionWithSolutionsHub(internalOrgId, competition.Id).Returns(competition);
-
-        associatedServicesService.GetPublishedAssociatedServicesForSolution(competitionSolution.SolutionId, PracticeReorganisationTypeEnum.None).Returns(associatedServices.Concat(new[] { existingService }).Select(x => x.CatalogueItem).ToList());
-
-        var result = (await controller.ConfirmAssociatedServiceChanges(
-            internalOrgId,
-            competition.Id,
-            solution.CatalogueItemId,
-            model)).As<RedirectToActionResult>();
-
-        result.Should().NotBeNull();
-        result.ActionName.Should().Be(nameof(controller.Hub));
+        redirectResult.Subject.ActionName.Should().Be(nameof(controller.Hub));
     }
 
     [Theory]

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Competitions/Controllers/CompetitionHubControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Competitions/Controllers/CompetitionHubControllerTests.cs
@@ -98,6 +98,28 @@ public static class CompetitionHubControllerTests
 
     [Theory]
     [MockAutoData]
+    public static async Task Hub_InvalidSolutionId_ReturnsViewWithModel(
+        string internalOrgId,
+        CatalogueItemId solutionId,
+        Competition competition,
+        CompetitionSolution competitionSolution,
+        Solution solution,
+        [Frozen] ICompetitionsService competitionsService,
+        CompetitionHubController controller)
+    {
+        competitionSolution.Solution = solution;
+        competitionSolution.SolutionId = solution.CatalogueItemId;
+        competition.CompetitionSolutions = new List<CompetitionSolution> { competitionSolution };
+
+        competitionsService.GetCompetitionWithSolutionsHub(internalOrgId, competition.Id).Returns(competition);
+
+        var result = (await controller.Hub(internalOrgId, competition.Id, solutionId)).As<BadRequestResult>();
+
+        result.Should().NotBeNull();
+    }
+
+    [Theory]
+    [MockAutoData]
     public static async Task Hub_NoAssociatedServicesRemaining_ReturnsViewWithModel(
         string internalOrgId,
         Competition competition,

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Competitions/Models/NonPriceElementModels/FeaturesModels/FeaturesPartialModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Competitions/Models/NonPriceElementModels/FeaturesModels/FeaturesPartialModelTests.cs
@@ -46,7 +46,6 @@ public static class FeaturesPartialModelTests
     }
 
     [Fact]
-    [MockAutoData]
     public static void CanDelete_NullReturnUrl_NullRequirements_True()
     {
         var model = new FeaturesPartialModel();

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SolutionSelection/AdditionalServicesControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SolutionSelection/AdditionalServicesControllerTests.cs
@@ -63,12 +63,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Sol
 
             var actualResult = result.Should().BeOfType<ViewResult>().Subject;
 
-            var previousItems = orderWrapper.Previous?.GetAssociatedServices().Select(x => x.CatalogueItem)
-                ?? Enumerable.Empty<CatalogueItem>();
-            var currentItems = orderWrapper.Order?.GetAssociatedServices().Select(x => x.CatalogueItem)
+            var excludedItems = orderWrapper.Previous?.GetAssociatedServices().Select(x => x.CatalogueItem)
                 ?? Enumerable.Empty<CatalogueItem>();
 
-            var expected = new SelectServicesModel(previousItems, currentItems, services)
+            var expected = new SelectServicesModel(excludedItems, services)
             {
                 InternalOrgId = internalOrgId,
                 AssociatedServicesOnly = order.OrderType.AssociatedServicesOnly,

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Models/Services/SelectAdditionalServicesModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Models/Services/SelectAdditionalServicesModelTests.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Models.Shared.Services;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Models.Services;
+
+public static class SelectAdditionalServicesModelTests
+{
+    [Theory]
+    [MockAutoData]
+    public static void Construct_SetsPropertiesAsExpected(
+        List<CatalogueItem> excludedServices,
+        List<CatalogueItem> allServices)
+    {
+        var model = new SelectAdditionalServicesModel(excludedServices, allServices);
+
+        model.ExistingServices.Should().BeEquivalentTo(excludedServices.Select(x => x.Name));
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Models/Services/SelectServicesModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Models/Services/SelectServicesModelTests.cs
@@ -46,23 +46,24 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Models.Services
             List<CatalogueItem> services)
         {
             var existingItem = order.OrderItems.First();
+            var existingService = services.First();
 
-            existingItem.CatalogueItem.Id = services.First().Id;
+            existingItem.CatalogueItem.Id = existingService.Id;
             existingItem.CatalogueItem.CatalogueItemType = catalogueItemType;
 
             var currentItems = order.OrderItems.Select(x => x.CatalogueItem);
+            var expectedServices = services.Skip(1).ToList();
 
             var model = new SelectServicesModel(currentItems, services);
 
-            model.ExistingServices.Should().BeEmpty();
-            model.Services.Count.Should().Be(services.Count);
+            model.Services.Count.Should().Be(expectedServices.Count);
 
-            for (var i = 0; i < services.Count; i++)
+            foreach (var expectedService in expectedServices)
             {
-                model.Services.Should().Contain(x => x.CatalogueItemId == services[i].Id && x.Description == services[i].Name);
+                model.Services.Should().Contain(x => x.CatalogueItemId == expectedService.Id && x.Description == expectedService.Name);
             }
 
-            model.Services.First(x => x.CatalogueItemId == existingItem.CatalogueItem.Id).IsSelected.Should().BeTrue();
+            model.Services.Should().NotContain(x => x.CatalogueItemId == existingService.Id && x.Description == existingService.Name);
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.csproj
@@ -46,7 +46,7 @@
 
   <ItemGroup>
     <Folder Include="Areas\Order\Models\SolutionSelection\ServiceRecipients\" />
-    <Folder Include="Areas\Order\Validators\SolutionSelection\Prices" />
+    <Folder Include="Areas\Order\Validators\SolutionSelection\RemoveService\" />
   </ItemGroup>
 
 </Project>

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Validation/Shared/RemoveServiceModelValidatorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Validation/Shared/RemoveServiceModelValidatorTests.cs
@@ -1,9 +1,9 @@
 ﻿using FluentValidation.TestHelper;
-using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.SolutionSelection.Shared;
-using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Validators.SolutionSelection.RemoveService;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Models.Shared.Services;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Validation.Shared;
 using Xunit;
 
-namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Validators.SolutionSelection.RemoveService
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Validation.Shared
 {
     public static class RemoveServiceModelValidatorTests
     {


### PR DESCRIPTION
Resolves a bug whereby adding Associated Services to a competition would remove the previously added services. This was introduced during the order journey redesign towards the start of this year due to both journeys reusing the same shared views for adding services.

Since the order journey business logic changed, drifting from the competition journey logic, this meant that existing services were being hidden from the `Add Associated Services` page.

This change aligns both journeys again to make them consistent by porting the order logic over to the competition journey:
1. Remove existing services from the Add Services pages
2. Delete the `Add Service` confirmation page
3. Introduce a Delete link under each Service
4. Add the Delete confirmation page from the ordering journey