### PR TITLE
Add function to rebuild SQL indexes

### DIFF
--- a/database/NHSD.GPITBuyingCatalogue.Database/Catalogue/Stored Procedures/OptimizeIndexes.sql
+++ b/database/NHSD.GPITBuyingCatalogue.Database/Catalogue/Stored Procedures/OptimizeIndexes.sql
@@ -1,0 +1,36 @@
+﻿CREATE PROCEDURE [catalogue].[OptimizeIndexes]
+AS
+    DECLARE @indexes AS TABLE
+      (
+         [Schema]               SYSNAME NOT NULL,
+         [Table]                SYSNAME NOT NULL,
+         [Index]                SYSNAME NOT NULL,
+         [FragmentationPercent] FLOAT NOT NULL
+      )
+
+    INSERT INTO @indexes
+                ([Schema],
+                 [Table],
+                 [Index],
+                 [FragmentationPercent])
+    SELECT S.[name]                           AS 'Schema',
+           T.[name]                           AS 'Table',
+           I.[name]                           AS 'Index',
+           DDIPS.avg_fragmentation_in_percent AS 'FragmentationPercent'
+    FROM   .sys.dm_db_index_physical_stats (Db_id(), NULL, NULL, NULL, NULL) AS DDIPS
+           INNER JOIN .sys.tables T
+                   ON T.object_id = DDIPS.object_id
+           INNER JOIN .sys.schemas S
+                   ON T.schema_id = S.schema_id
+           INNER JOIN .sys.indexes I
+                   ON I.object_id = DDIPS.object_id
+                      AND DDIPS.index_id = I.index_id
+    WHERE  DDIPS.database_id = Db_id()
+           AND I.[name] IS NOT NULL
+           AND DDIPS.avg_fragmentation_in_percent > 5
+    ORDER  BY DDIPS.avg_fragmentation_in_percent DESC
+
+    DECLARE @sqlcmd VARCHAR(max) = (SELECT STRING_AGG(CONCAT('ALTER INDEX ALL ON [',[Schema], '].[', [Table], '] ', (CASE WHEN FragmentationPercent > 40 THEN 'REBUILD' ELSE 'REORGANIZE' END)), ';' + Char(10)) FROM @indexes)
+
+    EXEC(@sqlcmd)
+RETURN 0

--- a/database/NHSD.GPITBuyingCatalogue.Database/Dockerfile
+++ b/database/NHSD.GPITBuyingCatalogue.Database/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS dacpacbuild
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS dacpacbuild
 WORKDIR /dacpac
 COPY database/NHSD.GPITBuyingCatalogue.Database .
 RUN dotnet build "NHSD.GPITBuyingCatalogue.Database.sqlproj" -c Release -o build
@@ -6,7 +6,7 @@ RUN dotnet build "NHSD.GPITBuyingCatalogue.Database.sqlproj" -c Release -o build
 FROM mcr.microsoft.com/mssql-tools:latest AS dacfx
 RUN apt-get -o Acquire::https::No-Cache=True -o Acquire::http::No-Cache=True update && apt-get install libunwind8 libicu-dev wget unzip -y
 WORKDIR /deploy-db
-RUN wget https://go.microsoft.com/fwlink/?linkid=2128144 -O sqlpackage.zip \
+RUN wget https://aka.ms/sqlpackage-linux -O sqlpackage.zip \
     && mkdir sqlpackage \
     && unzip sqlpackage.zip -d /sqlpackage \
     && chmod a+x /sqlpackage/sqlpackage

--- a/database/NHSD.GPITBuyingCatalogue.Database/NHSD.GPITBuyingCatalogue.Database.sqlproj
+++ b/database/NHSD.GPITBuyingCatalogue.Database/NHSD.GPITBuyingCatalogue.Database.sqlproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Sdk Name="Microsoft.Build.Sql" Version="0.1.10-preview" />
+  <Sdk Name="Microsoft.Build.Sql" Version="1.0.0-rc1" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -161,7 +161,7 @@
     <Folder Include="OdsOrganisations\Stored Procedures" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SqlServer.Dacpacs.Azure.Master" Version="160.0.0">
+    <PackageReference Include="Microsoft.SqlServer.Dacpacs.Azure.Master" Version="160.2.4">
       <GeneratePathProperty>true</GeneratePathProperty>
       <DacpacName>master</DacpacName>
     </PackageReference>

