### PR TITLE
23801 - investigate component accessibility

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components.WebApp/Views/Home/Buttons.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components.WebApp/Views/Home/Buttons.cshtml
@@ -72,7 +72,7 @@
                              label-text="Secondary Button"
                              size="ExtraLarge">
 
-    <vc:nhs-secondary-button url="buttons" text="Secondary Button" type="Secondary" />
+    <vc:nhs-anchor-button url="buttons" text="Secondary Button" type="Secondary" />
 
     <p>This button is used when you want to redirect a user to another page or do an action that doesn't involve submitting the form</p>
     <p>Multiple Secondary Buttons can be used per page</p>
@@ -81,7 +81,7 @@
                                  label-text="Code Example for the above button"
                                  size="Medium">
         <div class="app-tabs__container bc-code-snippet">
-            <span class="vs-light-theme-blue ">&lt;</span><span class="vs-light-theme-purple">vc:nhs-secondary-button url</span><span class="vs-light-theme-blue">="buttons"&nbsp;</span>
+            <span class="vs-light-theme-blue ">&lt;</span><span class="vs-light-theme-purple">vc:nhs-anchor-button url</span><span class="vs-light-theme-blue">="buttons"&nbsp;</span>
             <span class="vs-light-theme-purple">text</span><span class="vs-light-theme-blue">="Secondary Button" </span>
             <span class="vs-light-theme-blue ">/&gt;</span>
         </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsAnchorButton/NhsAnchorButton.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsAnchorButton/NhsAnchorButton.cshtml
