### PR TITLE
Update Regression suite to support newer competition designs

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionNonPriceElements/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionNonPriceElements/Index.cshtml
@@ -21,7 +21,7 @@
             <nhs-card-content title="Features">
                 @if (Model.NonPriceElements.HasNonPriceElement(NonPriceElement.Features))
                 {
-                    <partial name="Partials/_Features" model="@(new FeaturesPartialModel(Model.InternalOrgId, Model.CompetitionId, Model.NonPriceElements.Features, hasReviewedCriteria: Model.HasReviewedCriteria))" />
+                    <partial name="Partials/_Features" model="@(new FeaturesPartialModel(Model.InternalOrgId, Model.CompetitionId, Model.NonPriceElements.Features, hasReviewedCriteria: Model.HasReviewedCriteria))"/>
                 }
                 else
                 {
@@ -30,11 +30,11 @@
                     </p>
                 }
             </nhs-card-content>
-        @if (!Model.HasReviewedCriteria)
+            @if (!Model.HasReviewedCriteria)
             {
                 <nhs-card-footer>
                     <p class="nhsuk-body-m">
-                        <a class="nhsuk-link nhsuk-link--no-visited-state" href="@Url.Action(nameof(CompetitionNonPriceElementsController.Feature), typeof(CompetitionNonPriceElementsController).ControllerName(), routeValues)">
+                        <a class="nhsuk-link nhsuk-link--no-visited-state" data-test-id="features-link" href="@Url.Action(nameof(CompetitionNonPriceElementsController.Feature), typeof(CompetitionNonPriceElementsController).ControllerName(), routeValues)">
                             <img src="~/images/plus-icon.svg" width="23px" aria-hidden="true"/> Add feature requirements
                         </a>
                     </p>
@@ -45,7 +45,7 @@
             <nhs-card-content title="Implementation">
                 @if (Model.NonPriceElements.HasNonPriceElement(NonPriceElement.Implementation))
                 {
-                    <partial name="Partials/_Implementation" model="@Model.NonPriceElements.Implementation.Requirements" />
+                    <partial name="Partials/_Implementation" model="@Model.NonPriceElements.Implementation.Requirements"/>
                 }
                 else
                 {
@@ -54,26 +54,23 @@
                     </p>
                 }
             </nhs-card-content>
-        @if (!Model.HasReviewedCriteria)
+            @if (!Model.HasReviewedCriteria)
             {
                 <nhs-card-footer>
-                    @if (Model.NonPriceElements.HasNonPriceElement(NonPriceElement.Implementation))
-                    {
-                        <p>
-                            <a class="nhsuk-link--no-visited-state" href="@Url.Action(nameof(CompetitionNonPriceElementsController.Implementation), typeof(CompetitionNonPriceElementsController).ControllerName(), routeValues)">
+                    <p>
+                        <a class="nhsuk-link--no-visited-state" data-test-id="implementation-link" href="@Url.Action(nameof(CompetitionNonPriceElementsController.Implementation), typeof(CompetitionNonPriceElementsController).ControllerName(), routeValues)">
+                            @if (Model.NonPriceElements.HasNonPriceElement(NonPriceElement.Implementation))
+                            {
                                 <i class="fa-solid fa-pen-to-square" aria-hidden="true"></i>
-                                Change implementation requirements
-                            </a>
-                        </p>
-                    }
-                    else
-                    {
-                        <p class="nhsuk-body-m">
-                            <a class="nhsuk-link nhsuk-link--no-visited-state" href="@Url.Action(nameof(CompetitionNonPriceElementsController.Implementation), typeof(CompetitionNonPriceElementsController).ControllerName(), routeValues)">
-                                <img src="~/images/plus-icon.svg" width="23px" aria-hidden="true"/> Add implementation requirements
-                            </a>
-                        </p>
-                    }
+                                <span>Change implementation requirements</span>
+                            }
+                            else
+                            {
+                                <img src="~/images/plus-icon.svg" width="23px" aria-hidden="true"/>
+                                <span>Add implementation requirements</span>
+                            }
+                        </a>
+                    </p>
                 </nhs-card-footer>
             }
         </nhs-card-v2>
@@ -81,7 +78,7 @@
             <nhs-card-content title="Interoperability">
                 @if (Model.NonPriceElements.HasNonPriceElement(NonPriceElement.Interoperability))
                 {
-                    <partial name="Partials/_Interoperability" model="@(new InteroperabilityPartialModel(Model.AvailableIntegrations, Model.NonPriceElements.IntegrationTypes))" />
+                    <partial name="Partials/_Interoperability" model="@(new InteroperabilityPartialModel(Model.AvailableIntegrations, Model.NonPriceElements.IntegrationTypes))"/>
                 }
                 else
                 {
@@ -90,26 +87,23 @@
                     </p>
                 }
             </nhs-card-content>
-        @if (!Model.HasReviewedCriteria)
+            @if (!Model.HasReviewedCriteria)
             {
                 <nhs-card-footer>
-                    @if (Model.NonPriceElements.HasNonPriceElement(NonPriceElement.Interoperability))
-                    {
-                        <p>
-                            <a class="nhsuk-link--no-visited-state" href="@Url.Action(nameof(CompetitionNonPriceElementsController.Interoperability), typeof(CompetitionNonPriceElementsController).ControllerName(), routeValues)">
+                    <p>
+                        <a class="nhsuk-link--no-visited-state" data-test-id="interoperability-link" href="@Url.Action(nameof(CompetitionNonPriceElementsController.Interoperability), typeof(CompetitionNonPriceElementsController).ControllerName(), routeValues)">
+                            @if (Model.NonPriceElements.HasNonPriceElement(NonPriceElement.Interoperability))
+                            {
                                 <i class="fa-solid fa-pen-to-square" aria-hidden="true"></i>
-                                Change interoperability requirements
-                            </a>
-                        </p>
-                    }
-                    else
-                    {
-                        <p class="nhsuk-body-m">
-                            <a class="nhsuk-link nhsuk-link--no-visited-state" href="@Url.Action(nameof(CompetitionNonPriceElementsController.Interoperability), typeof(CompetitionNonPriceElementsController).ControllerName(), routeValues)">
-                                <img src="~/images/plus-icon.svg" width="23px" aria-hidden="true"/> Add interoperability requirements
-                            </a>
-                        </p>
-                    }
+                                <span>Change interoperability requirements</span>
+                            }
+                            else
+                            {
+                                <img src="~/images/plus-icon.svg" width="23px" aria-hidden="true"/>
+                                <span>Add interoperability requirements</span>
+                            }
+                        </a>
+                    </p>
                 </nhs-card-footer>
             }
         </nhs-card-v2>
@@ -117,7 +111,7 @@
             <nhs-card-content title="Service levels">
                 @if (Model.NonPriceElements.HasNonPriceElement(NonPriceElement.ServiceLevel))
                 {
-                    <partial name="Partials/_ServiceLevels" model="@Model.NonPriceElements.ServiceLevel" />
+                    <partial name="Partials/_ServiceLevels" model="@Model.NonPriceElements.ServiceLevel"/>
                 }
                 else
                 {
@@ -126,26 +120,23 @@
                     </p>
                 }
             </nhs-card-content>
-        @if (!Model.HasReviewedCriteria)
+            @if (!Model.HasReviewedCriteria)
             {
                 <nhs-card-footer>
-                    @if (Model.NonPriceElements.HasNonPriceElement(NonPriceElement.ServiceLevel))
-                    {
-                        <p>
-                            <a class="nhsuk-link--no-visited-state" href="@Url.Action(nameof(CompetitionNonPriceElementsController.ServiceLevel), typeof(CompetitionNonPriceElementsController).ControllerName(), routeValues)">
+                    <p>
+                        <a class="nhsuk-link--no-visited-state" data-test-id="service-levels-link" href="@Url.Action(nameof(CompetitionNonPriceElementsController.ServiceLevel), typeof(CompetitionNonPriceElementsController).ControllerName(), routeValues)">
+                            @if (Model.NonPriceElements.HasNonPriceElement(NonPriceElement.ServiceLevel))
+                            {
                                 <i class="fa-solid fa-pen-to-square" aria-hidden="true"></i>
-                                Change service level requirements
-                            </a>
-                        </p>
-                    }
-                    else
-                    {
-                        <p class="nhsuk-body-m">
-                            <a class="nhsuk-link nhsuk-link--no-visited-state" href="@Url.Action(nameof(CompetitionNonPriceElementsController.ServiceLevel), typeof(CompetitionNonPriceElementsController).ControllerName(), routeValues)">
-                                <img src="~/images/plus-icon.svg" width="23px" aria-hidden="true"/> Add service level requirements
-                            </a>
-                        </p>
-                    }
+                                <span>Change service level requirements</span>
+                            }
+                            else
+                            {
+                                <img src="~/images/plus-icon.svg" width="23px" aria-hidden="true"/>
+                                <span>Add service level requirements</span>
+                            }
+                        </a>
+                    </p>
                 </nhs-card-footer>
             }
         </nhs-card-v2>

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Objects/Competitions/NonPriceObjects.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/Objects/Competitions/NonPriceObjects.cs
@@ -1,10 +1,17 @@
-﻿using OpenQA.Selenium;
+﻿using NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.Common;
+using OpenQA.Selenium;
 
 namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.Competitions
 {
     public static class NonPriceObjects
     {
-        public static By AddNonPriceElementLink => By.LinkText("Add a non-price element");
+        public static By AddFeaturesLink => ByExtensions.DataTestId("features-link");
+
+        public static By AddImplementationLink => ByExtensions.DataTestId("implementation-link");
+
+        public static By AddInteroperabilityLink => ByExtensions.DataTestId("interoperability-link");
+
+        public static By AddServiceLevelsLink => ByExtensions.DataTestId("service-levels-link");
 
         public static By ElementRequirements => By.Id("Requirements");
 
@@ -16,7 +23,7 @@ namespace NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.Competitions
 
         public static By InteroperabilityWeightings => By.Id("Interoperability");
 
-        public static By ServieLevelWeightings => By.Id("ServiceLevel");
+        public static By ServiceLevelWeightings => By.Id("ServiceLevel");
 
         public static By TimeFrom => By.Id("TimeFrom");
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Competitions/CompetitionPages.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Competitions/CompetitionPages.cs
@@ -137,7 +137,7 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Competitions
             }
         }
 
-        public void StepTwoDefineCompetitionCriteria(CompetitionType competitiontype, NonPriceElementType elementtype = NonPriceElementType.Null)
+        public void StepTwoDefineCompetitionCriteria(CompetitionType competitiontype, NonPriceElementType elementType = NonPriceElementType.Null)
         {
             int competitionId = CompetitionId();
 
@@ -155,23 +155,14 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Competitions
                 CompetitionTaskList.AwardCriteriaWeightings();
                 AwardCriteriaWeightings.PriceNonPriceAwardCriteriaWeightings();
                 CompetitionTaskList.NonPriceElements();
-                CompetitionNonPriceElements.AddNonPriceElements(elementtype);
-                switch (elementtype)
-                {
-                    case NonPriceElementType.All:
-                        CompetitionNonPriceElements.AllNonPriceElementsReview();
-                        break;
-                    default:
-                        CompetitionNonPriceElements.AddNonPriceElement();
-                        break;
-                }
+                CompetitionNonPriceElements.AddNonPriceElements(elementType);
 
                 CompetitionTaskList.NonPriceWeightings();
-                NonPriceWeightings.Weightings(elementtype);
+                NonPriceWeightings.Weightings(elementType);
                 CompetitionTaskList.ReviewCompetitionCriteria();
                 ReviewCompetitionCriteria.ReviewCriteria();
                 CompetitionTaskList.CompareAndScoreLink();
-                CompareAndScore.CompareAndScoreShortlistedSolutions(elementtype);
+                CompareAndScore.CompareAndScoreShortlistedSolutions(elementType);
             }
 
             CompetitionTaskList.CalculatePriceTask();

--- a/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Competitions/CompetitionPages.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Competitions/CompetitionPages.cs
@@ -1,4 +1,5 @@
-﻿using NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Actions.Common;
+﻿using System.Runtime.CompilerServices;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Actions.Common;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Competitions.CompetitionToOrder;
 using NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Competitions.Dashboard;
@@ -102,7 +103,7 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Competitions
 
         internal IWebDriver Driver { get; }
 
-        public void StepOnePrepareCompetition(FilterType filterType, string competitionName, ServiceRecipientSelectionMode recipients = ServiceRecipientSelectionMode.None)
+        public void StepOnePrepareCompetition(FilterType filterType, ServiceRecipientSelectionMode recipients = ServiceRecipientSelectionMode.None, [CallerMemberName] string competitionName = "")
         {
             int selectedFilter = (int)filterType;
             SelectFilter.SelectFilterForNewCompetition(selectedFilter);

--- a/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Competitions/StepTwo/NonPrice/CompetitionNonPriceElements.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Competitions/StepTwo/NonPrice/CompetitionNonPriceElements.cs
@@ -28,8 +28,6 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Competitions.StepTwo.N
 
         public void AddNonPriceElements(NonPriceElementType elementType)
         {
-            AddElements();
-
             switch (elementType)
             {
                 case NonPriceElementType.Feature:
@@ -45,64 +43,35 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Competitions.StepTwo.N
                     ServiceLevelAgreement.AddServiceLevelAgreement();
                     break;
                 case NonPriceElementType.All:
-                    SelectAllNonPriceElements();
                     AddAllNonPriceElements();
                     break;
                 case NonPriceElementType.Multiple:
-                    SelectMultipleNonPriceElements();
                     AddMultipleNonPriceElements();
                     break;
                 default:
                     break;
             }
-        }
 
-        public void AddElements()
-        {
-            CommonActions.ClickLinkElement(NonPriceObjects.AddNonPriceElementLink);
-            CommonActions.HintText().Should().Be("You can add any or all optional non-price elements to help you score your shortlisted solutions.".FormatForComparison());
-        }
+            var content = elementType is NonPriceElementType.All
+                ? "All available non-price elements have been added for this competition."
+                : "Add at least 1 optional non-price element to help you score your shortlisted solutions, for example features, implementation, interoperability or service levels.";
 
-        public void AddNonPriceElement()
-        {
-                CommonActions.HintText().Should().Be("Add at least 1 optional non-price element to help you score your shortlisted solutions, for example features, implementation, interoperability or service levels.".FormatForComparison());
-                CommonActions.ClickSaveAndContinue();
-        }
-
-        public void AllNonPriceElementsReview()
-        {
-            CommonActions.HintText().Should().Be("All available non-price elements have been added for this competition.".FormatForComparison());
+            CommonActions.HintText().Should().Be(content.FormatForComparison());
             CommonActions.ClickSaveAndContinue();
-        }
-
-        public void SelectAllNonPriceElements()
-        {
-            CommonActions.ClickCheckboxByLabel("Features");
-            CommonActions.ClickCheckboxByLabel("Implementation");
-            CommonActions.ClickCheckboxByLabel("Interoperability");
-            CommonActions.ClickCheckboxByLabel("Service levels");
-            CommonActions.ClickSave();
         }
 
         public void AddAllNonPriceElements()
         {
-            Features.AddFeatureForAllNonPriceElements();
-            Implementation.AddImplementationForAllNonPriceElements();
-            Interoperability.AddInteroperabilityForAllNonPriceElements();
-            ServiceLevelAgreement.AddServiceLevelAgreementForAllNonPriceElements();
-        }
-
-        public void SelectMultipleNonPriceElements()
-        {
-            CommonActions.ClickCheckboxByLabel("Features");
-            CommonActions.ClickCheckboxByLabel("Implementation");
-            CommonActions.ClickSave();
+            Features.AddFeature();
+            Implementation.AddImplementation();
+            Interoperability.AddInteroperability();
+            ServiceLevelAgreement.AddServiceLevelAgreement();
         }
 
         public void AddMultipleNonPriceElements()
         {
-            Features.AddFeatureForAllNonPriceElements();
-            Implementation.AddImplementationForAllNonPriceElements();
+            Features.AddFeature();
+            Implementation.AddImplementation();
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Competitions/StepTwo/NonPrice/Features.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Competitions/StepTwo/NonPrice/Features.cs
@@ -16,49 +16,30 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Competitions.StepTwo.N
 
         public void AddFeature()
         {
-            CommonActions.ClickCheckboxByLabel("Features");
-            CommonActions.ClickSave();
-
-            CommonActions.HintText().Should().Be("Explain your requirements for features provided by the winning solution. You can add more features requirements later if needed.".FormatForComparison());
-
             MustFeature();
-            ReviewFeatureAddAnotherRequirement();
             ShouldFeature();
-            ReviewFeature();
         }
 
-        public void AddFeatureForAllNonPriceElements()
+        private void MustFeature()
         {
-            MustFeature();
-            ReviewFeatureAddAnotherRequirement();
-            ShouldFeature();
-            ReviewFeature();
-        }
-
-        public void MustFeature()
-        {
+            AddFeatureRequirement();
             CommonActions.ClickRadioButtonWithValue("Must");
             TextGenerators.TextInputAddText(NonPriceObjects.ElementRequirements, 100);
             CommonActions.ClickSave();
         }
 
-        public void ReviewFeatureAddAnotherRequirement()
+        private void ShouldFeature()
         {
-            CommonActions.HintText().Should().Be("Review the information you’ve provided and add any more features requirements if needed.".FormatForComparison());
-            CommonActions.ClickLinkElement(NonPriceObjects.AddAnotherRequirementLink);
-        }
-
-        public void ShouldFeature()
-        {
+            AddFeatureRequirement();
             CommonActions.ClickRadioButtonWithValue("Should");
             TextGenerators.TextInputAddText(NonPriceObjects.ElementRequirements, 100);
             CommonActions.ClickSave();
         }
 
-        public void ReviewFeature()
+        private void AddFeatureRequirement()
         {
-            CommonActions.HintText().Should().Be("Review the information you’ve provided and add any more features requirements if needed.".FormatForComparison());
-            CommonActions.ClickSave();
+            CommonActions.ClickLinkElement(NonPriceObjects.AddFeaturesLink);
+            CommonActions.HintText().Should().Be("Explain your requirements for features provided by the winning solution. You can add more features requirements later if needed.".FormatForComparison());
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Competitions/StepTwo/NonPrice/Implementation.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Competitions/StepTwo/NonPrice/Implementation.cs
@@ -16,16 +16,8 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Competitions.StepTwo.N
 
         public void AddImplementation()
         {
-            CommonActions.ClickCheckboxByLabel("Implementation");
-            CommonActions.ClickSave();
+            CommonActions.ClickLinkElement(NonPriceObjects.AddImplementationLink);
 
-            CommonActions.HintText().Should().Be("Explain your requirements for when the winning solution is implemented.".FormatForComparison());
-            TextGenerators.TextInputAddText(NonPriceObjects.ElementRequirements, 100);
-            CommonActions.ClickSave();
-        }
-
-        public void AddImplementationForAllNonPriceElements()
-        {
             CommonActions.HintText().Should().Be("Explain your requirements for when the winning solution is implemented.".FormatForComparison());
             TextGenerators.TextInputAddText(NonPriceObjects.ElementRequirements, 100);
             CommonActions.ClickSave();

--- a/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Competitions/StepTwo/NonPrice/Interoperability.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Competitions/StepTwo/NonPrice/Interoperability.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Actions.Common;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Objects.Competitions;
 using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
 using NHSD.GPIT.BuyingCatalogue.RegressionTests.Utils;
 using OpenQA.Selenium;
@@ -15,16 +16,8 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Competitions.StepTwo.N
 
         public void AddInteroperability()
         {
-            CommonActions.ClickCheckboxByLabel("Interoperability");
-            CommonActions.ClickSave();
+            CommonActions.ClickLinkElement(NonPriceObjects.AddInteroperabilityLink);
 
-            CommonActions.HintText().Should().Be("Select which integrations your winning solution needs to work with.".FormatForComparison());
-            CommonActions.ClickAllCheckboxes();
-            CommonActions.ClickSave();
-        }
-
-        public void AddInteroperabilityForAllNonPriceElements()
-        {
             CommonActions.HintText().Should().Be("Select which integrations your winning solution needs to work with.".FormatForComparison());
             CommonActions.ClickAllCheckboxes();
             CommonActions.ClickSave();

--- a/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Competitions/StepTwo/NonPrice/NonPriceWeightings.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Competitions/StepTwo/NonPrice/NonPriceWeightings.cs
@@ -61,7 +61,7 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Competitions.StepTwo.N
 
         public void ServiceLevelAgreementWeightings(int weightings)
         {
-            Driver.FindElement(NonPriceObjects.ServieLevelWeightings).SendKeys(weightings.ToString());
+            Driver.FindElement(NonPriceObjects.ServiceLevelWeightings).SendKeys(weightings.ToString());
             CommonActions.ClickSave();
         }
 
@@ -70,7 +70,7 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Competitions.StepTwo.N
             Driver.FindElement(NonPriceObjects.FeatureWeighting).SendKeys(weightings.ToString());
             Driver.FindElement(NonPriceObjects.ImplementationWeighting).SendKeys(weightings.ToString());
             Driver.FindElement(NonPriceObjects.InteroperabilityWeightings).SendKeys(weightings.ToString());
-            Driver.FindElement(NonPriceObjects.ServieLevelWeightings).SendKeys(weightings.ToString());
+            Driver.FindElement(NonPriceObjects.ServiceLevelWeightings).SendKeys(weightings.ToString());
             CommonActions.ClickSave();
         }
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Competitions/StepTwo/NonPrice/ReviewCompetitionCriteria.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Competitions/StepTwo/NonPrice/ReviewCompetitionCriteria.cs
@@ -15,6 +15,7 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Competitions.StepTwo.N
 
         public void ReviewCriteria()
         {
+            CommonActions.ClickFirstCheckbox();
             CommonActions.ClickSave();
             CommonActions.HintText().Should().Be("Complete the following steps to carry out a competition.".FormatForComparison());
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Competitions/StepTwo/NonPrice/ServiceLevelAgreement.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Competitions/StepTwo/NonPrice/ServiceLevelAgreement.cs
@@ -14,15 +14,8 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Competitions.StepTwo.N
 
         public void AddServiceLevelAgreement()
         {
-            CommonActions.ClickCheckboxByLabel("Service levels");
-            CommonActions.ClickSave();
-            CoreHours();
-            ApplicableDays();
-            BankHolidays();
-        }
+            CommonActions.ClickLinkElement(NonPriceObjects.AddServiceLevelsLink);
 
-        public void AddServiceLevelAgreementForAllNonPriceElements()
-        {
             CoreHours();
             ApplicableDays();
             BankHolidays();

--- a/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Competitions/View Result/ViewCompetitionResults.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Competitions/View Result/ViewCompetitionResults.cs
@@ -15,6 +15,7 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Competitions.View_Resu
 
         public void ViewResults()
         {
+            CommonActions.ClickAllCheckboxes();
             CommonActions.ClickSave();
             CommonActions.HintText().Should().Be("These are the results for this competition.".FormatForComparison());
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Ordering/OrderingPages.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Ordering/OrderingPages.cs
@@ -1,4 +1,5 @@
-﻿using NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Actions.Common;
+﻿using System.Runtime.CompilerServices;
+using NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.Actions.Common;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Ordering.Dashboard;
@@ -115,10 +116,10 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Ordering
 
         public void StepOnePrepareOrder(
             string supplierName,
-            string orderDescription,
             bool addNewSupplierContact = false,
-            EntityFramework.Catalogue.Models.CatalogueItemType itemType = EntityFramework.Catalogue.Models.CatalogueItemType.Solution,
-            AssociatedServiceType associatedServiceType = AssociatedServiceType.AssociatedServiceOther)
+            CatalogueItemType itemType = CatalogueItemType.Solution,
+            AssociatedServiceType associatedServiceType = AssociatedServiceType.AssociatedServiceOther,
+            [CallerMemberName] string orderDescription = "")
         {
             TaskList.OrderDescriptionTask();
             OrderingStepOne.AddOrderDescription(orderDescription);

--- a/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Scenarios/CompetitionScenarios.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Scenarios/CompetitionScenarios.cs
@@ -14,52 +14,44 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Further Competition", "Multiple Results")]
         public void CompetitionForMultipleResultFilter()
         {
-            string competitionName = "CompetitionForMultipleResultFilter";
-
             CompetitionPages.CompetitionDashboard.CompetitionTriage();
 
             CompetitionPages.BeforeYouStart.ReadyToStart();
 
-            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, competitionName, ServiceRecipientSelectionMode.Multiple);
+            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, ServiceRecipientSelectionMode.Multiple);
         }
 
         [Fact]
         [Trait("Further Competition", "No Results")]
         public void CompetitionForNoResultFilter()
         {
-            string competitionName = "CompetitionForNoResultFilter";
-
             CompetitionPages.CompetitionDashboard.CompetitionTriage();
 
             CompetitionPages.BeforeYouStart.ReadyToStart();
 
-            CompetitionPages.StepOnePrepareCompetition(FilterType.NoResults, competitionName);
+            CompetitionPages.StepOnePrepareCompetition(FilterType.NoResults);
         }
 
         [Fact]
         [Trait("Further Competition", "Single Results")]
         public void CompetitionForSingleResultFilter()
         {
-            string competitionName = "CompetitionForSingleResultFilter";
-
             CompetitionPages.CompetitionDashboard.CompetitionTriage();
 
             CompetitionPages.BeforeYouStart.ReadyToStart();
 
-            CompetitionPages.StepOnePrepareCompetition(FilterType.SingleResult, competitionName);
+            CompetitionPages.StepOnePrepareCompetition(FilterType.SingleResult);
         }
 
         [Fact]
         [Trait("Further Competition", "Price Only")]
         public void CompetitionPriceOnly()
         {
-            string competitionName = "CompetitionPriceOnly";
-
             CompetitionPages.CompetitionDashboard.CompetitionTriage();
 
             CompetitionPages.BeforeYouStart.ReadyToStart();
 
-            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, competitionName, ServiceRecipientSelectionMode.Single);
+            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, ServiceRecipientSelectionMode.Single);
 
             CompetitionPages.StepTwoDefineCompetitionCriteria(CompetitionType.PriceOnly);
 
@@ -70,13 +62,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Further Competition", "Competition to Order")]
         public void CompetitionOrderFromPriceOnlyCompetition()
         {
-            string competitionName = "CompetitionOrderFromPriceOnlyCompetition";
-
             CompetitionPages.CompetitionDashboard.CompetitionTriage();
 
             CompetitionPages.BeforeYouStart.ReadyToStart();
 
-            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, competitionName, ServiceRecipientSelectionMode.Single);
+            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, ServiceRecipientSelectionMode.Single);
 
             CompetitionPages.StepTwoDefineCompetitionCriteria(CompetitionType.PriceOnly);
 
@@ -91,15 +81,13 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
 
         [Fact]
         [Trait("Further Competition", "Competition to Order")]
-        public void CompetitionOrderFromPricAndNonPriceCompetition()
+        public void CompetitionOrderFromPriceAndNonPriceCompetition()
         {
-            string competitionName = "CompetitionOrderFromPricAndNonPriceCompetition";
-
             CompetitionPages.CompetitionDashboard.CompetitionTriage();
 
             CompetitionPages.BeforeYouStart.ReadyToStart();
 
-            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, competitionName, ServiceRecipientSelectionMode.Single);
+            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, ServiceRecipientSelectionMode.Single);
 
             CompetitionPages.StepTwoDefineCompetitionCriteria(CompetitionType.PriceAndNonPriceElement, NonPriceElementType.Feature);
 
@@ -116,13 +104,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Further Competition", "Competition to Order")]
         public void CompetitionOrderForPriceOnlyMultipleResults()
         {
-            string competitionName = "CompetitionOrderForPriceOnlyMultipleResults";
-
             CompetitionPages.CompetitionDashboard.CompetitionTriage();
 
             CompetitionPages.BeforeYouStart.ReadyToStart();
 
-            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, competitionName, ServiceRecipientSelectionMode.Multiple);
+            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, ServiceRecipientSelectionMode.Multiple);
 
             CompetitionPages.StepTwoDefineCompetitionCriteria(CompetitionType.PriceOnly);
 
@@ -139,13 +125,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Further Competition", "Price Only")]
         public void CompetitionPriceOnlyMultipleRecipients()
         {
-            string competitionName = "CompetitionPriceOnlyMultipleRecipients";
-
             CompetitionPages.CompetitionDashboard.CompetitionTriage();
 
             CompetitionPages.BeforeYouStart.ReadyToStart();
 
-            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, competitionName, ServiceRecipientSelectionMode.Multiple);
+            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, ServiceRecipientSelectionMode.Multiple);
 
             CompetitionPages.StepTwoDefineCompetitionCriteria(CompetitionType.PriceOnly);
 
@@ -156,13 +140,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Further Competition", "Price Only")]
         public void CompetitionPriceOnlyMultipleResults()
         {
-            string competitionName = "CompetitionPriceOnlyMultipleResults";
-
             CompetitionPages.CompetitionDashboard.CompetitionTriage();
 
             CompetitionPages.BeforeYouStart.ReadyToStart();
 
-            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, competitionName, ServiceRecipientSelectionMode.Multiple);
+            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, ServiceRecipientSelectionMode.Multiple);
 
             CompetitionPages.StepTwoDefineCompetitionCriteria(CompetitionType.PriceOnly);
 