--- a/database/NHSD.GPITBuyingCatalogue.Database/entrypoint.sh
+++ b/database/NHSD.GPITBuyingCatalogue.Database/entrypoint.sh
@@ -23,6 +23,8 @@ fi
 /sqlpackage/sqlpackage \
     /Action:publish \
     /SourceFile:NHSD.GPITBuyingCatalogue.Database.dacpac \
+    /TargetTrustServerCertificate:True \
+    /TargetEncryptConnection:False \
     /TargetServerName:$DB_SERVER,$PORT \
     /TargetDatabaseName:$DB_NAME \
     /TargetUser:$SA_USERNAME \

--- a/src/BuyingCatalogueFunction/DatabaseMaintenance/ConfigureDatabaseMaintenanceServices.cs
+++ b/src/BuyingCatalogueFunction/DatabaseMaintenance/ConfigureDatabaseMaintenanceServices.cs
@@ -1,0 +1,13 @@
+﻿using BuyingCatalogueFunction.DatabaseMaintenance.Interfaces;
+using BuyingCatalogueFunction.DatabaseMaintenance.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BuyingCatalogueFunction.DatabaseMaintenance;
+
+public class ConfigureDatabaseMaintenanceServices : IConfigureServices
+{
+    public void ConfigureServices(IServiceCollection serviceCollection)
+    {
+        serviceCollection.AddScoped<IDatabaseIndexMaintenanceService, DatabaseIndexMaintenanceService>();
+    }
+}

--- a/src/BuyingCatalogueFunction/DatabaseMaintenance/ConfigureDatabaseMaintenanceServices.cs
+++ b/src/BuyingCatalogueFunction/DatabaseMaintenance/ConfigureDatabaseMaintenanceServices.cs
@@ -1,13 +1,16 @@
-﻿using BuyingCatalogueFunction.DatabaseMaintenance.Interfaces;
+﻿using System.Diagnostics.CodeAnalysis;
+using BuyingCatalogueFunction.DatabaseMaintenance.Interfaces;
 using BuyingCatalogueFunction.DatabaseMaintenance.Services;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace BuyingCatalogueFunction.DatabaseMaintenance;
 
+[ExcludeFromCodeCoverage(Justification = "Registers dependencies in IoC container.")]
 public class ConfigureDatabaseMaintenanceServices : IConfigureServices
 {
-    public void ConfigureServices(IServiceCollection serviceCollection)
+    public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
     {
-        serviceCollection.AddScoped<IDatabaseIndexMaintenanceService, DatabaseIndexMaintenanceService>();
+        services.AddScoped<IDatabaseIndexMaintenanceService, DatabaseIndexMaintenanceService>();
     }
 }

--- a/src/BuyingCatalogueFunction/DatabaseMaintenance/Interfaces/IDatabaseIndexMaintenanceService.cs
+++ b/src/BuyingCatalogueFunction/DatabaseMaintenance/Interfaces/IDatabaseIndexMaintenanceService.cs
@@ -1,0 +1,8 @@
+﻿using System.Threading.Tasks;
+
+namespace BuyingCatalogueFunction.DatabaseMaintenance.Interfaces;
+
+public interface IDatabaseIndexMaintenanceService
+{
+    Task RebuildIndexes();
+}

--- a/src/BuyingCatalogueFunction/DatabaseMaintenance/OptimizeIndexesFunction.cs
+++ b/src/BuyingCatalogueFunction/DatabaseMaintenance/OptimizeIndexesFunction.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Threading.Tasks;
+using BuyingCatalogueFunction.DatabaseMaintenance.Interfaces;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace BuyingCatalogueFunction.DatabaseMaintenance;
+
+public class OptimizeIndexesFunction(
+    IDatabaseIndexMaintenanceService databaseIndexMaintenanceService,
+    ILogger<OptimizeIndexesFunction> logger)
+{
+    private readonly IDatabaseIndexMaintenanceService databaseIndexMaintenanceService =
+        databaseIndexMaintenanceService ?? throw new ArgumentNullException(nameof(databaseIndexMaintenanceService));
+
+    [Function("OptimizeIndexesFunction")]
+    public async Task Run([TimerTrigger("0 0 20 * * Sat")] TimerInfo myTimer)
+    {
+        logger.LogInformation("Beginning optimize indexes function");
+
+        await databaseIndexMaintenanceService.RebuildIndexes();
+    }
+}