@@ -1,4 +1,4 @@
-﻿@model NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSecondaryButton.NhsAnchorButtonModel
+﻿@model NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsAnchorButton.NhsAnchorButtonModel
 
     <a class="nhsuk-button @Model.ButtonClass" href="@Model.Url" draggable="false">
         @Model.Text

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsAnchorButton/NhsAnchorButtonModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsAnchorButton/NhsAnchorButtonModel.cs
@@ -1,4 +1,4 @@
-﻿namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSecondaryButton
+﻿namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsAnchorButton
 {
     public sealed class NhsAnchorButtonModel
     {

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsAnchorButton/NhsAnchorButtonViewComponent.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsAnchorButton/NhsAnchorButtonViewComponent.cs
@@ -2,9 +2,9 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 
-namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSecondaryButton
+namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsAnchorButton
 {
-    public sealed class NhsSecondaryButtonViewComponent : ViewComponent
+    public sealed class NhsAnchorButtonViewComponent : ViewComponent
     {
         private const string NhsSecondary = "nhsuk-button--secondary";
         private const string NhsDelete = "nhsuk-button--delete";

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsModalSearch/NhsModalSearch.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsModalSearch/NhsModalSearch.cshtml
@@ -29,6 +29,7 @@
 
                             <button type="button" class="app-search__submit" value="search">
                                 <vc:nhs-search-icon />
+                                <span class="nhsuk-u-visually-hidden">Search</span>
                             </button>
                         </div>
                     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsPageTitle/NhsPageTitle.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsPageTitle/NhsPageTitle.cshtml
@@ -11,7 +11,6 @@
     <h1 class="@headingClass">
         <span class="nhsuk-caption-m nhsuk-caption--top">
             @Model.Caption
-            <span class="nhsuk-u-visually-hidden"> - </span>
         </span>
         @Model.Title
     </h1>

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsSearchIcon/NhsSearchIcon.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsSearchIcon/NhsSearchIcon.cshtml
@@ -1,4 +1,3 @@
 ﻿<svg class="nhsuk-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
     <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
 </svg>
-<span class="nhsuk-u-visually-hidden">Search</span>

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsSecondaryButton/NhsAnchorButton.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsSecondaryButton/NhsAnchorButton.cshtml
@@ -1,0 +1,5 @@
+﻿@model NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSecondaryButton.NhsAnchorButtonModel
+
+    <a class="nhsuk-button @Model.ButtonClass" href="@Model.Url" draggable="false">
+        @Model.Text
+    </a>

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsSecondaryButton/NhsAnchorButtonModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsSecondaryButton/NhsAnchorButtonModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSecondaryButton
 {
-    public sealed class NhsSecondaryButtonModel
+    public sealed class NhsAnchorButtonModel
     {
         public string Url { get; set; }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsSecondaryButton/NhsSecondaryButton.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsSecondaryButton/NhsSecondaryButton.cshtml
@@ -1,5 +1,0 @@
-﻿@model NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSecondaryButton.NhsSecondaryButtonModel
-
-    <a class="nhsuk-button @Model.ButtonClass" href="@Model.Url" draggable="false">
-        @Model.Text
-    </a>

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsSecondaryButton/NhsSecondaryButtonViewComponent.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsSecondaryButton/NhsSecondaryButtonViewComponent.cs
@@ -18,7 +18,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSec
 
         public async Task<IViewComponentResult> InvokeAsync(string text, string url, ButtonType type)
         {
-            var model = new NhsSecondaryButtonModel
+            var model = new NhsAnchorButtonModel
             {
                 Text = text,
                 Url = url,
@@ -32,7 +32,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSec
                 _ => throw new ArgumentException($"{nameof(model.ButtonClass)} has an incorrect value of {model.ButtonClass}"),
             };
 
-            return await Task.FromResult(View("NhsSecondaryButton", model));
+            return await Task.FromResult(View("NhsAnchorButton", model));
         }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsSuggestionSearch/NhsSuggestionSearch.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsSuggestionSearch/NhsSuggestionSearch.cshtml
@@ -7,18 +7,16 @@
         "page"
     };
 
-    var labelClass = !string.IsNullOrWhiteSpace(Model.PlaceholderText) ? "nhsuk-u-visually-hidden" : string.Empty;
-
 }
 
 <div id="@(Model.Id + "-form-input-wrap-search")" class="suggestion-search-wrap-search">
-    <label id="@(Model.Id + "-form-input-label")" for="@(Model.Id + "-form-input")" class="@labelClass">@Model.TitleText</label>
+    <label id="@(Model.Id + "-form-input-label")" for="@(Model.Id + "-form-input")">@Model.TitleText</label>
     <form class="suggestion-search-wrap-form" id="@(Model.Id + "-search-form")" action="@(Model.CurrentPageUrl)" method="get" role="search">
         <div class="suggestion-search-container" style="display:none;">
             <label class="nhsuk-u-visually-hidden" for="@Model.Id">@Model.TitleText</label>
             <div id="@(Model.Id + "-container")"></div>
         </div>
-        <input class="nhsuk-search__input" id="@(Model.Id + "-form-input")" name="@Model.QueryParameterName" type="search" autocomplete="off" value="@Model.SearchText" placeholder="@Model.PlaceholderText">
+        <input class="nhsuk-search__input" id="@(Model.Id + "-form-input")" name="@Model.QueryParameterName" type="search" autocomplete="off" value="@Model.SearchText">
         @foreach(var queryParam in Context.Request.Query.Where(q => !ignoredQueryStrings.Contains(q.Key)))
         {
             <input type="hidden" name="@queryParam.Key" value="@queryParam.Value">
@@ -33,5 +31,5 @@
 <script type="text/javascript" src="@Url.Content("~/js/accessible-autocomplete/accessible-autocomplete.min.js")" asp-append-version="true"></script>
 <script type="text/javascript" src="@Url.Content("~/js/accessible-autocomplete/suggestionSearchConfig.min.js")" asp-append-version="true"></script>
 <script type="text/javascript">
-    new suggestionSearchConfig('@Model.Id','@Model.AjaxUrl','@Model.QueryParameterName','@Model.TitleText','@Model.CurrentPageUrl','@Model.PlaceholderText').Implement();
+    new suggestionSearchConfig('@Model.Id','@Model.AjaxUrl','@Model.QueryParameterName','@Model.TitleText','@Model.CurrentPageUrl').Implement();
 </script>

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsSuggestionSearch/NhsSuggestionSearch.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsSuggestionSearch/NhsSuggestionSearch.cshtml
@@ -21,9 +21,9 @@
         {
             <input type="hidden" name="@queryParam.Key" value="@queryParam.Value">
         }
-        <button class="suggestion-search-search__submit" type="submit">
+        <button class="suggestion-search-search__submit" type="submit" title="Submit search">
+            <span class="nhsuk-u-visually-hidden">Submit search</span>
             <vc:nhs-search-icon />
-            <span class="nhsuk-u-visually-hidden">Search</span>
         </button>
     </form>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsSuggestionSearch/NhsSuggestionSearch.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsSuggestionSearch/NhsSuggestionSearch.cshtml
@@ -25,6 +25,7 @@
         }
         <button class="suggestion-search-search__submit" type="submit">
             <vc:nhs-search-icon />
+            <span class="nhsuk-u-visually-hidden">Search</span>
         </button>
     </form>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsSuggestionSearch/NhsSuggestionSearchModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsSuggestionSearch/NhsSuggestionSearchModel.cs
@@ -13,7 +13,5 @@
         public string CurrentPageUrl { get; set; }
 
         public string SearchText { get; set; }
-
-        public string PlaceholderText { get; set; }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsSuggestionSearch/NhsSuggestionSearchViewComponent.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/Components/NhsSuggestionSearch/NhsSuggestionSearchViewComponent.cs
@@ -6,7 +6,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSug
 {
     public sealed class NhsSuggestionSearchViewComponent : ViewComponent
     {
-        public async Task<IViewComponentResult> InvokeAsync(string id, string ajaxUrl, string queryParameterName, string titleText, string placeholderText = "")
+        public async Task<IViewComponentResult> InvokeAsync(string id, string ajaxUrl, string queryParameterName, string titleText)
         {
             var model = new NhsSuggestionSearchModel
             {
@@ -14,7 +14,6 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSug
                 AjaxUrl = ajaxUrl,
                 QueryParameterName = queryParameterName,
                 TitleText = titleText,
-                PlaceholderText = placeholderText,
                 CurrentPageUrl = UriHelper.GetEncodedPathAndQuery(HttpContext.Request),
                 SearchText = HttpContext.Request.Query[queryParameterName],
             };

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Buttons/ButtonGroupTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Buttons/ButtonGroupTagHelper.cs
@@ -5,7 +5,7 @@ using NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers;
 namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Buttons
 {
     [HtmlTargetElement(TagHelperName)]
-    [RestrictChildren(SubmitButtonTagHelper.TagHelperName, "vc:nhs-anchor-button", TagHelperConstants.Anchor, "vc:nhs-delete-button")]
+    [RestrictChildren(SubmitButtonTagHelper.TagHelperName, "vc:nhs-anchor-button", TagHelperConstants.Anchor, "vc:nhs-delete-button", "button")]
     public class ButtonGroupTagHelper : TagHelper
     {
         public const string TagHelperName = "nhs-button-group";

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Buttons/ButtonGroupTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Buttons/ButtonGroupTagHelper.cs
@@ -1,7 +1,8 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers;
 
-namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
+namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Buttons
 {
     [HtmlTargetElement(TagHelperName)]
     [RestrictChildren(SubmitButtonTagHelper.TagHelperName, "vc:nhs-anchor-button", TagHelperConstants.Anchor, "vc:nhs-delete-button")]

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Buttons/ButtonGroupTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Buttons/ButtonGroupTagHelper.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
 {
     [HtmlTargetElement(TagHelperName)]
-    [RestrictChildren(SubmitButtonTagHelper.TagHelperName, "vc:nhs-secondary-button", TagHelperConstants.Anchor, "vc:nhs-delete-button")]
+    [RestrictChildren(SubmitButtonTagHelper.TagHelperName, "vc:nhs-anchor-button", TagHelperConstants.Anchor, "vc:nhs-delete-button")]
     public class ButtonGroupTagHelper : TagHelper
     {
         public const string TagHelperName = "nhs-button-group";

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/TaskList/TaskListItemTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/TaskList/TaskListItemTagHelper.cs
@@ -52,6 +52,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.TaskLi
             var statusTag = GetNhsTagBuilder(context);
             var labelHint = GetLabelHintBuilder();
             var breakRow = new TagBuilder("br") { TagRenderMode = TagRenderMode.SelfClosing };
+            breakRow.MergeAttribute("aria-hidden", "true");
 
             output.Content
                 .AppendHtml(taskNameSpan)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/AdditionalServices/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/AdditionalServices/Index.cshtml
@@ -54,7 +54,7 @@
             </nhs-table>
         }
 
-        <vc:nhs-secondary-button text="Save and continue" url="@Url.Action(
+        <vc:nhs-anchor-button text="Save and continue" url="@Url.Action(
                                                      nameof(CatalogueSolutionsController.ManageCatalogueSolution),
                                                      typeof(CatalogueSolutionsController).ControllerName(),
                                                      new { solutionId = Model.ItemId })" type="Primary" />

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/BrowserBased/BrowserBased.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/BrowserBased/BrowserBased.cshtml
@@ -82,7 +82,7 @@
 
             </nhs-table>
 
-            <vc:nhs-secondary-button text="Save and continue"
+            <vc:nhs-anchor-button text="Save and continue"
                                      type="Primary"
                                      url="@Url.Action(
                                      nameof(CatalogueSolutionsController.ApplicationType),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/ApplicationType.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/ApplicationType.cshtml
@@ -71,7 +71,7 @@
                     </nhs-table>
                 }
                 <br/>
-                <vc:nhs-secondary-button text="Save and continue"
+                <vc:nhs-anchor-button text="Save and continue"
                                          type="Primary"
                                          url="@Url.Action(
                                      nameof(CatalogueSolutionsController.ManageCatalogueSolution),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/ManageCatalogueSolution.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/CatalogueSolutions/ManageCatalogueSolution.cshtml
@@ -41,7 +41,7 @@
             </nhs-summary-list>
         }
 
-        <vc:nhs-secondary-button url="@Url.Action(
+        <vc:nhs-anchor-button url="@Url.Action(
                                       nameof(SolutionsController.Description),
                                       typeof(SolutionsController).ControllerName(),
                                       new { solutionId = Model.SolutionId, area = "Solutions" })"

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/DataProcessingInformation/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/DataProcessingInformation/Index.cshtml
@@ -177,7 +177,7 @@
             </nhs-card-footer>
         </nhs-card-v2>
 
-        <vc:nhs-secondary-button text="Save and continue"
+        <vc:nhs-anchor-button text="Save and continue"
                                  type="Primary"
                                  url="@Model.BackLink"/>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/DesktopBased/Desktop.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/DesktopBased/Desktop.cshtml
@@ -94,7 +94,7 @@
 
             </nhs-table>
 
-            <vc:nhs-secondary-button text="Save and continue"
+            <vc:nhs-anchor-button text="Save and continue"
                                      type="Primary"
                                      url="@Url.Action(
                                      nameof(CatalogueSolutionsController.ApplicationType),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/EmailDomainManagement/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/EmailDomainManagement/Index.cshtml
@@ -50,6 +50,6 @@
             </nhs-table>
         }
 
-        <vc:nhs-secondary-button text="Save and continue" type="Primary" url="@Url.Action(nameof(HomeController.Index), typeof(HomeController).ControllerName())"/>
+        <vc:nhs-anchor-button text="Save and continue" type="Primary" url="@Url.Action(nameof(HomeController.Index), typeof(HomeController).ControllerName())"/>
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Frameworks/Dashboard.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Frameworks/Dashboard.cshtml
@@ -74,7 +74,7 @@
             </nhs-table>
         }
 
-        <vc:nhs-secondary-button text="Save and continue"
+        <vc:nhs-anchor-button text="Save and continue"
                                  type="Primary"
                                  url="@Url.Action(nameof(HomeController.Index), typeof(HomeController).ControllerName())"/>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Gen2Mapping/Confirmation.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Gen2Mapping/Confirmation.cshtml
@@ -10,6 +10,6 @@
 
         <p class="nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-9">@Model.Content</p>
 
-        <vc:nhs-secondary-button type="Primary" text="Return to admin homepage" url="@(Url.Action(nameof(HomeController.Index), typeof(HomeController).ControllerName()))" />
+        <vc:nhs-anchor-button type="Primary" text="Return to admin homepage" url="@(Url.Action(nameof(HomeController.Index), typeof(HomeController).ControllerName()))" />
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Gen2Mapping/FailedCapabilities.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Gen2Mapping/FailedCapabilities.cshtml
@@ -40,6 +40,6 @@
 
         <br/>
 
-        <vc:nhs-secondary-button text="Return to admin homepage" url="@Url.Action(nameof(HomeController.Index), typeof(HomeController).ControllerName(), new { area = typeof(HomeController).AreaName() })" type="Primary"/>
+        <vc:nhs-anchor-button text="Return to admin homepage" url="@Url.Action(nameof(HomeController.Index), typeof(HomeController).ControllerName(), new { area = typeof(HomeController).AreaName() })" type="Primary"/>
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Gen2Mapping/FailedEpics.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Gen2Mapping/FailedEpics.cshtml
@@ -42,6 +42,6 @@
 
         <br/>
 
-        <vc:nhs-secondary-button text="Return to admin homepage" url="@Url.Action(nameof(HomeController.Index), typeof(HomeController).ControllerName(), new { area = typeof(HomeController).AreaName() })" type="Primary"/>
+        <vc:nhs-anchor-button text="Return to admin homepage" url="@Url.Action(nameof(HomeController.Index), typeof(HomeController).ControllerName(), new { area = typeof(HomeController).AreaName() })" type="Primary"/>
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ManageOrders/DeleteNotLatest.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ManageOrders/DeleteNotLatest.cshtml
@@ -20,7 +20,7 @@
                             advice="@advice" />
 
             <br />
-            <vc:nhs-secondary-button text="Return to orders dashboard" url="@Url.Action(nameof(ManageOrdersController.Index))" type="Primary" />
+            <vc:nhs-anchor-button text="Return to orders dashboard" url="@Url.Action(nameof(ManageOrdersController.Index))" type="Primary" />
         </div>
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ManageOrders/ViewOrder.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ManageOrders/ViewOrder.cshtml
@@ -55,12 +55,12 @@
         @if (Model.OrderStatus != OrderStatus.Deleted)
         {
             <div>
-                <vc:nhs-secondary-button text="Download order summary PDF"
+                <vc:nhs-anchor-button text="Download order summary PDF"
                                          url="@Url.Action(nameof(ManageOrdersController.Download), typeof(ManageOrdersController).ControllerName(), new { internalOrgId = Model.OrganisationInternalIdentifier, callOffId = Model.CallOffId })"
                                          type="Secondary"/>
                 @if (Model.OrderStatus is OrderStatus.Completed or OrderStatus.Terminated)
                 {
-                    <vc:nhs-secondary-button text="Download full order CSV"
+                    <vc:nhs-anchor-button text="Download full order CSV"
                                              url="@Url.Action(nameof(ManageOrdersController.DownloadFullOrderCsv), typeof(ManageOrdersController).ControllerName(), new { externalOrgId = Model.OrganisationExternalIdentifier, callOffId = Model.CallOffId })"
                                              type="Secondary"/>
                 }
@@ -100,7 +100,7 @@
         <p data-test-id="no-order-items">No solutions or services have been added to this order yet</p>
     }
 
-    <vc:nhs-secondary-button text="Save and continue" url="@Url.Action(
+    <vc:nhs-anchor-button text="Save and continue" url="@Url.Action(
                                                       nameof(ManageOrdersController.Index),
                                                       typeof(ManageOrdersController).ControllerName())"
                              type="Primary" />

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/MobileTabletBased/MobileTablet.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/MobileTabletBased/MobileTablet.cshtml
@@ -94,7 +94,7 @@
 
             </nhs-table>
 
-            <vc:nhs-secondary-button text="Save and continue"
+            <vc:nhs-anchor-button text="Save and continue"
                                      type="Primary"
                                      url="@Url.Action(
                                      nameof(CatalogueSolutionsController.ApplicationType),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Organisations/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Organisations/Index.cshtml
@@ -24,7 +24,7 @@
                                  typeof(OrganisationsController).ControllerName())"
                         text="Add an organisation"/>
 
-    <vc:nhs-secondary-button text="Import practice lists"
+    <vc:nhs-anchor-button text="Import practice lists"
                              url="@Url.Action(
                                       nameof(ImportController.ImportGpPracticeList),
                                       typeof(ImportController).ControllerName())"

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ServiceLevelAgreements/EditServiceLevelAgreement.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/ServiceLevelAgreements/EditServiceLevelAgreement.cshtml
@@ -146,7 +146,7 @@
     }
 </nhs-table>
 
-<vc:nhs-secondary-button text="Save and continue"
+<vc:nhs-anchor-button text="Save and continue"
                          type="Primary"
                          url="@Url.Action(
                                 nameof(CatalogueSolutionsController.ManageCatalogueSolution),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/ListPrices/ManageListPrices.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Shared/ListPrices/ManageListPrices.cshtml
@@ -1,7 +1,7 @@
 ﻿@using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models
 @using NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
 @using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.ActionLink
-@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSecondaryButton
+@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsAnchorButton
 @using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.SummaryList
 @using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Table
 @using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Tags
@@ -94,7 +94,7 @@
             </div>
         }
 