@@ -173,13 +155,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Further Competition", "Price Only")]
         public void CompetitionPriceOnlyAllICBRecipients()
         {
-            string competitionName = "CompetitionPriceOnlyAllICBRecipients";
-
             CompetitionPages.CompetitionDashboard.CompetitionTriage();
 
             CompetitionPages.BeforeYouStart.ReadyToStart();
 
-            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, competitionName, ServiceRecipientSelectionMode.All);
+            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, ServiceRecipientSelectionMode.All);
 
             CompetitionPages.StepTwoDefineCompetitionCriteria(CompetitionType.PriceOnly);
 
@@ -188,15 +168,13 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
 
         [Fact]
         [Trait("Further Competition", "Price And Non Price")]
-        public void CompetitionPricAndNonPriceElementFeature()
+        public void CompetitionPriceAndNonPriceElementFeature()
         {
-            string competitionName = "CompetitionPricAndNonPriceElementFeature";
-
             CompetitionPages.CompetitionDashboard.CompetitionTriage();
 
             CompetitionPages.BeforeYouStart.ReadyToStart();
 
-            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, competitionName, ServiceRecipientSelectionMode.Single);
+            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, ServiceRecipientSelectionMode.Single);
 
             CompetitionPages.StepTwoDefineCompetitionCriteria(CompetitionType.PriceAndNonPriceElement, NonPriceElementType.Feature);
 
