### PR TITLE
Terraform: Add settings for secondary VPN

### DIFF
--- a/terraform/webapp/modules/bc_webapp_pri/deployment_slot.tf
+++ b/terraform/webapp/modules/bc_webapp_pri/deployment_slot.tf
@@ -1,7 +1,7 @@
 resource "azurerm_linux_web_app_slot" "slot" {
-  name           = "staging"
-  count          = var.create_slot
-  app_service_id = azurerm_linux_web_app.webapp.id
+  name                                           = "staging"
+  count                                          = var.create_slot
+  app_service_id                                 = azurerm_linux_web_app.webapp.id
   ftp_publish_basic_authentication_enabled       = false
   webdeploy_publish_basic_authentication_enabled = false
 
@@ -16,25 +16,25 @@ resource "azurerm_linux_web_app_slot" "slot" {
     DOMAIN_NAME = var.app_dns_url
 
     # Settings for sql
-    BC_DB_CONNECTION                    = "Server=tcp:${data.azurerm_mssql_server.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.db_name_main};Persist Security Info=False;User ID=${var.sql_admin_username};Password=${var.sql_admin_password};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"    
+    BC_DB_CONNECTION                    = "Server=tcp:${data.azurerm_mssql_server.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.db_name_main};Persist Security Info=False;User ID=${var.sql_admin_username};Password=${var.sql_admin_password};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
     AZUREBLOBSETTINGS__CONNECTIONSTRING = var.blob_storage_connection_string
-    
-    RECAPTCHASETTINGS__SITEKEY          = var.recaptcha_site_key
-    RECAPTCHASETTINGS__SECRETKEY        = var.recaptcha_secret_key
+
+    RECAPTCHASETTINGS__SITEKEY   = var.recaptcha_site_key
+    RECAPTCHASETTINGS__SECRETKEY = var.recaptcha_secret_key
 
     NOTIFY_API_KEY = var.notify_api_key
 
-    SESSION_IDLE_TIMEOUT               = "60"
+    SESSION_IDLE_TIMEOUT = "60"
   }
 
   # Configure Docker Image to load on start
   site_config {
-    use_32_bit_worker   = true
-    always_on           = var.always_on
-    minimum_tls_version = "1.2"
+    use_32_bit_worker             = true
+    always_on                     = var.always_on
+    minimum_tls_version           = "1.2"
     ip_restriction_default_action = "Deny"
-    ftps_state = "Disabled"
-    http2_enabled = true
+    ftps_state                    = "Disabled"
+    http2_enabled                 = true
 
     application_stack {
       docker_image_name        = "${var.repository_name}:latest"
@@ -55,6 +55,16 @@ resource "azurerm_linux_web_app_slot" "slot" {
       ip_address = "${var.primary_vpn}/32"
       priority   = 210
       headers    = []
+    }
+
+    dynamic "ip_restriction" {
+      for_each = var.secondary_vpn
+
+      content {
+        name       = "SECONDARY_VPN_ACCESS_${ip_restriction.key}"
+        ip_address = "${ip_restriction.value}/32"
+        priority   = 300 + ip_restriction.key
+      }
     }
 
     scm_use_main_ip_restriction = false

--- a/terraform/webapp/modules/bc_webapp_pri/main.tf
+++ b/terraform/webapp/modules/bc_webapp_pri/main.tf
@@ -33,12 +33,12 @@ resource "azurerm_linux_web_app" "webapp" {
     BC_DB_CONNECTION                    = "Server=tcp:${data.azurerm_mssql_server.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.db_name_main};Persist Security Info=False;User ID=${var.sql_admin_username};Password=${var.sql_admin_password};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
     AZUREBLOBSETTINGS__CONNECTIONSTRING = var.blob_storage_connection_string
 
-    RECAPTCHASETTINGS__SITEKEY          = var.recaptcha_site_key
-    RECAPTCHASETTINGS__SECRETKEY        = var.recaptcha_secret_key
+    RECAPTCHASETTINGS__SITEKEY   = var.recaptcha_site_key
+    RECAPTCHASETTINGS__SECRETKEY = var.recaptcha_secret_key
 
-    NOTIFY_API_KEY                      = var.notify_api_key
+    NOTIFY_API_KEY = var.notify_api_key
 
-  SESSION_IDLE_TIMEOUT                  = "60"
+    SESSION_IDLE_TIMEOUT = "60"
   }
 
   # Configure Docker Image to load on start
@@ -72,6 +72,16 @@ resource "azurerm_linux_web_app" "webapp" {
       ip_address = "${var.primary_vpn}/32"
       priority   = 210
       headers    = []
+    }
+
+    dynamic "ip_restriction" {
+      for_each = var.secondary_vpn
+
+      content {
+        name       = "SECONDARY_VPN_ACCESS_${ip_restriction.key}"
+        ip_address = "${ip_restriction.value}/32"
+        priority   = 300 + ip_restriction.key
+      }
     }
 
     scm_use_main_ip_restriction = false

--- a/terraform/webapp/modules/bc_webapp_pri/variables.tf
+++ b/terraform/webapp/modules/bc_webapp_pri/variables.tf
@@ -50,6 +50,10 @@ variable "primary_vpn" {
   type = string
 }
 
+variable "secondary_vpn" {
+  type = list(string)
+}
+
 variable "app_gateway_ip" {
   type = string
 }

--- a/terraform/webapp/terraform.deploy.tfvars
+++ b/terraform/webapp/terraform.deploy.tfvars
@@ -2,6 +2,7 @@ environment                 = "$(tf_env)"
 region                      = "$(tf_region)"
 tenant_id                   = "$(tf_tenantid)"
 primary_vpn                 = "$(tf_primaryvpn)"
+secondary_vpn               = [ $(secondary_vpn) ]
 nhsd_network_range          = "$(tf_nhsvpn)"
 app_url                     = "$(tf_appurl)"
 acr_subscription_id         = "$(tf_subscription)"

--- a/terraform/webapp/variables.tf
+++ b/terraform/webapp/variables.tf
@@ -34,6 +34,10 @@ variable "primary_vpn" {
   type = string
 }
 
+variable "secondary_vpn" {
+  type = list(string)
+}
+
 variable "nhsd_network_range" {
   type = string
 }

--- a/terraform/webapp/webapp.tf
+++ b/terraform/webapp/webapp.tf
@@ -14,6 +14,7 @@ module "webapp" {
   aspnet_environment              = var.environment
   instrumentation_key             = azurerm_application_insights.appinsights.instrumentation_key
   primary_vpn                     = var.primary_vpn
+  secondary_vpn                     = var.secondary_vpn
   app_gateway_ip                  = module.appgateway.appgateway_pip_ipaddress
   app_dns_url                     = var.app_url
   docker_registry_server_url      = data.azurerm_container_registry.acr.login_server

--- a/terraform/webapp/webapp.tf
+++ b/terraform/webapp/webapp.tf
@@ -14,7 +14,7 @@ module "webapp" {
   aspnet_environment              = var.environment
   instrumentation_key             = azurerm_application_insights.appinsights.instrumentation_key
   primary_vpn                     = var.primary_vpn
-  secondary_vpn                     = var.secondary_vpn
+  secondary_vpn                   = var.secondary_vpn
   app_gateway_ip                  = module.appgateway.appgateway_pip_ipaddress
   app_dns_url                     = var.app_url
   docker_registry_server_url      = data.azurerm_container_registry.acr.login_server


### PR DESCRIPTION
Introduces a new list variable for the secondary VPN IPs which is then mapped to the App Service and Deployment Slot (think Blue/Green) to permit access to the secondary VPN IP addresses via the [ip_restriction](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_web_app#action-2) block.

Uses a [dynamic block](https://developer.hashicorp.com/terraform/language/expressions/dynamic-blocks) to dynamically add an `ip_restriction` for each IP address. Starts the priority at 300 to create a buffer between static and dynamic entries.