-        <vc:nhs-secondary-button text="Save and continue"
+        <vc:nhs-anchor-button text="Save and continue"
                                     type="Primary"
                                     url="@Model.BackLink" />
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/SupplierDefinedEpics/EditSupplierDefinedEpic.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/SupplierDefinedEpics/EditSupplierDefinedEpic.cshtml
@@ -54,7 +54,7 @@
             </nhs-table-row-container>
         </nhs-table>
 
-        <vc:nhs-secondary-button text="Save and continue"
+        <vc:nhs-anchor-button text="Save and continue"
                                  type="Primary"
                                  url="@Model.BackLink"/>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Suppliers/ManageSupplierContacts.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Suppliers/ManageSupplierContacts.cshtml
@@ -42,7 +42,7 @@
         </nhs-table>
         
         <div class="nhsuk-u-margin-top-9">
-            <vc:nhs-secondary-button text="Save and continue"
+            <vc:nhs-anchor-button text="Save and continue"
                                      type="Primary"
                                      url="@Url.Action(
                                               nameof(SuppliersController.EditSupplier),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionHub/Hub.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionHub/Hub.cshtml
@@ -82,7 +82,7 @@
             </div>
         }
 
-        <vc:nhs-secondary-button text="Save and continue"
+        <vc:nhs-anchor-button text="Save and continue"
                                  url="@Model.BackLink"
                                  type="Primary"/>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionHub/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionHub/Index.cshtml