--- a/src/BuyingCatalogueFunction/DatabaseMaintenance/Services/DatabaseIndexMaintenanceService.cs
+++ b/src/BuyingCatalogueFunction/DatabaseMaintenance/Services/DatabaseIndexMaintenanceService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using BuyingCatalogueFunction.DatabaseMaintenance.Interfaces;
 using Microsoft.EntityFrameworkCore;
@@ -7,6 +8,7 @@ using NHSD.GPIT.BuyingCatalogue.EntityFramework;
 
 namespace BuyingCatalogueFunction.DatabaseMaintenance.Services;
 
+[ExcludeFromCodeCoverage(Justification = "Executes stored procedure")]
 public class DatabaseIndexMaintenanceService(
     BuyingCatalogueDbContext dbContext,
     ILogger<DatabaseIndexMaintenanceService> logger) : IDatabaseIndexMaintenanceService

--- a/src/BuyingCatalogueFunction/DatabaseMaintenance/Services/DatabaseIndexMaintenanceService.cs
+++ b/src/BuyingCatalogueFunction/DatabaseMaintenance/Services/DatabaseIndexMaintenanceService.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading.Tasks;
+using BuyingCatalogueFunction.DatabaseMaintenance.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework;
+
+namespace BuyingCatalogueFunction.DatabaseMaintenance.Services;
+
+public class DatabaseIndexMaintenanceService(
+    BuyingCatalogueDbContext dbContext,
+    ILogger<DatabaseIndexMaintenanceService> logger) : IDatabaseIndexMaintenanceService
+{
+    private readonly BuyingCatalogueDbContext dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+    private readonly ILogger<DatabaseIndexMaintenanceService> logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    public async Task RebuildIndexes()
+    {
+        try
+        {
+            dbContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(20));
+            await dbContext.Database.ExecuteSqlRawAsync("EXEC catalogue.OptimizeIndexes");
+        }
+        catch (Exception ex)
+        {
+            logger.LogCritical(ex, "Index optimization failed");
+            throw;
+        }
+    }
+}

--- a/src/BuyingCatalogueFunction/EpicsAndCapabilities/ConfigureCapabilityServices.cs
+++ b/src/BuyingCatalogueFunction/EpicsAndCapabilities/ConfigureCapabilityServices.cs
@@ -1,0 +1,19 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using BuyingCatalogueFunction.EpicsAndCapabilities.Interfaces;
+using BuyingCatalogueFunction.EpicsAndCapabilities.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BuyingCatalogueFunction.EpicsAndCapabilities;
+
+[ExcludeFromCodeCoverage(Justification = "Registers dependencies in IoC container.")]
+public sealed class ConfigureCapabilityServices : IConfigureServices
+{
+    public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddTransient<ICapabilityService, CapabilityService>();
+        services.AddTransient<IEpicService, EpicService>();
+        services.AddTransient<IStandardService, StandardService>();
+        services.AddTransient<IStandardCapabilityService, StandardCapabilityService>();
+    }
+}

--- a/src/BuyingCatalogueFunction/IConfigureServices.cs
+++ b/src/BuyingCatalogueFunction/IConfigureServices.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace BuyingCatalogueFunction;
 
 public interface IConfigureServices
 {
-    void ConfigureServices(IServiceCollection serviceCollection);
+    void ConfigureServices(IServiceCollection services, IConfiguration configuration);
 }

--- a/src/BuyingCatalogueFunction/IConfigureServices.cs
+++ b/src/BuyingCatalogueFunction/IConfigureServices.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace BuyingCatalogueFunction;
+
+public interface IConfigureServices
+{
+    void ConfigureServices(IServiceCollection serviceCollection);
+}