@@ -205,15 +183,13 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
 
         [Fact]
         [Trait("Further Competition", "Price And Non Price")]
-        public void CompetitionPricAndNonPriceElementImplementation()
+        public void CompetitionPriceAndNonPriceElementImplementation()
         {
-            string competitionName = "CompetitionPricAndNonPriceElementImplementation";
-
             CompetitionPages.CompetitionDashboard.CompetitionTriage();
 
             CompetitionPages.BeforeYouStart.ReadyToStart();
 
-            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, competitionName, ServiceRecipientSelectionMode.Single);
+            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, ServiceRecipientSelectionMode.Single);
 
             CompetitionPages.StepTwoDefineCompetitionCriteria(CompetitionType.PriceAndNonPriceElement, NonPriceElementType.Implementation);
 
@@ -222,15 +198,13 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
 
         [Fact]
         [Trait("Further Competition", "Price And Non Price")]
-        public void CompetitionPricAndNonPriceElementInteroperability()
+        public void CompetitionPriceAndNonPriceElementInteroperability()
         {
-            string competitionName = "CompetitionPricAndNonPriceElementInteroperability";
-
             CompetitionPages.CompetitionDashboard.CompetitionTriage();
 
             CompetitionPages.BeforeYouStart.ReadyToStart();
 
-            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, competitionName, ServiceRecipientSelectionMode.Single);
+            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, ServiceRecipientSelectionMode.Single);
 
             CompetitionPages.StepTwoDefineCompetitionCriteria(CompetitionType.PriceAndNonPriceElement, NonPriceElementType.Interoperability);
 