@@ -1,5 +1,5 @@
 @using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums
-@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSecondaryButton
+@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsAnchorButton
 @using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Card
 @using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Table
 @using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Tags
@@ -42,7 +42,7 @@
             </nhs-card-content>
         </nhs-card-v2>
         <br/>
-        <vc:nhs-secondary-button type="Primary" text="Save and continue" url="@Model.BackLink"/>
+        <vc:nhs-anchor-button type="Primary" text="Save and continue" url="@Model.BackLink"/>
     </div>
 </div>
 @{

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionNonPriceElements/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionNonPriceElements/Index.cshtml
@@ -1,5 +1,5 @@
 @using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Competitions
-@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSecondaryButton
+@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsAnchorButton
 @using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Card
 @using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Competitions.Models.Shared.Partials
 @model NonPriceElementsModel
@@ -141,6 +141,6 @@
             }
         </nhs-card-v2>
         <br/>
-        <vc:nhs-secondary-button type="Primary" text="Save and continue" url="@Model.BackLink"/>
+        <vc:nhs-anchor-button type="Primary" text="Save and continue" url="@Model.BackLink"/>
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionResults/Confirm.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionResults/Confirm.cshtml
@@ -77,8 +77,8 @@
 
             <nhs-button-group>
                 <nhs-submit-button text="View results"/>
-                <vc:nhs-secondary-button type="Secondary" text="Save for later" url="@Url.Action(nameof(CompetitionsDashboardController.Index), typeof(CompetitionsDashboardController).ControllerName(), new { internalOrgId = Model.InternalOrgId })"/>
-                <vc:nhs-secondary-button text="Download summary (PDF)"
+                <vc:nhs-anchor-button type="Secondary" text="Save for later" url="@Url.Action(nameof(CompetitionsDashboardController.Index), typeof(CompetitionsDashboardController).ControllerName(), new { internalOrgId = Model.InternalOrgId })"/>
+                <vc:nhs-anchor-button text="Download summary (PDF)"
                                          url="@Model.PdfUrl"
                                          type="Secondary"/>
             </nhs-button-group>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionResults/_ResultsOrderingInformation.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionResults/_ResultsOrderingInformation.cshtml
@@ -12,7 +12,7 @@
         <p>Download the results of your competition as evidence of how you arrived at one solution.</p>
     }
 
-    <vc:nhs-secondary-button text="Download results (PDF)"
+    <vc:nhs-anchor-button text="Download results (PDF)"
                                 url="@Model.PdfUrl"
                                 type="Secondary" />
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionResults/_SolutionResult.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionResults/_SolutionResult.cshtml
@@ -71,6 +71,6 @@
     <div class="order-this-now">
         <h4 class="nhsuk-heading-s nhsuk-u-margin-top-3">Order winning solution</h4>
         <p class="nhsuk-body">The information you entered for this competition, such as the solution and recipients, will be carried over to the order.</p>
-        <vc:nhs-secondary-button type="Primary" text="Order @Model.SolutionName" url="@Url.Action(nameof(CompetitionResultsController.OrderingInformation), typeof(CompetitionResultsController).ControllerName(), new { internalOrgId = Model.InternalOrgId, competitionId = Model.CompetitionId, solutionId = Model.SolutionId})"/>
+        <vc:nhs-anchor-button type="Primary" text="Order @Model.SolutionName" url="@Url.Action(nameof(CompetitionResultsController.OrderingInformation), typeof(CompetitionResultsController).ControllerName(), new { internalOrgId = Model.InternalOrgId, competitionId = Model.CompetitionId, solutionId = Model.SolutionId})"/>
     </div>
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionScoring/Features.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionScoring/Features.cshtml
@@ -109,7 +109,7 @@
                     <nhs-button-group>
                         <nhs-submit-button/>
 
-                        <vc:nhs-secondary-button text="Download features comparison (PDF)"
+                        <vc:nhs-anchor-button text="Download features comparison (PDF)"
                                  url="@Model.PdfUrl"
                                  type="Secondary"/>
                     </nhs-button-group>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionScoring/Implementation.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionScoring/Implementation.cshtml
@@ -64,7 +64,7 @@
                     <nhs-button-group>
                         <nhs-submit-button/>
 
-                        <vc:nhs-secondary-button text="Download implementation comparison (PDF)"
+                        <vc:nhs-anchor-button text="Download implementation comparison (PDF)"
                                              url="@Model.PdfUrl"
                                              type="Secondary" />
                     </nhs-button-group>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionScoring/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionScoring/Index.cshtml
@@ -49,8 +49,8 @@
         <br/>
 
         <nhs-button-group>
-            <vc:nhs-secondary-button type="Primary" text="Save and continue" url="@Model.BackLink"/>
-            <vc:nhs-secondary-button type="Secondary" text="Save for later" url="@Url.Action(nameof(CompetitionsDashboardController.Index), typeof(CompetitionsDashboardController).ControllerName(), new { internalOrgId = Model.InternalOrgId })"/>
+            <vc:nhs-anchor-button type="Primary" text="Save and continue" url="@Model.BackLink"/>
+            <vc:nhs-anchor-button type="Secondary" text="Save for later" url="@Url.Action(nameof(CompetitionsDashboardController.Index), typeof(CompetitionsDashboardController).ControllerName(), new { internalOrgId = Model.InternalOrgId })"/>
         </nhs-button-group>
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionScoring/Interoperability.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionScoring/Interoperability.cshtml
@@ -136,7 +136,7 @@
                     <nhs-button-group>
                         <nhs-submit-button/>
 
-                        <vc:nhs-secondary-button text="Download interoperability comparison (PDF)"
+                        <vc:nhs-anchor-button text="Download interoperability comparison (PDF)"
                                              url="@Model.PdfUrl"
                                              type="Secondary" />
                     </nhs-button-group>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionScoring/ServiceLevel.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionScoring/ServiceLevel.cshtml
@@ -122,7 +122,7 @@
                     <nhs-button-group>
                         <nhs-submit-button/>
 
-                        <vc:nhs-secondary-button text="Download service levels comparison (PDF)"
+                        <vc:nhs-anchor-button text="Download service levels comparison (PDF)"
                                                  url="@Model.PdfUrl"
                                                  type="Secondary"/>
                     </nhs-button-group>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionSelectSolutions/SelectSolutions.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionSelectSolutions/SelectSolutions.cshtml
@@ -22,7 +22,7 @@
                         <p>You'll need to use a different filter.</p>
                     </nhs-inset-text>
 
