### PR TITLE
Bug: use correct Integration ID for delete URL

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/InteroperabilityController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/InteroperabilityController.cs
@@ -87,7 +87,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             if (!ModelState.IsValid)
             {
                 var integrationTypes =
-                    await integrationsService.GetIntegrationTypesByIntegration(SupportedIntegrations.GpConnect);
+                    await integrationsService.GetIntegrationTypesByIntegration(SupportedIntegrations.Im1);
 
                 return View("AddEditIm1Integration", model.WithIntegrationTypes(integrationTypes));
             }
@@ -138,7 +138,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
             if (!ModelState.IsValid)
             {
                 var integrationTypes =
-                    await integrationsService.GetIntegrationTypesByIntegration(SupportedIntegrations.GpConnect);
+                    await integrationsService.GetIntegrationTypesByIntegration(SupportedIntegrations.Im1);
 
                 return View("AddEditIm1Integration", model.WithIntegrationTypes(integrationTypes));
             }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/InteroperabilityController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Controllers/InteroperabilityController.cs
@@ -85,7 +85,12 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
         public async Task<IActionResult> AddIm1Integration(CatalogueItemId solutionId, AddEditIm1IntegrationModel model)
         {
             if (!ModelState.IsValid)
-                return View("AddEditIm1Integration", model);
+            {
+                var integrationTypes =
+                    await integrationsService.GetIntegrationTypesByIntegration(SupportedIntegrations.GpConnect);
+
+                return View("AddEditIm1Integration", model.WithIntegrationTypes(integrationTypes));
+            }
 
             var integration = new SolutionIntegration
             {
@@ -132,7 +137,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
         {
             if (!ModelState.IsValid)
             {
-                return View("AddEditIm1Integration", model);
+                var integrationTypes =
+                    await integrationsService.GetIntegrationTypesByIntegration(SupportedIntegrations.GpConnect);
+
+                return View("AddEditIm1Integration", model.WithIntegrationTypes(integrationTypes));
             }
 
             var solution = await solutionsService.GetSolutionThin(solutionId);
@@ -228,7 +236,12 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
         public async Task<IActionResult> AddGpConnectIntegration(CatalogueItemId solutionId, AddEditGpConnectIntegrationModel model)
         {
             if (!ModelState.IsValid)
-                return View("AddEditGpConnectIntegration", model);
+            {
+                var integrationTypes =
+                    await integrationsService.GetIntegrationTypesByIntegration(SupportedIntegrations.GpConnect);
+
+                return View("AddEditGpConnectIntegration", model.WithIntegrationTypes(integrationTypes));
+            }
 
             var integration = new SolutionIntegration
             {
@@ -273,7 +286,12 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers
         public async Task<IActionResult> EditGpConnectIntegration(CatalogueItemId solutionId, int integrationId, AddEditGpConnectIntegrationModel model)
         {
             if (!ModelState.IsValid)
-                return View("AddEditGpConnectIntegration", model);
+            {
+                var integrationTypes =
+                    await integrationsService.GetIntegrationTypesByIntegration(SupportedIntegrations.GpConnect);
+
+                return View("AddEditGpConnectIntegration", model.WithIntegrationTypes(integrationTypes));
+            }
 
             var solution = await solutionsService.GetSolutionThin(solutionId);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/InteroperabilityModels/AddEditGpConnectIntegrationModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/InteroperabilityModels/AddEditGpConnectIntegrationModel.cs
@@ -21,7 +21,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.InteroperabilityMo
         {
             SolutionName = solution.Name;
             SolutionId = solution.Id;
-            IntegrationTypes = integrationTypes.Select(x => new SelectOption<string>(x.Name, x.Id.ToString())).ToList();
+
+            WithIntegrationTypes(integrationTypes);
         }
 
         public AddEditGpConnectIntegrationModel(
@@ -30,13 +31,13 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.InteroperabilityMo
             SolutionIntegration solutionIntegration)
             : this(solution, integrationTypes)
         {
-            IntegrationTypeId = solutionIntegration.IntegrationTypeId;
+            IntegrationId = solutionIntegration.Id;
             SelectedIntegrationType = solutionIntegration.IntegrationTypeId;
             IsConsumer = solutionIntegration.IsConsumer.GetValueOrDefault();
             AdditionalInformation = solutionIntegration.Description;
         }
 
-        public string SolutionName { get; }
+        public string SolutionName { get; set; }
 
         public List<SelectOption<string>> IntegrationTypes { get; set; }
 
@@ -53,8 +54,15 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.InteroperabilityMo
         [StringLength(1000)]
         public string AdditionalInformation { get; set; }
 
-        public CatalogueItemId SolutionId { get; init; }
+        public CatalogueItemId SolutionId { get; set; }
 
-        public int? IntegrationTypeId { get; set; }
+        public int? IntegrationId { get; set; }
+
+        public AddEditGpConnectIntegrationModel WithIntegrationTypes(IEnumerable<IntegrationType> integrationTypes)
+        {
+            IntegrationTypes = integrationTypes.Select(x => new SelectOption<string>(x.Name, x.Id.ToString())).ToList();
+
+            return this;
+        }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/InteroperabilityModels/AddEditIm1IntegrationModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Models/InteroperabilityModels/AddEditIm1IntegrationModel.cs
@@ -22,7 +22,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.InteroperabilityMo
             SolutionName = solution.Name;
             SolutionId = solution.Id;
 
-            IntegrationTypes = integrationTypes.Select(x => new SelectOption<string>(x.Name, x.Id.ToString())).ToList();
+            WithIntegrationTypes(integrationTypes);
         }
 
         public AddEditIm1IntegrationModel(
@@ -31,14 +31,14 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.InteroperabilityMo
             SolutionIntegration solutionIntegration)
         : this(solution, integrationTypes)
         {
-            IntegrationTypeId = solutionIntegration.IntegrationTypeId;
+            IntegrationId = solutionIntegration.Id;
             SelectedIntegrationType = solutionIntegration.IntegrationTypeId;
             IsConsumer = solutionIntegration.IsConsumer.GetValueOrDefault();
             Description = solutionIntegration.Description;
             IntegratesWith = solutionIntegration.IntegratesWith;
         }
 
-        public string SolutionName { get; }
+        public string SolutionName { get; set; }
 
         public List<SelectOption<string>> IntegrationTypes { get; set; }
 
@@ -58,8 +58,15 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.InteroperabilityMo
         [StringLength(1000)]
         public string Description { get; set; }
 
-        public CatalogueItemId SolutionId { get; }
+        public CatalogueItemId SolutionId { get; set; }
 
-        public int? IntegrationTypeId { get; set; }
+        public int? IntegrationId { get; set; }
+
+        public AddEditIm1IntegrationModel WithIntegrationTypes(IEnumerable<IntegrationType> integrationTypes)
+        {
+            IntegrationTypes = integrationTypes.Select(x => new SelectOption<string>(x.Name, x.Id.ToString())).ToList();
+
+            return this;
+        }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Interoperability/AddEditGpConnectIntegration.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Interoperability/AddEditGpConnectIntegration.cshtml
@@ -1,6 +1,6 @@
 ﻿@model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.InteroperabilityModels.AddEditGpConnectIntegrationModel;
 @{
-    ViewBag.Title = $"{(Model.IntegrationTypeId is null ? "Add" : "Edit")} a GP Connect integration";
+    ViewBag.Title = $"{(Model.IntegrationId is null ? "Add" : "Edit")} a GP Connect integration";
 }
 
 <div class="nhsuk-width-container">
@@ -30,12 +30,12 @@
 
                 <nhs-submit-button />
             </form>
-            @if (Model.IntegrationTypeId is not null)
+            @if (Model.IntegrationId is not null)
             {
                 <vc:nhs-delete-button url="@Url.Action(
                                                nameof(InteroperabilityController.DeleteGpConnectIntegration),
                                                typeof(InteroperabilityController).ControllerName(),
-                                               new { Model.SolutionId, integrationId = Model.IntegrationTypeId })"
+                                               new { Model.SolutionId, integrationId = Model.IntegrationId })"
                                       text="Delete integration" />
             }
         </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Interoperability/AddEditIm1Integration.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Views/Interoperability/AddEditIm1Integration.cshtml
@@ -1,6 +1,6 @@
 ﻿@model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.InteroperabilityModels.AddEditIm1IntegrationModel;
 @{
-    ViewBag.Title = $"{(Model.IntegrationTypeId is not null ? "Edit" : "Add")} an IM1 integration";
+    ViewBag.Title = $"{(Model.IntegrationId is not null ? "Edit" : "Add")} an IM1 integration";
 }
 
 <div class="nhsuk-width-container">
@@ -33,12 +33,12 @@
 
                 <nhs-submit-button />
             </form>
-            @if (Model.IntegrationTypeId is not null)
+            @if (Model.IntegrationId is not null)
             {
                 <vc:nhs-delete-button url="@Url.Action(
                                                nameof(InteroperabilityController.DeleteIm1Integration),
                                                typeof(InteroperabilityController).ControllerName(),
-                                               new { Model.SolutionId, integrationId = Model.IntegrationTypeId })"
+                                               new { Model.SolutionId, integrationId = Model.IntegrationId })"
                               text="Delete integration" />
             }
         </div>

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/InteroperabilityControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Controllers/InteroperabilityControllerTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
+using NHSD.GPIT.BuyingCatalogue.Framework.Models;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Integrations;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Solutions;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Controllers;
@@ -119,6 +120,29 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             var actual = (await controller.AddIm1Integration(catalogueItemId)).As<BadRequestObjectResult>();
 
             actual.Value.Should().Be($"No Solution found for Id: {catalogueItemId}");
+        }
+
+        [Theory]
+        [MockAutoData]
+        public static async Task Post_AddIm1Integration_InvalidModel_RedirectsToManageCatalogueSolution(
+            CatalogueItemId catalogueItemId,
+            AddEditIm1IntegrationModel model,
+            List<IntegrationType> integrationTypes,
+            [Frozen] IIntegrationsService mockIntegrationsService,
+            InteroperabilityController controller)
+        {
+            controller.ModelState.AddModelError("some-key", "some-error");
+
+            mockIntegrationsService.GetIntegrationTypesByIntegration(SupportedIntegrations.Im1)
+                .Returns(integrationTypes);
+
+            var actual = (await controller.AddIm1Integration(catalogueItemId, model)).As<ViewResult>();
+            var actualModel = actual?.Model as AddEditIm1IntegrationModel;
+
+            Assert.NotNull(actual);
+            Assert.NotNull(actualModel);
+            Assert.Equal(model, actualModel);
+            Assert.Equivalent(integrationTypes.Select(x => new SelectOption<string>(x.Name, x.Id.ToString())).ToList(), actualModel.IntegrationTypes);
         }
 
         [Theory]