@@ -239,15 +213,13 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
 
         [Fact]
         [Trait("Further Competition", "Price And Non Price")]
-        public void CompetitionPricAndNonPriceElementServiceLevelAgreement()
+        public void CompetitionPriceAndNonPriceElementServiceLevelAgreement()
         {
-            string competitionName = "CompetitionPricAndNonPriceElementServiceLevelAgreement";
-
             CompetitionPages.CompetitionDashboard.CompetitionTriage();
 
             CompetitionPages.BeforeYouStart.ReadyToStart();
 
-            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, competitionName, ServiceRecipientSelectionMode.Single);
+            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, ServiceRecipientSelectionMode.Single);
 
             CompetitionPages.StepTwoDefineCompetitionCriteria(CompetitionType.PriceAndNonPriceElement, NonPriceElementType.ServiceLevelAgreement);
 
@@ -258,13 +230,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Further Competition", "Price And Non Price")]
         public void CompetitionAllNonPriceElements()
         {
-            string competitionName = "CompetitionAllNonPriceElements";
-
             CompetitionPages.CompetitionDashboard.CompetitionTriage();
 
             CompetitionPages.BeforeYouStart.ReadyToStart();
 
-            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, competitionName, ServiceRecipientSelectionMode.Single);
+            CompetitionPages.StepOnePrepareCompetition(FilterType.MultipleResults, ServiceRecipientSelectionMode.Single);
 
             CompetitionPages.StepTwoDefineCompetitionCriteria(CompetitionType.PriceAndNonPriceElement, NonPriceElementType.All);
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Scenarios/OrderScenarios.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Scenarios/OrderScenarios.cs
@@ -10,13 +10,9 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
     public class OrderScenarios(LocalWebApplicationFactory factory, ITestOutputHelper testOutputHelper)
         : BuyerTestBase(factory, testOutputHelper), IClassFixture<LocalWebApplicationFactory>
     {
-        private const string InternalOrgId = "IB-QWO";
         private const string FileName = "valid_service_recipients.csv";
         private const string SupplierName = "EMIS Health";
-        private const string FrameWorkTechInnovation = "Tech Innovation";
-        private const string FrameWorkDFOCVC = "DFOCVC";
         private const string SolutionName = "Anywhere Consult";
-        private const string SolutionWithMultipleFrameworks = "Video Consult";
         private const string SolutionForLocalfundingonly = "Online and Video Consult";
         private const string AssociatedServiceName = "Anywhere Consult – Integrated Device";
         private const string AssociatedServiceMerger = "Practice Merge";
@@ -31,13 +27,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionUnder40K()
         {
-            string orderDescription = "OrderWithSolutionUnder40K";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(SolutionName);
 
@@ -50,13 +44,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Framework", "Order")]
         public void LocalFundingOnlyFrameworksOrderWithSolutionUnder40K()
         {
-            string orderDescription = "LocalFundingOnlyFrameworksOrderWithSolutionUnder40K";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.DFOCVC, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType(FrameworkType.DFOCVC);
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(SolutionForLocalfundingonly);
 
@@ -69,13 +61,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAndAssociatedServiceUnder40K()
         {
-            string orderDescription = "OrderWithSolutionAndAssociatedServiceUnder40K";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(solutionName: SolutionName, associatedService: AssociatedServiceName);
 
@@ -88,13 +78,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAndAdditionalServiceUnder40K()
         {
-            string orderDescription = "OrderWithSolutionAndAdditionalServiceUnder40K";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices("Emis Web GP", additionalService: "Automated Arrivals");
 
@@ -107,13 +95,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAdditionalAndAssociatedServiceUnder40K()
         {
-            string orderDescription = "OrderWithSolutionAdditionalAndAssociatedServiceUnder40K";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices("Emis Web GP", additionalService: "Automated Arrivals", associatedService: "Automated Arrivals – Engineering Half Day");
 
@@ -126,17 +112,15 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Order Journey", "Order")]
         public void EditPlannedDeliveryDateOrderWithSolutionAdditionalAndAssociatedServiceUnder40K()
         {
-            string orderDescription = "EditPlannedDeliveryDateOrderWithSolutionAdditionalAndAssociatedServiceUnder40K";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices("Emis Web GP", additionalService: "Automated Arrivals", associatedService: "Automated Arrivals – Engineering Half Day");
 
-            OrderingPages.EditPlannedDeliveryDate("Emis Web GP", additionalService: "Automated Arrivals", associatedService: "Automated Arrivals – Engineering Half Day", true);
+            OrderingPages.EditPlannedDeliveryDate("Emis Web GP", additionalService: "Automated Arrivals", associatedService: "Automated Arrivals – Engineering Half Day");
 
             OrderingPages.StepThreeCompleteContract();
 
@@ -147,13 +131,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void CatalogueSolutionOnlyBetween40KTo250K()
         {
-            string orderDescription = "CatalogueSolutionOnlyBetween40KTo250K";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, EntityFramework.Catalogue.Models.CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(SolutionName);
 
@@ -168,13 +150,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Amend Order Journey", "Order")]
         public void Amend_CatalogueSolution()
         {
-            string orderDescription = "Amend_CatalogueSolution";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName);
 
@@ -191,13 +171,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Amend Order Journey", "Order")]
         public void Amend_CatalogueSolution_multiple_servicereceipients()
         {
-            string orderDescription = "Amend_CatalogueSolution_multiple_servicereceipients";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName);
 
@@ -214,13 +192,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Amend Order Journey", "Order")]
         public void Amend_CatalogueSolution_import_servicereceipients()
         {
-            string orderDescription = "Amend_CatalogueSolution_import_servicereceipients";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName);
 
@@ -240,13 +216,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Amend Order Journey", "Order")]
         public void AmendCatalogueSolutionsAndAdditionalService()
         {
-            string orderDescription = "AmendCatalogueSolutionsAndAdditionalService";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices("Emis Web GP", additionalService: "Automated Arrivals");
 
@@ -263,13 +237,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Amend Order Journey", "Order")]
         public void AmendMultipleAdditionalService()
         {
-            string orderDescription = "AmendMultipleAdditionalService";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName);
 
@@ -292,13 +264,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void CatalogueSolutionOnlyWithNewSupplierContactBetween40KTo250K()
         {
-            string orderDescription = "CatalogueSolutionOnlyWithNewSupplierContactBetween40KTo250K";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, EntityFramework.Catalogue.Models.CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, true);
+            OrderingPages.StepOnePrepareOrder(SupplierName, true);
 
             OrderingPages.StepTwoAddSolutionsAndServices(SolutionName);
 
@@ -311,13 +281,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAndAdditionalServiceBetween40Kand250K()
         {
-            string orderDescription = "OrderWithSolutionAndAdditionalServiceBetween40Kand250K";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices("Emis Web GP", additionalService: "Automated Arrivals");
 
@@ -330,13 +298,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAndAdditionalServiceBetween40Kand250KStepThreeCustomRoute()
         {
-            string orderDescription = "OrderWithSolutionAndAdditionalServiceBetween40Kand250K StepThreeCustomRoute";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices("Emis Web GP", additionalService: "Automated Arrivals");
 
@@ -349,13 +315,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAndAssociatedServiceBetween40Kand250K()
         {
-            string orderDescription = "OrderWithSolutionAndAssociatedServiceBetween40Kand250K";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(solutionName: SolutionName, associatedService: AssociatedServiceName);
 
@@ -368,13 +332,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAdditionalAndAssociatedServiceBetween40Kand250K()
         {
-            string orderDescription = "OrderWithSolutionAdditionalAndAssociatedServiceBetween40Kand250K";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices("Emis Web GP", additionalService: "Automated Arrivals", associatedService: "Automated Arrivals – Engineering Half Day");
 
@@ -387,13 +349,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAdditionalAndAssociatedServiceBetween40Kand250KStepThreeCustomRoute()
         {
-            string orderDescription = "OrderWithSolutionAdditionalAndAssociatedServiceBetween40Kand250K StepThreeCustomRoute";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices("Emis Web GP", additionalService: "Automated Arrivals", associatedService: "Automated Arrivals – Engineering Half Day");
 
@@ -406,13 +366,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void CatalogueSolutionOnlyOver250K_AllserviceRecipients()
         {
-            string orderDescription = "CatalogueSolutionOnlyOver250K_AllserviceRecipients";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, EntityFramework.Catalogue.Models.CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(SolutionName, allServiceRecipients: true);
 
@@ -425,13 +383,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void CatalogueSolutionOnlyOver250K()
         {
-            string orderDescription = "CatalogueSolutionOnlyOver250K";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, EntityFramework.Catalogue.Models.CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(SolutionName);
 
@@ -444,13 +400,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void CatalogueSolutionOnlyOver250KStepThreeCustomRoute()
         {
-            string orderDescription = "CatalogueSolutionOnlyOver250K Step Three Custom Route";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, EntityFramework.Catalogue.Models.CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(SolutionName);
 
@@ -463,13 +417,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAndAssociatedServiceOver250K()
         {
-            string orderDescription = "OrderWithSolutionAndAssociatedServiceOver250K";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, EntityFramework.Catalogue.Models.CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(solutionName: SolutionName, associatedService: AssociatedServiceName);
 
@@ -482,13 +434,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAndAdditionalServiceOver250K()
         {
-            string orderDescription = "OrderWithSolutionAndAdditionalServiceOver250K";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices("Emis Web GP", additionalService: "Automated Arrivals");
 
@@ -501,13 +451,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAdditionalAndAssociatedServiceOver250K()
         {
-            string orderDescription = "OrderWithSolutionAdditionalAndAssociatedServiceOver250K";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices("Emis Web GP", additionalService: "Automated Arrivals", associatedService: "Automated Arrivals – Engineering Half Day");
 
@@ -520,13 +468,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Associated Service Only Journey", "Order")]
         public void OrderAssociatedServiceOnly()
         {
-            string orderDescription = "OrderAssociatedServiceOnly";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.AssociatedService, AssociatedServiceType.AssociatedServiceOther);
+            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.AssociatedService);
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false, itemType: CatalogueItemType.AssociatedService);
+            OrderingPages.StepOnePrepareOrder(SupplierName, itemType: CatalogueItemType.AssociatedService);
 
             OrderingPages.StepTwoAddSolutionsAndServices(solutionName: SolutionName, associatedService: AssociatedServiceName);
 
@@ -539,13 +485,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Associated Service Only Journey", "Split Order")]
         public void OrderSplitAssociatedServiceOnly()
         {
-            string orderDescription = "OrderSplitAssociatedServiceOnly";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
             OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.AssociatedService, AssociatedServiceType.AssociatedServiceSplit);
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false, itemType: CatalogueItemType.AssociatedService, associatedServiceType: AssociatedServiceType.AssociatedServiceSplit);
+            OrderingPages.StepOnePrepareOrder(SupplierName, itemType: CatalogueItemType.AssociatedService, associatedServiceType: AssociatedServiceType.AssociatedServiceSplit);
 
             OrderingPages.StepTwoAddSolutionsAndServices(solutionName: SolutionName, associatedService: AssociatedServiceSplit, multipleServiceRecipients: 3);
 
@@ -558,13 +502,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Associated Service Only Journey", "Merger Order")]
         public void OrderMergerAssociatedServiceOnly()
         {
-            string orderDescription = "OrderMergerAssociatedServiceOnly";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
             OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.AssociatedService, AssociatedServiceType.AssociatedServiceMerger);
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false, itemType: CatalogueItemType.AssociatedService, associatedServiceType: AssociatedServiceType.AssociatedServiceMerger);
+            OrderingPages.StepOnePrepareOrder(SupplierName, itemType: CatalogueItemType.AssociatedService, associatedServiceType: AssociatedServiceType.AssociatedServiceMerger);
 
             OrderingPages.StepTwoAddSolutionsAndServices(solutionName: SolutionName, associatedService: AssociatedServiceMerger, multipleServiceRecipients: 3);
 
@@ -577,17 +519,15 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Associated Service Only Journey", "Order")]
         public void EditPlannedDeliveryDateOrderAssociatedServiceOnly()
         {
-            string orderDescription = "EditPlannedDeliveryDateOrderAssociatedServiceOnly";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
             OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.AssociatedService);
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false, itemType: CatalogueItemType.AssociatedService);
+            OrderingPages.StepOnePrepareOrder(SupplierName, itemType: CatalogueItemType.AssociatedService);
 
             OrderingPages.StepTwoAddSolutionsAndServices(solutionName: SolutionName, associatedService: AssociatedServiceName);
 
-            OrderingPages.EditPlannedDeliveryDate("Anywhere Consult", "Anywhere Consult – Integrated Device", " ", true);
+            OrderingPages.EditPlannedDeliveryDate("Anywhere Consult", "Anywhere Consult – Integrated Device", " ");
 
             OrderingPages.StepThreeContractAssociatedServices();
 
@@ -598,13 +538,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Associated Service Only Journey", "Order")]
         public void OrderAssociatedServiceOnlyWithStepThreeCustomRoute()
         {
-            string orderDescription = "OrderAssociatedServiceOnlyWithStepThreeCustomRoute";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
             OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.AssociatedService);
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false, itemType: CatalogueItemType.AssociatedService);
+            OrderingPages.StepOnePrepareOrder(SupplierName, itemType: CatalogueItemType.AssociatedService);
 
             OrderingPages.StepTwoAddSolutionsAndServices(solutionName: SolutionName, associatedService: AssociatedServiceName);
 
@@ -617,13 +555,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Catalogue Solution", "Order")]
         public void OrderWithSolutionUnder40K_EditCatalogueSolution()
         {
-            string orderDescription = "OrderWithSolutionUnder40K_EditCatalogueSolution";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(SolutionName);
 
@@ -638,13 +574,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Catalogue Solution", "Order")]
         public void OrderWithSolutionAndAdditionalServiceUnder40K_EditCatalogueSolution()
         {
-            string orderDescription = "OrderWithSolutionAndAdditionalServiceUnder40K_EditCatalogueSolution";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(SolutionName);
 
@@ -659,13 +593,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Catalogue Solution", "Order")]
         public void OrderWithSolutionAndAssociatedServiceUnder40K_EditCatalogueSolution()
         {
-            string orderDescription = "OrderWithSolutionAndAssociatedServiceUnder40K_EditCatalogueSolution";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(SolutionName);
 
@@ -680,13 +612,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Catalogue Solution", "Order")]
         public void OrderWithSolutionAdditionalAndAssociatedServiceUnder40K_EditCatalogueSolution()
         {
-            string orderDescription = "OrderWithSolutionAdditionalAndAssociatedServiceUnder40K_EditCatalogueSolution";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(SolutionName);
 
@@ -701,13 +631,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Catalogue Solution", "Order")]
         public void OrderAssociatedServiceOnly_EditCatalogueSolution()
         {
-            string orderDescription = "OrderAssociatedServiceOnly_EditCatalogueSolution";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
             OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.AssociatedService);
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false, itemType: CatalogueItemType.AssociatedService);
+            OrderingPages.StepOnePrepareOrder(SupplierName, itemType: CatalogueItemType.AssociatedService);
 
             OrderingPages.StepTwoAddSolutionsAndServices(solutionName: SolutionName, associatedService: AssociatedServiceName);
 
@@ -722,13 +650,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Additional Service", "Order")]
         public void OrderWithSolutionUnder40K_SolutionDoesNotHaveAdditionalService_EditAdditionalService()
         {
-            string orderDescription = "OrderWithSolutionUnder40K_SolutionDoesNotHaveAdditionalService_EditAdditionalService";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(SolutionName);
 
@@ -743,13 +669,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Additional Service", "Order")]
         public void OrderWithSolutionUnder40K_EditAdditionalService()
         {
-            string orderDescription = "OrderWithSolutionUnder40K_EditAdditionalService";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName);
 
@@ -764,13 +688,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Additional Service", "Order")]
         public void OrderWithSolutionAndAdditionalServiceUnder40K_EditAdditionalService()
         {
-            string orderDescription = "OrderWithSolutionAndAdditionalServiceUnder40K_EditAdditionalService";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName, AdditionalServiceName);
 
@@ -785,13 +707,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Additional Service", "Order")]
         public void OrderWithSolutionAndAssociatedServiceUnder40K_EditAdditionalService()
         {
-            string orderDescription = "OrderWithSolutionAndAssociatedServiceUnder40K_EditAdditionalService";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName, associatedService: NewAssociatedServiceName);
 
@@ -806,13 +726,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Additional Service", "Order")]
         public void OrderWithSolutionAdditionalAndAssociatedServiceUnder40K_EditAdditionalService()
         {
-            string orderDescription = "OrderWithSolutionAdditionalAndAssociatedServiceUnder40K_EditAdditionalService";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName, AdditionalServiceName, NewAssociatedServiceName);
 
@@ -827,13 +745,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Associated Service", "Order")]
         public void OrderWithSolutionUnder40K_EditAssociatedService()
         {
-            string orderDescription = "OrderWithSolutionUnder40K_EditAssociatedService";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName);
 
@@ -848,13 +764,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Associated Service", "Order")]
         public void OrderWithSolutionAndAdditionalServiceUnder40K_EditAssociatedService()
         {
-            string orderDescription = "OrderWithSolutionAndAdditionalServiceUnder40K_EditAssociatedService";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName, NewAdditionalServiceName);
 
@@ -869,13 +783,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Associated Service", "Order")]
         public void OrderWithSolutionAndAssociatedServiceUnder40K_EditAssociatedService()
         {
-            string orderDescription = "OrderWithSolutionAndAssociatedServiceUnder40K_EditAssociatedService";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName, associatedService: AssociatedServiceNameForWebGP);
 
@@ -890,13 +802,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Associated Service", "Order")]
         public void OrderWithSolutionAdditionalAndAssociatedServiceUnder40K_EditAssociatedService()
         {
-            string orderDescription = "OrderWithSolutionAdditionalAndAssociatedServiceUnder40K_EditAssociatedService";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName, NewAdditionalServiceName, AssociatedServiceNameForWebGP);
 
@@ -911,13 +821,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Associated Service Only Journey", "Order")]
         public void OrderAssociatedServiceOnly_EditAssociatedService()
         {
-            string orderDescription = "OrderAssociatedServiceOnly_EditAssociatedService";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
             OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.AssociatedService);
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false, itemType: CatalogueItemType.AssociatedService);
+            OrderingPages.StepOnePrepareOrder(SupplierName, itemType: CatalogueItemType.AssociatedService);
 
             OrderingPages.StepTwoAddSolutionsAndServices(solutionName: NewSolutionName, associatedService: AssociatedServiceNameForWebGP);
 
@@ -932,13 +840,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Order Journey", "Order")]
         public void OrderWithSolutionUnder40K_EditCatalogueSolutionServiceRecipient()
         {
-            string orderDescription = "OrderWithSolutionUnder40K_EditCatalogueSolutionServiceRecipient";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName);
 
@@ -953,13 +859,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Order Journey", "Order")]
         public void OrderWithSolutionUnder40K_EditCatalogueSolutionPrice()
         {
-            string orderDescription = "OrderWithSolutionUnder40K_EditCatalogueSolutionPrice";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName);
 
@@ -974,13 +878,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Order Journey", "Order")]
         public void OrderWithSolutionUnder40K_EditCatalogueSolutionQuantity()
         {
-            string orderDescription = "OrderWithSolutionUnder40K_EditCatalogueSolutionQuantity";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName);
 
@@ -995,13 +897,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Order Journey", "Order")]
         public void OrderWithSolutionAndAdditionalServiceUnder40K_EditAdditionalServiceRecipient()
         {
-            string orderDescription = "OrderWithSolutionAndAdditionalServiceUnder40K_EditAdditionalServiceRecipient";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName, NewAdditionalServiceName);
 
@@ -1016,13 +916,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Order Journey", "Order")]
         public void OrderWithSolutionAndAdditionalServiceUnder40K_EditAdditionalServicePrice()
         {
-            string orderDescription = "OrderWithSolutionAndAdditionalServiceUnder40K_EditAdditionalServicePrice";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName, NewAdditionalServiceName);
 
@@ -1037,13 +935,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Order Journey", "Order")]
         public void OrderWithSolutionAndAdditionalServiceUnder40K_EditAdditionalServiceQuantity()
         {
-            string orderDescription = "OrderWithSolutionAndAdditionalServiceUnder40K_EditAdditionalServiceQuantity";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName, NewAdditionalServiceName);
 
@@ -1058,13 +954,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Order Journey", "Order")]
         public void OrderWithSolutionAndAssociatedServiceUnder40K_EditAssociatedServiceRecipient()
         {
-            string orderDescription = "OrderWithSolutionAndAssociatedServiceUnder40K_EditAssociatedServiceRecipient";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName, associatedService: NewAssociatedServiceName);
 
@@ -1079,13 +973,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Order Journey", "Order")]
         public void OrderWithSolutionAndAssociatedServiceUnder40K_EditAssociatedServicePrice()
         {
-            string orderDescription = "OrderWithSolutionAndAssociatedServiceUnder40K_EditAssociatedServicePrice";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName, associatedService: NewAssociatedServiceName);
 
@@ -1100,13 +992,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Order Journey", "Order")]
         public void OrderWithSolutionAndAssociatedServiceUnder40K_EditAssociatedServiceQuantity()
         {
-            string orderDescription = "OrderWithSolutionAndAssociatedServiceUnder40K_EditAssociatedServiceQuantity";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName, associatedService: NewAssociatedServiceName);
 
@@ -1121,13 +1011,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Order Journey", "Order")]
         public void OrderAssociatedServiceOnly_EditAssociatedServiceRecipients()
         {
-            string orderDescription = "OrderAssociatedServiceOnly_EditAssociatedServiceRecipients";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
             OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.AssociatedService);
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false, itemType: CatalogueItemType.AssociatedService);
+            OrderingPages.StepOnePrepareOrder(SupplierName, itemType: CatalogueItemType.AssociatedService);
 
             OrderingPages.StepTwoAddSolutionsAndServices(solutionName: NewSolutionName, associatedService: NewAssociatedServiceName);
 
@@ -1142,13 +1030,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Order Journey", "Order")]
         public void OrderAssociatedServiceOnly_EditAssociatedServicePrice()
         {
-            string orderDescription = "OrderAssociatedServiceOnly_EditAssociatedServicePrice";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
             OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.AssociatedService);
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false, itemType: CatalogueItemType.AssociatedService);
+            OrderingPages.StepOnePrepareOrder(SupplierName, itemType: CatalogueItemType.AssociatedService);
 
             OrderingPages.StepTwoAddSolutionsAndServices(solutionName: NewSolutionName, associatedService: NewAssociatedServiceName);
 
@@ -1163,13 +1049,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Order Journey", "Order")]
         public void OrderAssociatedServiceOnly_EditAssociatedServiceQuantity()
         {
-            string orderDescription = "OrderAssociatedServiceOnly_EditAssociatedServiceQuantity";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
             OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.AssociatedService);
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false, itemType: CatalogueItemType.AssociatedService);
+            OrderingPages.StepOnePrepareOrder(SupplierName, itemType: CatalogueItemType.AssociatedService);
 
             OrderingPages.StepTwoAddSolutionsAndServices(solutionName: NewSolutionName, associatedService: NewAssociatedServiceName);
 
@@ -1184,13 +1068,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAndAdditionalServicesUnder40K_MultipleAdditionalServices()
         {
-            string orderDescription = "OrderWithSolutionAndAdditionalServicesUnder40K_MultipleAdditionalServices";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(
                 solutionName: NewSolutionName,
@@ -1209,13 +1091,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAdditionalAndAssociatedServicesUnder40K_MultipleAdditionalServices_OneAssociatedService()
         {
-            string orderDescription = "OrderWithSolutionAdditionalAndAssociatedServicesUnder40K_MultipleAdditionalServices_OneAssociatedService";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(
                 solutionName: NewSolutionName,
@@ -1235,13 +1115,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAdditionalAndAssociatedServiceUnder40K_MultipleAssociatedServices_OneAdditionalService()
         {
-            string orderDescription = "OrderWithSolutionAdditionalAndAssociatedServiceUnder40K_MultipleAssociatedServices_OneAdditionalService";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(
                 solutionName: NewSolutionName,
@@ -1257,13 +1135,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAndAssociatedServiceUnder40K_MultipleAssociatedServices()
         {
-            string orderDescription = "OrderWithSolutionAndAssociatedServiceUnder40K_MultipleAssociatedServices";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(
                 solutionName: NewSolutionName,
@@ -1279,13 +1155,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAdditionalAndAssociatedServiceUnder40K_MultipleAdditionalServices_MultipleAssociatedServices()
         {
-            string orderDescription = "OrderWithSolutionAdditionalAndAssociatedServiceUnder40K_MultipleAdditionalServices_MultipleAssociatedServices";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(
                 solutionName: NewSolutionName,
@@ -1305,13 +1179,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Associated Service Only Journey", "Order")]
         public void OrderWithAssociatedServiceOnly_MultipleAssociatedServices()
         {
-            string orderDescription = "OrderWithAssociatedServiceOnly_MultipleAssociatedServices";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
             OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.AssociatedService);
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false, itemType: CatalogueItemType.AssociatedService);
+            OrderingPages.StepOnePrepareOrder(SupplierName, itemType: CatalogueItemType.AssociatedService);
 
             OrderingPages.StepTwoAddSolutionsAndServices(
                 solutionName: NewSolutionName,
@@ -1327,13 +1199,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionUnder40K_MultipleServiceRecipients()
         {
-            string orderDescription = "OrderWithSolutionUnder40K_MultipleServiceRecipients";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(
                 solutionName: NewSolutionName,
@@ -1348,13 +1218,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionUnder40K_ImportServiceRecipients()
         {
-            string orderDescription = "OrderWithSolutionUnder40K_ImportServiceRecipients";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(
                 solutionName: NewSolutionName,
@@ -1370,13 +1238,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAndAdditionalServiceUnder40K_MultipleServiceRecipients()
         {
-            string orderDescription = "OrderWithSolutionAndAdditionalServiceUnder40K_MultipleServiceRecipients";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(
                 solutionName: NewSolutionName,
@@ -1392,13 +1258,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAndAdditionalServiceUnder40K_ImportServiceRecipients()
         {
-            string orderDescription = "OrderWithSolutionAndAdditionalServiceUnder40K_ImportServiceRecipients";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(
                 solutionName: NewSolutionName,
@@ -1415,13 +1279,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Associated Service Only Journey", "Order")]
         public void OrderAssociatedServiceOnly_ImportServiceRecipients()
         {
-            string orderDescription = "OrderAssociatedServiceOnly_ImportServiceRecipients";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
             OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.AssociatedService);
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false, itemType: CatalogueItemType.AssociatedService);
+            OrderingPages.StepOnePrepareOrder(SupplierName, itemType: CatalogueItemType.AssociatedService);
 
             OrderingPages.StepTwoAddSolutionsAndServices(
                 solutionName: SolutionName,
@@ -1438,13 +1300,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAndAssociatedServiceUnder40K_MultipleServiceRecipients()
         {
-            string orderDescription = "OrderWithSolutionAndAssociatedServiceUnder40K_MultipleServiceRecipients";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(
                 solutionName: NewSolutionName,
@@ -1460,13 +1320,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAndAssociatedServiceUnder40K_ImportServiceRecipients()
         {
-            string orderDescription = "OrderWithSolutionAndAssociatedServiceUnder40K_ImportServiceRecipients";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(
                 solutionName: NewSolutionName,
@@ -1483,13 +1341,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Order Journey", "Order")]
         public void OrderWithSolutionAdditionalAndAssociatedServiceUnder40K_MultipleServiceRecipients()
         {
-            string orderDescription = "OrderWithSolutionAdditionalAndAssociatedServiceUnder40K_MultipleServiceRecipients";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(
                 solutionName: NewSolutionName,
@@ -1506,13 +1362,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Associated Service Only Journey", "Order")]
         public void OrderWithAssociatedServiceOnly_MultipleServiceRecipients()
         {
-            string orderDescription = "OrderWithAssociatedServiceOnly_MultipleServiceRecipients";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
             OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.AssociatedService);
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false, itemType: CatalogueItemType.AssociatedService);
+            OrderingPages.StepOnePrepareOrder(SupplierName, itemType: CatalogueItemType.AssociatedService);
 
             OrderingPages.StepTwoAddSolutionsAndServices(
                 solutionName: NewSolutionName,
@@ -1528,13 +1382,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Associated Service Only Journey", "Order")]
         public void OrderAssociatedServiceOnly_EditCatalogueSolution_AddMultipleAssociatedServices()
         {
-            string orderDescription = "OrderAssociatedServiceOnly_EditCatalogueSolution_AddMultipleAssociatedServices";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
             OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.AssociatedService);
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false, itemType: CatalogueItemType.AssociatedService);
+            OrderingPages.StepOnePrepareOrder(SupplierName, itemType: CatalogueItemType.AssociatedService);
 
             OrderingPages.StepTwoAddSolutionsAndServices(solutionName: SolutionName, associatedService: AssociatedServiceName);
 
@@ -1549,13 +1401,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Catalogue Solution", "Order")]
         public void OrderWithSolutionUnder40K_EditCatalogueSolution_AddMultipleAdditionalServices()
         {
-            string orderDescription = "OrderWithSolutionUnder40K_EditCatalogueSolution_AddMultipleAdditionalServices";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(SolutionName);
 
@@ -1570,13 +1420,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Catalogue Solution", "Order")]
         public void OrderWithSolutionUnder40K_EditCatalogueSolution_AddMultipleAssociatedServices()
         {
-            string orderDescription = "OrderWithSolutionUnder40K_EditCatalogueSolution_AddMultipleAssociatedServices";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(SolutionName);
 
@@ -1591,13 +1439,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Catalogue Solution", "Order")]
         public void OrderWithSolutionUnder40K_EditCatalogueSolution_AddMultipleAdditional_AddultipleAssociatedServices()
         {
-            string orderDescription = "OrderWithSolutionUnder40K_EditCatalogueSolution_AddMultipleAdditional_AddultipleAssociatedServices";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(SolutionName);
 
@@ -1612,13 +1458,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Catalogue Solution", "Order")]
         public void OrderWithSolutionUnder40K_EditCatalogueSolution_AddMultipleServiceRecipients()
         {
-            string orderDescription = "OrderWithSolutionUnder40K_EditCatalogueSolution_AddMultipleServiceRecipients";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(SolutionName);
 
@@ -1633,13 +1477,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Catalogue Solution", "Order")]
         public void OrderWithSolutionUnder40K_EditCatalogueSolution_AddMultipleAdditionalServices_MultipleServiceRecipients()
         {
-            string orderDescription = "OrderWithSolutionUnder40K_EditCatalogueSolution_AddMultipleAdditionalServices_MultipleServiceRecipients";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(SolutionName);
 
@@ -1654,13 +1496,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Catalogue Solution", "Order")]
         public void OrderWithSolutionUnder40K_EditCatalogueSolution_AddMultipleAssociatedServices_MultipleServiceRecipients()
         {
-            string orderDescription = "OrderWithSolutionUnder40K_EditCatalogueSolution_AddMultipleAssociatedServices_MultipleServiceRecipients";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(SolutionName);
 
@@ -1675,13 +1515,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Catalogue Solution", "Order")]
         public void OrderWithSolutionUnder40K_EditCatalogueSolution_AddMultipleAdditionalServices_AddMultipleAssociatedServices_AddMultipleServiceRecipients()
         {
-            string orderDescription = "OrderWithSolutionUnder40K_EditCatalogueSolution_AddMultipleAdditionalServices_AddMultipleAssociatedServices_AddMultipleServiceRecipients";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(SolutionName);
 
@@ -1696,13 +1534,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Catalogue Solution", "Order")]
         public void OrderWithAssociatedServiceOnly_EditCatalogueSolution_AddMultipleAssociatedServices_AddMultipleServiceRecipients()
         {
-            string orderDescription = "OrderWithAssociatedServiceOnly_EditCatalogueSolution_AddMultipleAssociatedServices_AddMultipleServiceRecipients";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
             OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.AssociatedService);
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false, itemType: CatalogueItemType.AssociatedService);
+            OrderingPages.StepOnePrepareOrder(SupplierName, itemType: CatalogueItemType.AssociatedService);
 
             OrderingPages.StepTwoAddSolutionsAndServices(
                 solutionName: SolutionName,
@@ -1720,13 +1556,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Catalogue Solution", "Order")]
         public void OrderWithSolutionUnder40K_EditCatalogueSolution_AddMultipleAdditionalServices_AddOneAssociatedService()
         {
-            string orderDescription = "OrderWithSolutionUnder40K_EditCatalogueSolution_AddMultipleAdditionalServices_AddOneAssociatedService";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(SolutionName);
 
@@ -1741,13 +1575,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Additional Service", "Order")]
         public void OrderWithSolutionUnder40K_EditAdditionalService_AddMultipleAdditionalServices()
         {
-            string orderDescription = "OrderWithSolutionUnder40K_EditAdditionalService_AddMultipleAdditionalServices";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName);
 
@@ -1762,13 +1594,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Additional Service", "Order")]
         public void OrderWithSolutionAndAdditionalServiceUnder40K_EditAdditionalService_MultipleAdditionalServices()
         {
-            string orderDescription = "OrderWithSolutionAndAdditionalServiceUnder40K_EditAdditionalService_MultipleAdditionalServices";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName, "Document Management", multipleServiceRecipients: 0);
 
@@ -1783,13 +1613,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Associated Service", "Order")]
         public void OrderWithSolutionUnder40K_EditAssociatedService_AddMultipleAssociatedServices()
         {
-            string orderDescription = "OrderWithSolutionUnder40K_EditAssociatedService_AddMultipleAssociatedServices";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName);
 
@@ -1804,13 +1632,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Associated Service", "Order")]
         public void OrderWithSolutionAndAssociatedServiceUnder40K_EditAssociatedService_AddMultipleAssociatedServices()
         {
-            string orderDescription = "OrderWithSolutionAndAssociatedServiceUnder40K_EditAssociatedService_AddMultipleAssociatedServices";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName, associatedService: "Automated Arrivals – Engineering Half Day");
 
@@ -1825,13 +1651,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Edit Associated Service Only Journey", "Order")]
         public void OrderAssociatedServiceOnly_EditAssociatedService_AddMultipleAssociatedServices()
         {
-            string orderDescription = "OrderAssociatedServiceOnly_EditAssociatedService_AddMultipleAssociatedServices";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
             OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.AssociatedService);
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false, itemType: CatalogueItemType.AssociatedService);
+            OrderingPages.StepOnePrepareOrder(SupplierName, itemType: CatalogueItemType.AssociatedService);
 
             OrderingPages.StepTwoAddSolutionsAndServices(solutionName: NewSolutionName, associatedService: "Automated Arrivals – Engineering Half Day");
 
@@ -1846,13 +1670,11 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Amend Order Journey", "Order")]
         public void OrderAmendCatalogueSolutionGreaterThan250K()
         {
-            string orderDescription = "CatalogueSolutionOver250K";
-
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, EntityFramework.Catalogue.Models.CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName);
 
@@ -1869,15 +1691,13 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Scenarios
         [Trait("Amend Order Journey", "Order")]
         public void OrderAmendCatalogueSolutionAmendDescription()
         {
-            string orderDescription = "Amend_CatalogueSolution";
-
             string amendOrderDescription = "AmendedOrder_CatalogueSolution";
 
             OrderingPages.OrderingDashboard.CreateNewOrder();
 
-            OrderingPages.OrderType.ChooseOrderType(FrameworkType.Tech_Innovation, CatalogueItemType.Solution);
+            OrderingPages.OrderType.ChooseOrderType();
 
-            OrderingPages.StepOnePrepareOrder(SupplierName, orderDescription, false);
+            OrderingPages.StepOnePrepareOrder(SupplierName);
 
             OrderingPages.StepTwoAddSolutionsAndServices(NewSolutionName);
 


### PR DESCRIPTION
This updates the existing regression suite to support the newer competition journey designs.

I've also taken the liberty to update the Competition Name/Order Description logic since they're typically based on the method name. This is now supplied via the `CallerMemberNameAttribute` 

https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.callermembernameattribute?view=net-8.0

