### PR TITLE
Bugfix: Allow users to visit Non-price elements weightings page once criteria has been reviewed

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Controllers/CompetitionNonPriceElementsController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Controllers/CompetitionNonPriceElementsController.cs
@@ -316,7 +316,6 @@ public class CompetitionNonPriceElementsController(
         return GetRedirect(internalOrgId, competitionId, returnUrl);
     }
 
-    [CriteriaReviewedGuardFilter]
     [HttpGet("weights")]
     public async Task<IActionResult> Weights(
         string internalOrgId,


### PR DESCRIPTION
Removes the `CriteriaReviewedGuardFilter` attribute from the `Weights` action on `CompetitionNonPriceElementsController` as this filter should be used only when there isn't a read-only view of a page where the user would be able to change values up to that point