--- a/src/BuyingCatalogueFunction/Notifications/ConfigureNotificationsServices.cs
+++ b/src/BuyingCatalogueFunction/Notifications/ConfigureNotificationsServices.cs
@@ -1,0 +1,48 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using BuyingCatalogueFunction.Notifications.ContractExpiry.Interfaces;
+using BuyingCatalogueFunction.Notifications.ContractExpiry.Services;
+using BuyingCatalogueFunction.Notifications.Interfaces;
+using BuyingCatalogueFunction.Notifications.PasswordExpiry.Interfaces;
+using BuyingCatalogueFunction.Notifications.PasswordExpiry.Services;
+using BuyingCatalogueFunction.Notifications.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Notifications.Models;
+using Notify.Client;
+using Notify.Interfaces;
+
+namespace BuyingCatalogueFunction.Notifications;
+
+[ExcludeFromCodeCoverage(Justification = "Registers dependencies in IoC container.")]
+public sealed class ConfigureNotificationsServices : IConfigureServices
+{
+    public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    {
+        services.Configure<TemplateOptions>(configuration.GetSection("template"));
+        services.Configure<QueueOptions>(options =>
+        {
+            options.SendEmailNotifications = configuration.GetValue<string>("QUEUE:SEND_EMAIL_NOTIFICATION");
+            options.CompleteEmailNotifications = configuration.GetValue<string>("QUEUE:COMPLETE_EMAIL_NOTIFICATION");
+        });
+
+        ConfigureGovNotify(services, configuration);
+
+        services.AddTransient<IContractExpiryService, ContractExpiryService>();
+        services.AddTransient<IPasswordExpiryService, PasswordExpiryService>();
+        services.AddTransient<IEmailPreferenceService, EmailPreferenceService>();
+    }
+
+    private static void ConfigureGovNotify(IServiceCollection services, IConfiguration configuration)
+    {
+        var notifyApiKey = configuration.GetValue<string>("NOTIFY_API_KEY");
+        if (!string.IsNullOrWhiteSpace(notifyApiKey))
+        {
+            services.AddScoped<IAsyncNotificationClient, NotificationClient>(sp => new NotificationClient(notifyApiKey));
+            services.AddScoped<IGovNotifyEmailService, GovNotifyEmailService>();
+        }
+        else
+        {
+            services.AddScoped<IGovNotifyEmailService, FakeGovNotifyEmailService>();
+        }
+    }
+}

--- a/src/BuyingCatalogueFunction/OrganisationImport/ConfigureTrudServices.cs
+++ b/src/BuyingCatalogueFunction/OrganisationImport/ConfigureTrudServices.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using BuyingCatalogueFunction.OrganisationImport.Interfaces;
+using BuyingCatalogueFunction.OrganisationImport.Models;
+using BuyingCatalogueFunction.OrganisationImport.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace BuyingCatalogueFunction.OrganisationImport;
+
+[ExcludeFromCodeCoverage(Justification = "Registers dependencies in IoC container.")]
+public sealed class ConfigureTrudServices : IConfigureServices
+{
+    public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    {
+        services.Configure<TrudApiOptions>(configuration.GetSection("trudApi"));
+        services.Configure<TrudBatchOptions>(configuration.GetSection("batchOptions"));
+        services.AddTransient<IHttpService, HttpService>();
+        services.AddTransient<ITrudApiService, TrudApiService>();
+        services.AddTransient<ITrudService, TrudService>();
+        services.AddTransient<IZipService, ZipService>();
+
+        services
+            .AddHttpClient<TrudApiService>((provider, client) =>
+            {
+                var options = provider.GetRequiredService<IOptions<TrudApiOptions>>();
+
+                client.BaseAddress = new Uri(options.Value.ApiUrl);
+            });
+    }
+}

--- a/src/BuyingCatalogueFunction/Program.cs
+++ b/src/BuyingCatalogueFunction/Program.cs
@@ -2,32 +2,14 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Azure.Storage.Queues;
-using BuyingCatalogueFunction.EpicsAndCapabilities.Interfaces;
-using BuyingCatalogueFunction.EpicsAndCapabilities.Services;
-using BuyingCatalogueFunction.Notifications.ContractExpiry.Interfaces;
-using BuyingCatalogueFunction.Notifications.ContractExpiry.Services;
-using BuyingCatalogueFunction.Notifications.Interfaces;
-using BuyingCatalogueFunction.Notifications.PasswordExpiry.Interfaces;
-using BuyingCatalogueFunction.Notifications.PasswordExpiry.Services;
-using BuyingCatalogueFunction.Notifications.Services;
-using BuyingCatalogueFunction.OrganisationImport.Interfaces;
-using BuyingCatalogueFunction.OrganisationImport.Models;
-using BuyingCatalogueFunction.OrganisationImport.Services;
 using BuyingCatalogueFunction.Services;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Identity;