@@ -248,6 +272,30 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             actual.Should().NotBeNull();
             actual.Should().BeOfType<BadRequestObjectResult>();
             actual.As<BadRequestObjectResult>().Value.Should().BeEquivalentTo($"No integration found for Id: {integrationId}");
+        }
+
+        [Theory]
+        [MockAutoData]
+        public static async Task Post_EditIm1Integration_InvalidModel_RedirectsToManageCatalogueSolution(
+            CatalogueItemId catalogueItemId,
+            int integrationId,
+            AddEditIm1IntegrationModel model,
+            List<IntegrationType> integrationTypes,
+            [Frozen] IIntegrationsService mockIntegrationsService,
+            InteroperabilityController controller)
+        {
+            controller.ModelState.AddModelError("some-key", "some-error");
+
+            mockIntegrationsService.GetIntegrationTypesByIntegration(SupportedIntegrations.Im1)
+                .Returns(integrationTypes);
+
+            var actual = (await controller.EditIm1Integration(catalogueItemId, integrationId, model)).As<ViewResult>();
+            var actualModel = actual?.Model as AddEditIm1IntegrationModel;
+
+            Assert.NotNull(actual);
+            Assert.NotNull(actualModel);
+            Assert.Equal(model, actualModel);
+            Assert.Equivalent(integrationTypes.Select(x => new SelectOption<string>(x.Name, x.Id.ToString())).ToList(), actualModel.IntegrationTypes);
         }
 
         [Theory]
