### PR TITLE
23998 - simplify delete order / amendment screen

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/DeleteOrder/DeleteOrder.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/DeleteOrder/DeleteOrder.cshtml
@@ -1,6 +1,6 @@
 ﻿@model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.DeleteOrder.DeleteOrderModel;
 @{
-    ViewBag.Title = $"Are you sure you want to delete this {Model.OrderType}?";
+    ViewBag.Title = $"Delete {Model.OrderType}";
 }
 
 <div data-test-id="delete-order-page">
@@ -11,9 +11,8 @@
             <nhs-validation-summary RadioId="@nameof(Model.SelectedOption)" />
 
             <nhs-page-title title="@ViewBag.Title"
-                            caption="Order @Model.CallOffId"
-                            advice="@Model.Advice" />
-
+                            caption="Order @Model.CallOffId"/>
+            
             <nhs-warning-callout label-text="Deleting an @Model.OrderType"
                                  data-test-id="delete-warning-callout">
                 <p>@Model.Warning</p>
@@ -23,7 +22,7 @@
                 <input type="hidden" asp-for="BackLink" />
                 <input type="hidden" asp-for="IsAmendment" />
 
-                <nhs-fieldset-form-label asp-for="@Model">
+                <nhs-fieldset-form-label label-text="Are you sure you want to delete this @Model.OrderType?" asp-for="@Model">
                     <nhs-radio-buttons asp-for="SelectedOption" 
                                        values="Model.AvailableOptions.Cast<object>()"
                                        value-name="Value"


### PR DESCRIPTION
This PR:

Simplifies the text content on the delete order / amendment screen, and brings the question closer to the selection. This helps when navigating the page with a screen reader, and reducing the overall cognitive load of the page.