-using NHSD.GPIT.BuyingCatalogue.EntityFramework.Notifications.Models;
-using Notify.Client;
-using Notify.Interfaces;
-using Serilog;
-using Serilog.Events;
 
 namespace BuyingCatalogueFunction;
 
@@ -41,84 +23,35 @@ public static class Program
             {
                 var configuration = context.Configuration;
 
-                var configureServicesType = typeof(IConfigureServices);
-                var configureServicesTypes = configureServicesType.Assembly.GetTypes()
-                    .Where(x => x.IsClass && configureServicesType.IsAssignableFrom(x))
-                    .Select(x => (IConfigureServices)Activator.CreateInstance(x))
-                    .Where(x => x != null);
-
-                foreach (var implementation in configureServicesTypes)
-                {
-                    implementation.ConfigureServices(services);
-                }
-
-                services.Configure<TrudApiOptions>(configuration.GetSection("trudApi"));
-                services.Configure<TrudBatchOptions>(configuration.GetSection("batchOptions"));
-                services.Configure<TemplateOptions>(configuration.GetSection("template"));
-                services.Configure<QueueOptions>(options =>
-                {
-                    options.SendEmailNotifications = configuration.GetValue<string>("QUEUE:SEND_EMAIL_NOTIFICATION");
-                    options.CompleteEmailNotifications = configuration.GetValue<string>("QUEUE:COMPLETE_EMAIL_NOTIFICATION");
-                });
-
                 services.AddSingleton<IIdentityService, FunctionsIdentityService>();
-
                 services.AddApplicationInsightsTelemetryWorkerService();
                 services.ConfigureFunctionsApplicationInsights();
 
-                services.ConfigureGovNotify(configuration);
-                services.ConfigureQueueStorage(configuration);
-
-                services.AddTransient<IContractExpiryService, ContractExpiryService>();
-                services.AddTransient<ICapabilityService, CapabilityService>();
-                services.AddTransient<IEpicService, EpicService>();
-                services.AddTransient<IStandardService, StandardService>();
-                services.AddTransient<IStandardCapabilityService, StandardCapabilityService>();
-                services.AddTransient<IPasswordExpiryService, PasswordExpiryService>();
-                services.AddTransient<IEmailPreferenceService, EmailPreferenceService>();
-
-                services.AddTransient<IHttpService, HttpService>();
-                services.AddTransient<ITrudApiService, TrudApiService>();
-                services.AddTransient<ITrudService, TrudService>();
-                services.AddTransient<IZipService, ZipService>();
-
-                services
-                    .AddHttpClient<TrudApiService>((provider, client) =>
-                {
-                    var options = provider.GetRequiredService<IOptions<TrudApiOptions>>();
-
-                    client.BaseAddress = new Uri(options.Value.ApiUrl);
-                });
-
+                services.AddScoped<QueueServiceClient>(_ => new(configuration.GetValue<string>("AzureWebJobsStorage")));
                 services.AddDbContext<BuyingCatalogueDbContext>((_, options) =>
                 {
                     options.UseSqlServer(configuration.GetValue<string>("BUYINGCATALOGUECONNECTIONSTRING"));
                     options.EnableSensitiveDataLogging();
                 });
+
+                services.ConfigureDependentServices(configuration);
             })
             .Build();
 
         await host.RunAsync();
     }
 