@@ -445,6 +493,29 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
 
         [Theory]
         [MockAutoData]
+        public static async Task Post_AddGpConnectIntegration_InvalidModel_RedirectsToManageCatalogueSolution(
+            CatalogueItemId catalogueItemId,
+            AddEditGpConnectIntegrationModel model,
+            List<IntegrationType> integrationTypes,
+            [Frozen] IIntegrationsService mockIntegrationsService,
+            InteroperabilityController controller)
+        {
+            controller.ModelState.AddModelError("some-key", "some-error");
+
+            mockIntegrationsService.GetIntegrationTypesByIntegration(SupportedIntegrations.GpConnect)
+                .Returns(integrationTypes);
+
+            var actual = (await controller.AddGpConnectIntegration(catalogueItemId, model)).As<ViewResult>();
+            var actualModel = actual?.Model as AddEditGpConnectIntegrationModel;
+
+            Assert.NotNull(actual);
+            Assert.NotNull(actualModel);
+            Assert.Equal(model, actualModel);
+            Assert.Equivalent(integrationTypes.Select(x => new SelectOption<string>(x.Name, x.Id.ToString())).ToList(), actualModel.IntegrationTypes);
+        }
+
+        [Theory]
+        [MockAutoData]
         public static async Task Get_EditGpConnectIntegration_ValidId_ReturnsViewWithExpectedModel(
             Solution solution,
             List<IntegrationType> integrationTypes,
@@ -558,6 +629,30 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Controllers
             actual.Should().NotBeNull();
             actual.Should().BeOfType<BadRequestObjectResult>();
             actual.As<BadRequestObjectResult>().Value.Should().BeEquivalentTo($"No integration found for Id: {integrationId}");
+        }
+
+        [Theory]
+        [MockAutoData]
+        public static async Task Post_EditGpConnectIntegration_InvalidModel_RedirectsToManageCatalogueSolution(
+            CatalogueItemId catalogueItemId,
+            int integrationId,
+            AddEditGpConnectIntegrationModel model,
+            List<IntegrationType> integrationTypes,
+            [Frozen] IIntegrationsService mockIntegrationsService,
+            InteroperabilityController controller)
+        {
+            controller.ModelState.AddModelError("some-key", "some-error");
+
+            mockIntegrationsService.GetIntegrationTypesByIntegration(SupportedIntegrations.GpConnect)
+                .Returns(integrationTypes);
+
+            var actual = (await controller.EditGpConnectIntegration(catalogueItemId, integrationId, model)).As<ViewResult>();
+            var actualModel = actual?.Model as AddEditGpConnectIntegrationModel;
+
+            Assert.NotNull(actual);
+            Assert.NotNull(actualModel);
+            Assert.Equal(model, actualModel);
+            Assert.Equivalent(integrationTypes.Select(x => new SelectOption<string>(x.Name, x.Id.ToString())).ToList(), actualModel.IntegrationTypes);
         }
 
         [Theory]

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/InteroperabilityModels/AddEditGpConnectIntegrationModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/InteroperabilityModels/AddEditGpConnectIntegrationModelTests.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+using NHSD.GPIT.BuyingCatalogue.Framework.Models;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.InteroperabilityModels;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.InteroperabilityModels;
+
+public static class AddEditGpConnectIntegrationModelTests
+{
+    [Theory]
+    [MockAutoData]
+    public static void Construct_AddScenario_SetsPropertiesAsExpected(
+        Solution solution,
+        ICollection<IntegrationType> integrationTypes)
+    {
+        var expectedIntegrationTypes = integrationTypes.Select(x => new SelectOption<string>(x.Name, x.Id.ToString())).ToList();
+
+        var model = new AddEditGpConnectIntegrationModel(solution.CatalogueItem, integrationTypes);
+
+        Assert.Equal(solution.CatalogueItemId, model.SolutionId);
+        Assert.Equal(solution.CatalogueItem.Name, model.SolutionName);
+        Assert.Equivalent(expectedIntegrationTypes, model.IntegrationTypes);
+    }
+
+    [Theory]
+    [MockAutoData]
+    public static void Construct_EditScenario_SetsPropertiesAsExpected(
+        Solution solution,
+        ICollection<IntegrationType> integrationTypes,
+        SolutionIntegration solutionIntegration)
+    {
+        var expectedIntegrationTypes = integrationTypes.Select(x => new SelectOption<string>(x.Name, x.Id.ToString())).ToList();
+
+        var model = new AddEditGpConnectIntegrationModel(solution.CatalogueItem, integrationTypes, solutionIntegration);
+
+        Assert.Equal(solution.CatalogueItemId, model.SolutionId);
+        Assert.Equal(solution.CatalogueItem.Name, model.SolutionName);
+        Assert.Equivalent(expectedIntegrationTypes, model.IntegrationTypes);
+        Assert.Equal(solutionIntegration.Id, model.IntegrationId);
+        Assert.Equal(solutionIntegration.IntegrationTypeId, model.SelectedIntegrationType);
+        Assert.Equal(solutionIntegration.IsConsumer, model.IsConsumer);
+        Assert.Equal(solutionIntegration.Description, model.AdditionalInformation);
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/InteroperabilityModels/AddEditIm1IntegrationModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Models/InteroperabilityModels/AddEditIm1IntegrationModelTests.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+using NHSD.GPIT.BuyingCatalogue.Framework.Models;
+using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Models.InteroperabilityModels;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Models.InteroperabilityModels;
+
+public static class AddEditIm1IntegrationModelTests
+{
+    [Theory]
+    [MockAutoData]
+    public static void Construct_AddScenario_SetsPropertiesAsExpected(
+        Solution solution,
+        ICollection<IntegrationType> integrationTypes)
+    {
+        var expectedIntegrationTypes = integrationTypes.Select(x => new SelectOption<string>(x.Name, x.Id.ToString())).ToList();
+
+        var model = new AddEditIm1IntegrationModel(solution.CatalogueItem, integrationTypes);
+
+        Assert.Equal(solution.CatalogueItemId, model.SolutionId);
+        Assert.Equal(solution.CatalogueItem.Name, model.SolutionName);
+        Assert.Equivalent(expectedIntegrationTypes, model.IntegrationTypes);
+    }
+
+    [Theory]
+    [MockAutoData]
+    public static void Construct_EditScenario_SetsPropertiesAsExpected(
+        Solution solution,
+        ICollection<IntegrationType> integrationTypes,
+        SolutionIntegration solutionIntegration)
+    {
+        var expectedIntegrationTypes = integrationTypes.Select(x => new SelectOption<string>(x.Name, x.Id.ToString())).ToList();
+
+        var model = new AddEditIm1IntegrationModel(solution.CatalogueItem, integrationTypes, solutionIntegration);
+
+        Assert.Equal(solution.CatalogueItemId, model.SolutionId);
+        Assert.Equal(solution.CatalogueItem.Name, model.SolutionName);
+        Assert.Equivalent(expectedIntegrationTypes, model.IntegrationTypes);
+        Assert.Equal(solutionIntegration.Id, model.IntegrationId);
+        Assert.Equal(solutionIntegration.IntegrationTypeId, model.SelectedIntegrationType);
+        Assert.Equal(solutionIntegration.IsConsumer, model.IsConsumer);
+        Assert.Equal(solutionIntegration.Description, model.Description);
+        Assert.Equal(solutionIntegration.IntegratesWith, model.IntegratesWith);
+    }
+}


### PR DESCRIPTION
Resolves 2 bugs:
1. The incorrect ID is being used as part of the Delete Integration URL on the Admin section
2. The integration types aren't re-populated when POST results in an invalid model state