### PR TITLE
Use managed identity for database

### DIFF
--- a/database/NHSD.GPITBuyingCatalogue.Database/NHSD.GPITBuyingCatalogue.Database.sqlproj
+++ b/database/NHSD.GPITBuyingCatalogue.Database/NHSD.GPITBuyingCatalogue.Database.sqlproj
@@ -99,6 +99,11 @@
       <DefaultValue>True</DefaultValue>
       <Value>$(SqlCmdVar__11)</Value>
     </SqlCmdVariable>
+    <SqlCmdVariable Include="WEB_USER_ID">
+      <DefaultValue>
+      </DefaultValue>
+      <Value>$(SqlCmdVar__12)</Value>
+    </SqlCmdVariable>
   </ItemGroup>
   <ItemGroup>
     <PostDeploy Include="PostDeployment\PostDeployment.sql" />

--- a/database/NHSD.GPITBuyingCatalogue.Database/PostDeployment/InfrastructureUsers.sql
+++ b/database/NHSD.GPITBuyingCatalogue.Database/PostDeployment/InfrastructureUsers.sql
@@ -1,0 +1,11 @@
+﻿IF '$(WEB_USER_ID)' IS NOT NULL AND '$(WEB_USER_ID)' <> ''
+BEGIN
+    DECLARE @security_id VARBINARY(16) = CAST(CAST('$(WEB_USER_ID)' AS UNIQUEIDENTIFIER) AS VARBINARY(16))
+
+    DROP USER IF EXISTS [BC-Web-App];
+
+    DECLARE @cmd NVARCHAR(MAX) = 'CREATE USER [BC-Web-App] WITH DEFAULT_SCHEMA=[dbo], SID = ' + CONVERT(VARCHAR(MAX), @security_id, 1) + ', TYPE = E;';
+    EXEC (@cmd);
+
+    ALTER ROLE [BuyingCatalogue] ADD MEMBER [BC-Web-App];
+END

--- a/database/NHSD.GPITBuyingCatalogue.Database/PostDeployment/PostDeployment.sql
+++ b/database/NHSD.GPITBuyingCatalogue.Database/PostDeployment/PostDeployment.sql
@@ -1,4 +1,5 @@
-﻿:r ./InsertOrganisationTypes.sql
+﻿:r ./InfrastructureUsers.sql
+:r ./InsertOrganisationTypes.sql
 :r ./InsertRoles.sql
 
 :r ./OdsOrganisationsSeedData/InsertOdsOrganisations.sql

--- a/database/NHSD.GPITBuyingCatalogue.Database/Security/Roles/BuyingCatalogueRole.sql
+++ b/database/NHSD.GPITBuyingCatalogue.Database/Security/Roles/BuyingCatalogueRole.sql
@@ -1,0 +1,8 @@
+﻿CREATE ROLE [BuyingCatalogue];
+GO
+ALTER ROLE db_datareader ADD MEMBER [BuyingCatalogue];
+GO
+ALTER ROLE db_datawriter ADD MEMBER [BuyingCatalogue];
+GO
+GRANT ALTER ON [organisations].[GpPracticeSize] TO [BuyingCatalogue];
+GO

--- a/terraform/webapp/modules/bc_webapp_pri/deployment_slot.tf
+++ b/terraform/webapp/modules/bc_webapp_pri/deployment_slot.tf
@@ -17,7 +17,7 @@ resource "azurerm_linux_web_app_slot" "slot" {
     DOMAIN_NAME = var.app_dns_url
 
     # Settings for sql
-    BC_DB_CONNECTION                    = "Server=tcp:${data.azurerm_mssql_server.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.db_name_main};Persist Security Info=False;User ID=${var.sql_admin_username};Password=${var.sql_admin_password};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+    BC_DB_CONNECTION                    = "Server=tcp:${data.azurerm_mssql_server.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.db_name_main};Persist Security Info=False;Authentication=Active Directory Managed Identity;User Id=${azurerm_user_assigned_identity.web_app_identity.client_id};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
     AZUREBLOBSETTINGS__CONNECTIONSTRING = var.blob_storage_connection_string
 
     RECAPTCHASETTINGS__SITEKEY   = var.recaptcha_site_key
@@ -70,8 +70,10 @@ resource "azurerm_linux_web_app_slot" "slot" {
 
     scm_use_main_ip_restriction = false
   }
+
   identity {
-    type = "SystemAssigned"
+    type = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.web_app_identity.id]
   }
 
   tags = {

--- a/terraform/webapp/modules/bc_webapp_pri/main.tf
+++ b/terraform/webapp/modules/bc_webapp_pri/main.tf
@@ -11,6 +11,16 @@ resource "azurerm_service_plan" "webapp_sp" {
   }
 }
 
+resource "azurerm_user_assigned_identity" "web_app_identity" {
+  name                = "${var.project}-${var.environment}-webapp-identity"
+  location            = var.region
+  resource_group_name = var.rg_name
+
+  tags = {
+    environment  = var.environment
+  }
+}
+
 resource "azurerm_linux_web_app" "webapp" {
   name                                           = var.webapp_name
   location                                       = var.region
@@ -31,7 +41,7 @@ resource "azurerm_linux_web_app" "webapp" {
     DOMAIN_NAME = var.app_dns_url
 
     # Settings for sql
-    BC_DB_CONNECTION                    = "Server=tcp:${data.azurerm_mssql_server.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.db_name_main};Persist Security Info=False;User ID=${var.sql_admin_username};Password=${var.sql_admin_password};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+    BC_DB_CONNECTION                    = "Server=tcp:${data.azurerm_mssql_server.sql_server.fully_qualified_domain_name},1433;Initial Catalog=${var.db_name_main};Persist Security Info=False;Authentication=Active Directory Managed Identity;User Id=${azurerm_user_assigned_identity.web_app_identity.client_id};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
     AZUREBLOBSETTINGS__CONNECTIONSTRING = var.blob_storage_connection_string
 
     RECAPTCHASETTINGS__SITEKEY   = var.recaptcha_site_key
@@ -87,8 +97,10 @@ resource "azurerm_linux_web_app" "webapp" {
 
     scm_use_main_ip_restriction = false
   }
+
   identity {
-    type = "SystemAssigned"
+    type = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.web_app_identity.id]
   }
 
   tags = {


### PR DESCRIPTION
At present the website uses SQL credentials to connect to the database. Moving to a managed identity is a long overdue improvement that came with a challenge.

In an ideal world, we'd be able to use the standard syntax:
```sql
CREATE USER [<identity>] FROM EXTERNAL PROVIDER;
```

This SQL performs a query against Microsoft Entra to validate the identity name. It then creates a user with an SID. The problem is that neither our pipeline nor the database can query Entra. The workaround is to pass the Client ID GUID and cast it to a 16-byte binary value. Since the user should only be created against pipeline environments, as there would be no managed identity locally, this uses dynamic SQL in a post-deployment script.