### PR TITLE
24019 - lock fluent assertions version at 7.1.0

### DIFF
--- a/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Bogus" Version="34.0.2" />
     <PackageReference Include="DotNetSeleniumExtras.PageObjects" Version="3.11.0" />
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.1.0,8.0.0)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.1" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="Selenium.Support" Version="4.2.0" />

--- a/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests.csproj
@@ -21,7 +21,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
-      <PackageReference Include="FluentAssertions" Version="6.7.0" />
+      <PackageReference Include="FluentAssertions" Version="[7.1.0,8.0.0)" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
       <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
         <PrivateAssets>all</PrivateAssets>

--- a/tests/NHSD.GPIT.BuyingCatalogue.Framework.UnitTests/NHSD.GPIT.BuyingCatalogue.Framework.UnitTests.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Framework.UnitTests/NHSD.GPIT.BuyingCatalogue.Framework.UnitTests.csproj
@@ -23,7 +23,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.1.0,8.0.0)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />

--- a/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/NHSD.GPIT.BuyingCatalogue.RegressionTests.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/NHSD.GPIT.BuyingCatalogue.RegressionTests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.1.0,8.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Selenium.Support" Version="4.2.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.2.0" />

--- a/tests/NHSD.GPIT.BuyingCatalogue.ServiceContracts.UnitTests/NHSD.GPIT.BuyingCatalogue.ServiceContracts.UnitTests.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.ServiceContracts.UnitTests/NHSD.GPIT.BuyingCatalogue.ServiceContracts.UnitTests.csproj
@@ -24,7 +24,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.1.0,8.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NSubstitute" Version="4.4.0 " />

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests.csproj
@@ -25,7 +25,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.1.0,8.0.0)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NSubstitute" Version="4.4.0 " />

--- a/tests/NHSD.GPIT.BuyingCatalogue.UI.Components.UnitTests/NHSD.GPIT.BuyingCatalogue.UI.Components.UnitTests.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.UI.Components.UnitTests/NHSD.GPIT.BuyingCatalogue.UI.Components.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -21,7 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.1.0,8.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/NHSD.GPIT.BuyingCatalogue.UnitTest.Framework/NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.UnitTest.Framework/NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.17.0" />
     <PackageReference Include="AutoFixture.xUnit2" Version="4.17.0" />
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.1.0,8.0.0)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.csproj
@@ -24,7 +24,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.1.0,8.0.0)" />
     <PackageReference Include="FluentValidation" Version="11.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NSubstitute" Version="4.4.0" />


### PR DESCRIPTION
Following the widespread announcement that fluent assertions will require a licence for commercial use from v8 onwards, a spike was conducted to gauge the impact of this change on the buying catalogue, the following points informed our response to this change:

- The cost for a licence, per **developer** (non transferrable) is $150 per year.
- The Buying Catalogue uses this library extensively, so would require lots of work to unpick it.
- The authors have committed to supporting version 7 with critical patches and fixes on the existing licence terms.
- The only major alternative to Fluent Assertions, shouldly, is not maintained to the same level as fluent assertions, with its last update being over 18 months ago.
- Up until now we were running v6.7.0, so clearly had no reliance on the latest cutting edge features
- Fluent Assertions had never appeared in vulnerability databases such as Snyk, and the code is not user facing so currently presents minimal risk even if it were to fall out of maintenance.

Ultimately the decision was to update to the most current apache2 licenced version, V7.1.0, and watchful wait the situation to see how it develops.