-                    <vc:nhs-secondary-button text="Start a new search"
+                    <vc:nhs-anchor-button text="Start a new search"
                                              type="Primary"
                                              url="@Url.Action(nameof(SolutionsController.Index), typeof(SolutionsController).ControllerName(), new { Area = typeof(SolutionsController).AreaName() })" />
                 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionTaskList/ShortlistedSolutions.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionTaskList/ShortlistedSolutions.cshtml
@@ -52,7 +52,7 @@
                 </nhs-card-content>
             </nhs-card-v2>
 
-            <vc:nhs-secondary-button text="Save and continue"
+            <vc:nhs-anchor-button text="Save and continue"
                                      type="Primary"
                                      url="@Model.BackLink"/>
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/CommencementDate/CommencementDate.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/CommencementDate/CommencementDate.cshtml
@@ -37,7 +37,7 @@
                 </nhs-summary-list>
             </div>
 
-            <vc:nhs-secondary-button text="Save and continue"
+            <vc:nhs-anchor-button text="Save and continue"
                                      type="Primary"
                                      url="@Url.Action(
                                               nameof(OrderController.Order),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Dashboard/Organisation.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Dashboard/Organisation.cshtml
@@ -49,7 +49,6 @@
                 <vc:nhs-suggestion-search id="orders-suggestion-search"
                                           ajax-url="@Url.Action(nameof(DashboardController.FilterSearchSuggestions), typeof(DashboardController).ControllerName(), new { Model.InternalOrgId })"
                                           title-text="Search for order by order description or Call-off ID"
-                                          placeholder-text="Search by Call-off Agreement ID or order description"
                                           query-parameter-name="search"/>
             }
             <br/>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/DeliveryDates/Review.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/DeliveryDates/Review.cshtml
@@ -195,7 +195,7 @@
             }
         }
 
-        <vc:nhs-secondary-button text="Save and continue"
+        <vc:nhs-anchor-button text="Save and continue"
                                  type="Primary"
                                  url="@Url.Action(
                                           nameof(OrderController.Order),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/Completed.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/Completed.cshtml
@@ -1,5 +1,5 @@
 ﻿@using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers
-@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSecondaryButton
+@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsAnchorButton
 @model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.Orders.CompletedModel
 
 @{
@@ -60,10 +60,10 @@
         </nhs-step-list>
 
         <nhs-button-group>
-            <vc:nhs-secondary-button text="Return to orders dashboard"
+            <vc:nhs-anchor-button text="Return to orders dashboard"
                                      type="Primary"
                                      url="@Model.BackLink" />
-            <vc:nhs-secondary-button text="Download order (PDF)"
+            <vc:nhs-anchor-button text="Download order (PDF)"
                                      type="Secondary"
                                      url="@Url.Action(
                                               nameof(OrderController.Download),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/Order.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/Order.cshtml
@@ -128,7 +128,7 @@
             {
                 <nhs-button-group>
 
-                    <vc:nhs-secondary-button text="Save for later"
+                    <vc:nhs-anchor-button text="Save for later"
                                              url="@Model.BackLink"
                                              type="Secondary" />
                 </nhs-button-group>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/Summary.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/Summary.cshtml
@@ -394,20 +394,20 @@
                         }
                         else
                         {
-                            <vc:nhs-secondary-button text="Save and continue"
+                            <vc:nhs-anchor-button text="Save and continue"
                                                      type="Primary"
                                                      url="@Url.Action(nameof(OrderController.Order), typeof(OrderController).ControllerName(), new { Model.InternalOrgId, Model.CallOffId })"/>
                         }
                     }
 
-                    <vc:nhs-secondary-button text="Download order (PDF)"
+                    <vc:nhs-anchor-button text="Download order (PDF)"
                                              type="Secondary"
                                              url="@Url.Action(nameof(OrderController.Download), typeof(OrderController).ControllerName(), new { Model.InternalOrgId, Model.CallOffId })"/>
 
 
                     @if (Model.CanBeAmended)
                     {
-                        <vc:nhs-secondary-button text="Amend contract"
+                        <vc:nhs-anchor-button text="Amend contract"
                                                  type="Secondary"
                                                  url="@Url.Action(nameof(OrderController.AmendOrder), typeof(OrderController).ControllerName(), new { Model.InternalOrgId, Model.CallOffId })"/>
                     }
@@ -426,7 +426,7 @@
                 @if (Model.Order.OrderStatus != OrderStatus.InProgress)
                 {
                     <nhs-button-group>
-                        <vc:nhs-secondary-button text="Return to orders"
+                        <vc:nhs-anchor-button text="Return to orders"
                                                  type="Primary"
                                                  url="@Url.Action(nameof(DashboardController.Organisation), typeof(DashboardController).ControllerName(), new { Model.InternalOrgId })"/>
                     </nhs-button-group>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Quantity/ViewOrderItemQuantity.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Quantity/ViewOrderItemQuantity.cshtml
@@ -19,7 +19,7 @@
         </div>
         
         <div class="nhsuk-u-margin-top-9">
-            <vc:nhs-secondary-button text="Save and continue"
+            <vc:nhs-anchor-button text="Save and continue"
                                      type="Primary"
                                      url="@Model.BackLink"/>
         </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Quantity/ViewServiceRecipientQuantity.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Quantity/ViewServiceRecipientQuantity.cshtml
@@ -40,7 +40,7 @@
         </div>
 
         <div class="nhsuk-u-margin-top-6">
-            <vc:nhs-secondary-button text="Save and continue"
+            <vc:nhs-anchor-button text="Save and continue"
                                      type="Primary"
                                      url="@Model.BackLink"/>
         </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Supplier/NoAvailableSuppliers.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Supplier/NoAvailableSuppliers.cshtml
@@ -12,7 +12,7 @@
                             advice="There are currently no suppliers on the Buying Catalogue that support this type of order: @Model.OrderTypeText" />
 
             <p>You should return to your order tasklist and delete this order.</p>
-            <vc:nhs-secondary-button text="Return to order tasklist"
+            <vc:nhs-anchor-button text="Return to order tasklist"
                                      type="Primary"
                                      url="@Model.BackLink" />
         </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/TaskList/TaskList.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/TaskList/TaskList.cshtml
@@ -161,7 +161,7 @@
             }
         </nhs-card-v2>
 
-        <vc:nhs-secondary-button text="Save and continue"
+        <vc:nhs-anchor-button text="Save and continue"
                                  url="@Model.OnwardLink"
                                  type="Primary" />
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/ManageFilters/CannotSaveFilter.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/ManageFilters/CannotSaveFilter.cshtml
@@ -1,7 +1,7 @@
 ﻿@using NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @using NHSD.GPIT.BuyingCatalogue.Framework.Extensions
-@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSecondaryButton
+@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsAnchorButton
 @using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
 @using ValidationSummaryTagHelper = Microsoft.AspNetCore.Mvc.TagHelpers.ValidationSummaryTagHelper
 @model NHSD.GPIT.BuyingCatalogue.WebApp.Models.NavBaseModel
@@ -20,7 +20,7 @@
         <nhs-page-title title="@ViewBag.Title"
                         advice="You already have 10 filters saved which is the maximum allowed. You’ll need to delete an existing filter." />
         
