### PR TITLE
Bugfix: VNET Integration for app service and slot

### DIFF
--- a/terraform/webapp/modules/bc_webapp_pri/deployment_slot.tf
+++ b/terraform/webapp/modules/bc_webapp_pri/deployment_slot.tf
@@ -4,6 +4,7 @@ resource "azurerm_linux_web_app_slot" "slot" {
   app_service_id                                 = azurerm_linux_web_app.webapp.id
   ftp_publish_basic_authentication_enabled       = false
   webdeploy_publish_basic_authentication_enabled = false
+  virtual_network_subnet_id                      = var.backend_subnet_id
 
   app_settings = {
     # Main Settings
@@ -80,7 +81,6 @@ resource "azurerm_linux_web_app_slot" "slot" {
 
   lifecycle {
     ignore_changes = [
-      virtual_network_subnet_id,
       site_config[0].scm_minimum_tls_version,
       site_config[0].ftps_state,
       site_config[0].application_stack[0].docker_image_name,

--- a/terraform/webapp/modules/bc_webapp_pri/main.tf
+++ b/terraform/webapp/modules/bc_webapp_pri/main.tf
@@ -18,6 +18,7 @@ resource "azurerm_linux_web_app" "webapp" {
   service_plan_id                                = azurerm_service_plan.webapp_sp.id
   ftp_publish_basic_authentication_enabled       = false
   webdeploy_publish_basic_authentication_enabled = false
+  virtual_network_subnet_id                      = var.backend_subnet_id
 
   app_settings = {
     # Main Settings
@@ -97,7 +98,6 @@ resource "azurerm_linux_web_app" "webapp" {
 
   lifecycle {
     ignore_changes = [
-      virtual_network_subnet_id,
       site_config[0].scm_minimum_tls_version,
       site_config[0].ftps_state,
       site_config[0].application_stack[0].docker_image_name,

--- a/terraform/webapp/modules/bc_webapp_pri/variables.tf
+++ b/terraform/webapp/modules/bc_webapp_pri/variables.tf
@@ -124,3 +124,7 @@ variable "recaptcha_site_key" {
 variable "recaptcha_secret_key" {
   type = string
 }
+
+variable "backend_subnet_id" {
+  type = string
+}

--- a/terraform/webapp/virtual_network.tf
+++ b/terraform/webapp/virtual_network.tf
@@ -36,8 +36,3 @@ resource "azurerm_subnet" "backend" {
 
   service_endpoints = ["Microsoft.Sql", "Microsoft.Storage"]
 }
-
-resource "azurerm_app_service_virtual_network_swift_connection" "webapp" {
-  app_service_id = module.webapp.webapp_service_id
-  subnet_id      = azurerm_subnet.backend.id
-}

--- a/terraform/webapp/webapp.tf
+++ b/terraform/webapp/webapp.tf
@@ -27,6 +27,7 @@ module "webapp" {
   blob_storage_connection_string  = module.documentstorageaccount.primary_connection_string
   recaptcha_site_key              = var.recaptcha_site_key
   recaptcha_secret_key            = var.recaptcha_secret_key
+  backend_subnet_id               = azurerm_subnet.backend.id
 
   # SQL Vars
   sqlserver_name     = local.is_dr ? "${var.project}-${var.primary_env}-sql-primary" : join("", module.sql_server_pri[*].sql_server_name)


### PR DESCRIPTION
The previous change surrounding the storage account access policies didn't include a regional vnet on the App Service slot, causing any App Service slots to fail requests when attempting to communicate with the storage account.

This has already been fixed in the release, this PR merges the fix into `develop`