-    public static IServiceCollection ConfigureGovNotify(this IServiceCollection services, IConfiguration configuration)
+    private static void ConfigureDependentServices(this IServiceCollection services, IConfiguration configuration)
     {
-        var notifyApiKey = configuration.GetValue<string>("NOTIFY_API_KEY");
-        if (!string.IsNullOrWhiteSpace(notifyApiKey))
-        {
-            services.AddScoped<IAsyncNotificationClient, NotificationClient>(sp => new NotificationClient(notifyApiKey));
-            services.AddScoped<IGovNotifyEmailService, GovNotifyEmailService>();
-        }
-        else
-        {
-            services.AddScoped<IGovNotifyEmailService, FakeGovNotifyEmailService>();
-        }
+        var configureServicesType = typeof(IConfigureServices);
+        var configureServicesTypes = configureServicesType.Assembly.GetTypes()
+            .Where(x => x.IsClass && configureServicesType.IsAssignableFrom(x))
+            .Select(x => (IConfigureServices)Activator.CreateInstance(x))
+            .Where(x => x != null);
 
-        return services;
-    }
-
-    public static void ConfigureQueueStorage(this IServiceCollection services, IConfiguration configuration)
-    {
-        services.AddScoped<QueueServiceClient>(_ => new(configuration.GetValue<string>("AzureWebJobsStorage")));
+        foreach (var implementation in configureServicesTypes)
+        {
+            implementation.ConfigureServices(services, configuration);
+        }
     }
 }

--- a/src/BuyingCatalogueFunction/Program.cs
+++ b/src/BuyingCatalogueFunction/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Azure.Storage.Queues;
 using BuyingCatalogueFunction.EpicsAndCapabilities.Interfaces;
@@ -34,25 +35,22 @@ public static class Program
 {
     public static async Task Main(string[] args)
     {
-        Log.Logger = new LoggerConfiguration()
-            .MinimumLevel.Debug()
-            .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
-            .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
-            .Enrich.FromLogContext()
-#if DEBUG
-            .WriteTo.Debug()
-            .WriteTo.Seq("http://localhost:5341")
-#endif
-            .WriteTo.ApplicationInsights(TelemetryConfiguration.CreateDefault(), TelemetryConverter.Traces)
-            .WriteTo.Console()
-            .CreateLogger();
-
         var host = Host.CreateDefaultBuilder(args)
-            .UseSerilog()
             .ConfigureFunctionsWorkerDefaults()
             .ConfigureServices((context, services) =>
             {
                 var configuration = context.Configuration;
+
+                var configureServicesType = typeof(IConfigureServices);
+                var configureServicesTypes = configureServicesType.Assembly.GetTypes()
+                    .Where(x => x.IsClass && configureServicesType.IsAssignableFrom(x))
+                    .Select(x => (IConfigureServices)Activator.CreateInstance(x))
+                    .Where(x => x != null);
+
+                foreach (var implementation in configureServicesTypes)
+                {
+                    implementation.ConfigureServices(services);
+                }
 
                 services.Configure<TrudApiOptions>(configuration.GetSection("trudApi"));
                 services.Configure<TrudBatchOptions>(configuration.GetSection("batchOptions"));

--- a/src/BuyingCatalogueFunction/host.json
+++ b/src/BuyingCatalogueFunction/host.json
@@ -7,7 +7,10 @@
   },
   "logging": {
     "logLevel": {
-      "default": "Information"
+      "Default": "Warning",
+      "Host.Aggregator": "Trace",
+      "Host.Results": "Information",
+      "Function": "Information"
     },
     "applicationInsights": {
       "samplingSettings": {


### PR DESCRIPTION
Several indexes in the database have become fragmented due to bulk writes which is having an impact on performance for the website.

In the past, with on-premise, this sort of thing would've been added as an agent job. Microsoft have left a bit of a gap with Azure SQL since Agent jobs don't exist (they do with Managed SQL instances). There are Elastic Jobs but they only run on Azure SQL SKUs of S1 and above which prevents us from testing this in lower environments.

This pull request does the following:
1. Adds a stored procedure that'll rebuild any heavily fragmented indexes, or reorganize indexes that aren't as heavily fragmented.
2. Update the [Microsoft.Build.Sql](https://github.com/microsoft/DacFx/tree/main/src/Microsoft.Build.Sql) SDK to the latest version
3. Update the local docker image to pull the latest version of SqlPackage
4. Update the bash script to pass in two parameters for the newer version of SqlPackage
5. Add a Function that runs every Saturday @ 8PM to execute the stored procedure.

While making changes, I also took the libertry to:
1. Remove Serilog as this is producing double-log entries in App Insights
2. Tweak the default log levels as it's currently too verbose

Additionally, I refactored how service dependencies are registered in the IoC container. The idea is that all individual functions are self-contained units which can be added/removed without the need to refactor additional classes (aside from tests).