-        <vc:nhs-secondary-button text="Go to saved filters"
+        <vc:nhs-anchor-button text="Go to saved filters"
                                  url="@Url.Action(
                                           nameof(ManageFiltersController.Index),
                                           typeof(ManageFiltersController).ControllerName())"

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/Index.cshtml
@@ -30,8 +30,7 @@
                     <div id="search-by">
                         <vc:nhs-suggestion-search id="marketing-suggestion-search"
                                                     ajax-url="@Url.Action(nameof(SolutionsController.FilterSearchSuggestions), typeof(SolutionsController).ControllerName())"
-                                                    title-text="Filter Catalogue Solutions"
-                                                    placeholder-text="Search by supplier or solution name"
+                                                    title-text="Search by supplier or solution name"
                                                     query-parameter-name="search" />
                     </div>
                 </nhs-card>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/ListPrice.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/ListPrice.cshtml
@@ -94,7 +94,7 @@
         @if (Model.IsSubPage)
         {
             string buttonText = "Return to " + @Model.PriceFor + "s";
-            <vc:nhs-secondary-button url=@Model.BackLink
+            <vc:nhs-anchor-button url=@Model.BackLink
                                  type="Secondary"
                                  text=@buttonText />
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/NominateOrganisation/Confirmation.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/NominateOrganisation/Confirmation.cshtml
@@ -16,7 +16,7 @@
                 The Buying Catalogue Team aims to respond to nomination requests within 5 working days.
             </p>
         </div>
-        <vc:nhs-secondary-button text="Return to buyer dashboard"
+        <vc:nhs-anchor-button text="Return to buyer dashboard"
                                  url="@Model.BackLink"
                                  type="Primary" />
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/NominateOrganisation/Unavailable.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/NominateOrganisation/Unavailable.cshtml
@@ -9,7 +9,7 @@
         <nhs-page-title title="@ViewBag.Title"
                         advice="As you are buying for a single practice, you cannot nominate an organisation to act on your behalf." />
 
-        <vc:nhs-secondary-button text="Return to homepage"
+        <vc:nhs-anchor-button text="Return to homepage"
                                  url="@Url.Action(
                                           nameof(HomeController.Index),
                                           typeof(HomeController).ControllerName())"

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/Dashboard/_CompetitionsCardPartial.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/Dashboard/_CompetitionsCardPartial.cshtml
@@ -1,7 +1,7 @@
 @using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
 @using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Competitions.Controllers
 @using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums
-@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSecondaryButton
+@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsAnchorButton
 @using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Competitions.Models.DashboardModels
 
 @model NHSD.GPIT.BuyingCatalogue.WebApp.Models.Shared.Dashboard.DashboardCardBaseModel<CompetitionDashboardItem>
@@ -80,7 +80,7 @@
                    asp-controller="@typeof(SolutionsController).ControllerName()"
                    asp-area="@typeof(SolutionsController).AreaName()">Catalogue Solutions</a>.
             </p>
-            <vc:nhs-secondary-button text="Create new competition"
+            <vc:nhs-anchor-button text="Create new competition"
                                      url="@(Url.Action(nameof(CompetitionsDashboardController.BeforeYouStart), typeof(CompetitionsDashboardController).ControllerName(), new { area = typeof(CompetitionsDashboardController).AreaName(), internalOrgId = Model.InternalOrgId }))"
                                      type="Primary"/>
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/Dashboard/_OrderCardPartial.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/Dashboard/_OrderCardPartial.cshtml
@@ -109,7 +109,7 @@
                        asp-controller="@typeof(SolutionsController).ControllerName()"
                        asp-area="@typeof(SolutionsController).AreaName()">Catalogue Solutions</a> available to order.
                 </p>
-                <vc:nhs-secondary-button text="Create new order"
+                <vc:nhs-anchor-button text="Create new order"
                                          url="@Url.Action(nameof(OrderController.ReadyToStart), typeof(OrderController).ControllerName(), new { internalOrgId = Model.InternalOrgId, area = typeof(OrderController).AreaName() })"
                                          type="Primary" />
             }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/Dashboard/_ShortlistCardPartial.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/Dashboard/_ShortlistCardPartial.cshtml
@@ -89,7 +89,7 @@
                    asp-controller="@typeof(SolutionsController).ControllerName()"
                    asp-area="@typeof(SolutionsController).AreaName()">Catalogue Solutions</a> available and create a shortlist.
             </p>
-            <vc:nhs-secondary-button text="Create new shortlist"
+            <vc:nhs-anchor-button text="Create new shortlist"
                                      url="@(Url.Action(nameof(SolutionsController.Index), typeof(SolutionsController).ControllerName(), new { Area = typeof(SolutionsController).AreaName() }))"
                                      type="Primary" />
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/OrganisationBase/NominatedOrganisations.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/OrganisationBase/NominatedOrganisations.cshtml
@@ -86,7 +86,7 @@
             </div>
         }
 
-        <vc:nhs-secondary-button text="Save and continue" 
+        <vc:nhs-anchor-button text="Save and continue" 
                                  url="@Url.Action(
                                           nameof(OrganisationBaseController.Details),
                                           Model.ControllerName,

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/OrganisationBase/RelatedOrganisations.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/OrganisationBase/RelatedOrganisations.cshtml
@@ -80,7 +80,7 @@
             </div>
         }
 
-        <vc:nhs-secondary-button text="Save and continue" 
+        <vc:nhs-anchor-button text="Save and continue" 
                                  url="@Url.Action(
                                           nameof(OrganisationBaseController.Details),
                                           Model.ControllerName,

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/OrganisationBase/Users.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/OrganisationBase/Users.cshtml
@@ -98,7 +98,7 @@
             </div>
         }
 
-        <vc:nhs-secondary-button text="Save and continue" 
+        <vc:nhs-anchor-button text="Save and continue" 
                                  url="@Url.Action(
                                           nameof(OrganisationBaseController.Details),
                                           Model.ControllerName,

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/Partials/_CookieConsentPartial.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/Partials/_CookieConsentPartial.cshtml
@@ -4,19 +4,21 @@
         <p class="nhsuk-body-m">We've put some small files called cookies on your device to make the Buying Catalogue website work.</p>
         <p class="nhsuk-body-m">We'd also like to use analytics cookies. These send information about how our site is used to services called Adobe Analytics and Hotjar. We use this information to improve our website.</p>
         <p class="nhsuk-body-m">Let us know if this is OK. We'll use a cookie to save your choice. You can read more about our <a href="/privacy-policy">cookies and privacy policy</a> before you choose.</p>
-        <div data-test-id="cookie-dismiss" class="nhsuk-button-group">
-            <a id="accept-analytics" class="nhsuk-button nhsuk-u-margin-right-3" draggable="false"
-               asp-controller="@typeof(ConsentController).ControllerName()" 
-               asp-action="@nameof(ConsentController.AcceptCookies)" 
-               asp-route-agreeToAnalytics="true">
-                I'm OK with analytics cookies
-            </a>
-            <a id="reject-analytics" class="nhsuk-button" draggable="false"
-               asp-controller="@typeof(ConsentController).ControllerName()" 
-               asp-action="@nameof(ConsentController.AcceptCookies)" 
-               asp-route-agreeToAnalytics="false">
-                Do not use analytics cookies
-            </a>
+        <div data-test-id="cookie-dismiss">
+            <nhs-button-group>
+            <vc:nhs-anchor-button text="I'm OK with analytics cookies"
+                                  type="Primary"
+                                  url="@Url.Action(
+                                           nameof(ConsentController.AcceptCookies),
+                                           typeof(ConsentController).ControllerName(),
+                                           new { agreeToAnalytics = true }) ?? string.Empty"/>
+            <vc:nhs-anchor-button text="Do not use analytics cookies"
+                                  type="Primary"
+                                  url="@Url.Action(
+                                           nameof(ConsentController.AcceptCookies),
+                                           typeof(ConsentController).ControllerName(),
+                                           new { agreeToAnalytics = false }) ?? string.Empty"/>
+            </nhs-button-group>
         </div>
     </div>
 </section>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/Partials/_CookieConsentPartial.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/Partials/_CookieConsentPartial.cshtml
