### PR TITLE
Bugfix: ICO link and Supplier Contact title

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/SupplierController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/SupplierController.cs
@@ -273,7 +273,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers
             {
                 Title = newContact == null
                     ? "Add a contact"
-                    : $"{newContact.FirstName} {newContact.LastName} details",
+                    : $"{newContact.NameOrDepartment} details",
                 BackLink = Url.Action(nameof(Supplier), new { internalOrgId, callOffId }),
                 FirstName = newContact?.FirstName,
                 LastName = newContact?.LastName,

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Home/PrivacyPolicy.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Home/PrivacyPolicy.cshtml
@@ -340,7 +340,7 @@
         </ul>
 
         <p>
-            <a href="https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/individual-rights/">Find more information on these rights</a>.
+            <a href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/individual-rights/">Find more information on these rights</a>.
         </p>
 
         <p>

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SupplierControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SupplierControllerTests.cs
@@ -687,6 +687,47 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
 
         [Theory]
         [MockAutoData]
+        public static async Task Get_NewContact_WithDepartmentName_ReturnsModelWithExpectedTitle(
+            string internalOrgId,
+            CallOffId callOffId,
+            int supplierId,
+            string supplierName,
+            EntityFramework.Ordering.Models.Order order,
+            SupplierContact supplierContact,
+            [Frozen] IOrderService mockOrderService,
+            [Frozen] ISupplierContactSessionService mockSessionService,
+            SupplierController systemUnderTest)
+        {
+            supplierContact.FirstName = supplierContact.LastName = null;
+            var model = new NewContactModel(callOffId, supplierId, supplierName)
+            {
+                Title = $"{supplierContact.Department} details",
+                FirstName = supplierContact.FirstName,
+                LastName = supplierContact.LastName,
+                Department = supplierContact.Department,
+                PhoneNumber = supplierContact.PhoneNumber,
+                Email = supplierContact.Email,
+            };
+
+            order.SupplierId = supplierId;
+            order.Supplier.Name = supplierName;
+
+            mockOrderService
+                .GetOrderWithSupplier(callOffId, internalOrgId)
+                .Returns(new OrderWrapper(order));
+
+            mockSessionService
+                .GetSupplierContact(callOffId, supplierId)
+                .Returns(supplierContact);
+
+            var result = await systemUnderTest.NewContact(internalOrgId, callOffId);
+
+            result.Should().BeOfType<ViewResult>();
+            result.As<ViewResult>().ViewData.Model.Should().BeEquivalentTo(model, x => x.Excluding(m => m.BackLink));
+        }
+
+        [Theory]
+        [MockAutoData]
         public static void Post_NewContact_AddsContactToSession_RedirectsCorrectly(
             string internalOrgId,
             CallOffId callOffId,


### PR DESCRIPTION
Fixes two bugs:
1. Updates the ICO GDPR link to the newer URL
2. Uses the existing `NameOrDepartment` property for the `SupplierContact` to set the page title correctly in the ordering journey