@@ -4,7 +4,7 @@
         <p class="nhsuk-body-m">We've put some small files called cookies on your device to make the Buying Catalogue website work.</p>
         <p class="nhsuk-body-m">We'd also like to use analytics cookies. These send information about how our site is used to services called Adobe Analytics and Hotjar. We use this information to improve our website.</p>
         <p class="nhsuk-body-m">Let us know if this is OK. We'll use a cookie to save your choice. You can read more about our <a href="/privacy-policy">cookies and privacy policy</a> before you choose.</p>
-        <div data-test-id="cookie-dismiss">
+        <div data-test-id="cookie-dismiss" class="nhsuk-button-group">
             <a id="accept-analytics" class="nhsuk-button nhsuk-u-margin-right-3" draggable="false"
                asp-controller="@typeof(ConsentController).ControllerName()" 
                asp-action="@nameof(ConsentController.AcceptCookies)" 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/PriceSelection/ViewPrice.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/PriceSelection/ViewPrice.cshtml
@@ -1,5 +1,5 @@
 ﻿@using Microsoft.AspNetCore.Mvc.TagHelpers
-@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSecondaryButton
+@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsAnchorButton
 @using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.SummaryList
 @model NHSD.GPIT.BuyingCatalogue.WebApp.Models.Shared.Pricing.ViewPriceModel
 @{
@@ -31,7 +31,7 @@
                      model="new PriceCalculationDetailsModel(Model.ItemType, Model.PriceType, Model.CalculationType)" />
         </div>
 
-        <vc:nhs-secondary-button type="Primary"
+        <vc:nhs-anchor-button type="Primary"
                                  text="Save and continue"
                                  url="@Model.OnwardLink"/>
 	</div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/ServiceRecipients/ImportServiceRecipients/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/ServiceRecipients/ImportServiceRecipients/Index.cshtml
@@ -18,7 +18,7 @@
             If you upload Service Recipients more than once for this item, they’ll be overwritten each time.
         </p>
 
-        <vc:nhs-secondary-button text="Download template (CSV)"
+        <vc:nhs-anchor-button text="Download template (CSV)"
                                  type="Secondary"
                                  url="@Model.DownloadTemplateLink"/>
         

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/ServiceRecipients/ImportServiceRecipients/ValidateOds.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/ServiceRecipients/ImportServiceRecipients/ValidateOds.cshtml
@@ -43,7 +43,7 @@
 
         <p>If you continue with your import, any Service Recipients that have failed to import will not be included.</p>
 
-        <vc:nhs-secondary-button type="Primary"
+        <vc:nhs-anchor-button type="Primary"
                                          text="Save and continue"
                                          url="@Model.ValidateNamesLink" />
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/ServiceRecipients/SelectRecipients.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/ServiceRecipients/SelectRecipients.cshtml
@@ -1,6 +1,6 @@
 @using NHSD.GPIT.BuyingCatalogue.EntityFramework.Organisations.Models
 @using NHSD.GPIT.BuyingCatalogue.WebApp.Models.Shared.ServiceRecipientModels;
-@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSecondaryButton
+@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsAnchorButton
 @model NHSD.GPIT.BuyingCatalogue.WebApp.Models.Shared.ServiceRecipientModels.SelectRecipientsModel;
 
 @{
@@ -38,10 +38,10 @@
                 </nhs-inset-text>
             }
             <div class="bc-u-max-width-full">
-                <vc:nhs-secondary-button url="@Url.Action(null, values: new { selectionMode = SelectionMode.All })"
+                <vc:nhs-anchor-button url="@Url.Action(null, values: new { selectionMode = SelectionMode.All })"
                                      text="Select all"
                                      type="Secondary" />
-                <vc:nhs-secondary-button url="@Url.Action(null, values: new { selectionMode = SelectionMode.None })"
+                <vc:nhs-anchor-button url="@Url.Action(null, values: new { selectionMode = SelectionMode.None })"
                                      text="Deselect all"
                                      type="Secondary" />
                 <button id="show-dialog" class="nhsuk-button nhsuk-button--secondary bc-u-float-right nhsuk-button--js-only">

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/ServiceRecipients/SelectRecipients.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/ServiceRecipients/SelectRecipients.cshtml
@@ -38,16 +38,18 @@
                 </nhs-inset-text>
             }
             <div class="bc-u-max-width-full">
-                <vc:nhs-anchor-button url="@Url.Action(null, values: new { selectionMode = SelectionMode.All })"
-                                     text="Select all"
-                                     type="Secondary" />
-                <vc:nhs-anchor-button url="@Url.Action(null, values: new { selectionMode = SelectionMode.None })"
-                                     text="Deselect all"
-                                     type="Secondary" />
-                <button id="show-dialog" class="nhsuk-button nhsuk-button--secondary bc-u-float-right nhsuk-button--js-only">
-                    <vc:nhs-search-icon/>
-                    Search for Service Recipients
-                </button>
+                <nhs-button-group>
+                    <vc:nhs-anchor-button url="@Url.Action(null, values: new { selectionMode = SelectionMode.All })"
+                                          text="Select all"
+                                          type="Secondary"/>
+                    <vc:nhs-anchor-button url="@Url.Action(null, values: new { selectionMode = SelectionMode.None })"
+                                          text="Deselect all"
+                                          type="Secondary"/>
+                    <button id="show-dialog" class="nhsuk-button nhsuk-button--secondary bc-u-float-right nhsuk-button--js-only">
+                        <vc:nhs-search-icon/>
+                        Search for Service Recipients
+                    </button>
+                </nhs-button-group>
             </div>
         }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/Shortlists/FilterDetails.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/Shortlists/FilterDetails.cshtml
@@ -28,7 +28,7 @@
                 {
                     <span class="bc-flex-container" style="justify-content: space-between">
                         <h3 class="header-with-detail">@Model.FilterDetails.Name (@Model.ResultsCount)</h3>
-                        <vc:nhs-secondary-button text="Download results (PDF)"
+                        <vc:nhs-anchor-button text="Download results (PDF)"
                                                  url="@Url.Action(nameof(ManageFiltersController.DownloadResults),
                                                                     typeof(ManageFiltersController).ControllerName(),
                                                                     new { Area = typeof(ManageFiltersController).AreaName(), filterId = Model.FilterDetails.Id })"
@@ -44,7 +44,7 @@
                         <hr class="nhsuk-u-padding-bottom-5 nhsuk-u-margin-bottom-5 nhsuk-u-margin-top-0">
                         <p>Due to changes on the Buying Catalogue, there are currently no results returned using the selected filters. This may change in future as a wider range of solutions are added.</p>
                         <div style="display: inline-block" class="nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4">
-                            <vc:nhs-secondary-button url="@Model.BackLink"
+                            <vc:nhs-anchor-button url="@Model.BackLink"
                                                      type="Secondary"
                                                      text="Return to shortlists" />
                             @if (!Model.InCompetition)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/wwwroot/scss/_suggestion-search.scss
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/wwwroot/scss/_suggestion-search.scss
@@ -264,4 +264,12 @@
         cursor: pointer;
         border: 1px solid #fff;
     }
+
+    &:focus {
+        background-color: #ffeb3b;
+        box-shadow: 0 -2px #ffeb3b, 0 4px #212b32;
+        color: #212b32;
+        outline: 4px solid transparent;
+        text-decoration: none;
+    }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/wwwroot/ts/suggestionSearchConfig.ts
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/wwwroot/ts/suggestionSearchConfig.ts
@@ -31,7 +31,6 @@ class suggestionSearchConfig {
     ajaxUrl: string;
     queryParameterName: string;
     titleText: string;
-    placeholderText: string;
     currentPageUrl: string;
     form: HTMLFormElement;
     defaultInput: HTMLElement;
@@ -41,13 +40,11 @@ class suggestionSearchConfig {
                 ajaxUrl: string,
                 queryParameterName: string,
                 titleText: string,
-                currentPageUrl: string,
-                placeholderText: string) {
+                currentPageUrl: string) {
         this.modelId = modelId;
         this.ajaxUrl = ajaxUrl;
         this.queryParameterName = queryParameterName;
         this.titleText = titleText;
-        this.placeholderText = placeholderText;
         this.currentPageUrl = currentPageUrl;
         let form = document.getElementById(modelId.concat("-search-form"));
 
@@ -71,7 +68,6 @@ class suggestionSearchConfig {
             confirmOnBlur: false,
             onConfirm: this.onConfirm.bind(this),
             defaultValue: this.defaultValue(),
-            placeholder: this.placeholderText,
             minLength: 2,
             cssNamespace: "suggestion-search",
             templates: {

--- a/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Admin/ManageSolutions/ListPricesForServices.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Admin/ManageSolutions/ListPricesForServices.cs
@@ -26,7 +26,7 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Admin.ManageSolutions
             CommonActions.ClickSave();
             CommonActions.PageTitle()
                 .Should()
-                .BeEquivalentTo($"{service} - Add a flat list price".FormatForComparison());
+                .BeEquivalentTo($"{service}Add a flat list price".FormatForComparison());
 
             AddFlatPriceDetails(service);
         }
@@ -45,7 +45,7 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Admin.ManageSolutions
             CommonActions.ClickSave();
             CommonActions.PageTitle()
                 .Should()
-                .BeEquivalentTo($"{service} - List price".FormatForComparison());
+                .BeEquivalentTo($"{service}List price".FormatForComparison());
 
             CommonActions.ClickSaveAndContinue();
         }
@@ -57,7 +57,7 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Admin.ManageSolutions
             CommonActions.ClickSave();
             CommonActions.PageTitle()
                 .Should()
-                .BeEquivalentTo($"{service} - Add a tiered list price".FormatForComparison());
+                .BeEquivalentTo($"{service}Add a tiered list price".FormatForComparison());
 
             AddTieredPriceDetails(service);
             AddTieredPriceTierDetails(service);
@@ -75,7 +75,7 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Admin.ManageSolutions
             CommonActions.ClickSave();
             CommonActions.PageTitle()
                 .Should()
-                .BeEquivalentTo($"{service} - Tiered list price information".FormatForComparison());
+                .BeEquivalentTo($"{service}Tiered list price information".FormatForComparison());
         }
 
         public void AddTieredPriceTierDetails(string service)
@@ -83,7 +83,7 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Admin.ManageSolutions
             CommonActions.ClickLinkElement(ListPriceObjects.AddTierLink);
             CommonActions.PageTitle()
                 .Should()
-                .BeEquivalentTo($"{service} - Add a pricing tier".FormatForComparison());
+                .BeEquivalentTo($"{service}Add a pricing tier".FormatForComparison());
 
             const decimal price = 3.14m;
             const int lowerRange = 1;
@@ -95,13 +95,13 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Admin.ManageSolutions
             CommonActions.ClickSave();
             CommonActions.PageTitle()
                 .Should()
-                .BeEquivalentTo($"{service} - Tiered list price information".FormatForComparison());
+                .BeEquivalentTo($"{service}Tiered list price information".FormatForComparison());
 
             CommonActions.ClickLastRadio();
             CommonActions.ClickSave();
             CommonActions.PageTitle()
                 .Should()
-                .BeEquivalentTo($"{service} - List price".FormatForComparison());
+                .BeEquivalentTo($"{service}List price".FormatForComparison());
 
             CommonActions.ClickSaveAndContinue();
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Admin/ManageSolutions/SolutionAdditionalServices/SolutionAdditionalService.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Admin/ManageSolutions/SolutionAdditionalServices/SolutionAdditionalService.cs
@@ -88,13 +88,13 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Admin.ManageSolutions.
             CommonActions.ClickLinkElement(AdditionalServicesObjects.EditPriceLink(serviceId));
             CommonActions.PageTitle()
                 .Should()
-                .BeEquivalentTo($"{service} - List price".FormatForComparison());
+                .BeEquivalentTo($"{service}List price".FormatForComparison());
 
             CommonActions.ClickLinkElement(ManageListPricesObjects.AddPriceLink);
 
             CommonActions.PageTitle()
                 .Should()
-                .BeEquivalentTo($"{service} - List price type".FormatForComparison());
+                .BeEquivalentTo($"{service}List price type".FormatForComparison());
 
             if (priceType == ListPriceTypes.Flat_price.ToString())
             {

--- a/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Admin/ManageSolutions/SolutionAssociatedServices/SolutionAssociatedService.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/Pages/Admin/ManageSolutions/SolutionAssociatedServices/SolutionAssociatedService.cs
@@ -67,13 +67,13 @@ namespace NHSD.GPIT.BuyingCatalogue.RegressionTests.Pages.Admin.ManageSolutions.
             CommonActions.ClickLinkElement(AssociatedServicesObjects.EditPriceLink(serviceId));
             CommonActions.PageTitle()
                 .Should()
-                .BeEquivalentTo($"{service} - List price".FormatForComparison());
+                .BeEquivalentTo($"{service}List price".FormatForComparison());
 
             CommonActions.ClickLinkElement(ManageListPricesObjects.AddPriceLink);
 
             CommonActions.PageTitle()
                 .Should()
-                .BeEquivalentTo($"{service} - List price type".FormatForComparison());
+                .BeEquivalentTo($"{service}List price type".FormatForComparison());
 
             if (priceType == ListPriceTypes.Flat_price.ToString())
             {


### PR DESCRIPTION
This PR:

Updates the button component to remove the misleading nhs-secondary-button tag helper name and replaces it with nhs-anchor-button to better reflect its purpose

Updates button groups to use the nhsuk-button-group tag helper / class as this solves screen reader issues on Firefox

Updates page titles to no longer have a visually hidden '-' within them as this also solves screen reader issues on firefox

Updates the search icon component to no longer have the visually hidden search span within, as the screen reader announcement of 'search' didn't always make sense depending on where the icon was used.

Updates the search component to no longer have an inline placeholder, and use the label above in the remaining two instances.

Updates the search button on the search component to have focus highlighting when tabbed.

Updates the task list component to aria hide the break tag so this isn't read out by the screen reader.