### PR TITLE
Bugfix: Add validation for tiered price lower range

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Validators/ListPrices/AddEditTieredPriceTierModelValidator.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Admin/Validators/ListPrices/AddEditTieredPriceTierModelValidator.cs
@@ -8,6 +8,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Validators.ListPrices
     public class AddEditTieredPriceTierModelValidator : AbstractValidator<AddEditTieredPriceTierModel>
     {
         internal const string LowerRangeMissing = "Enter a lower range";
+        internal const string LowerRangeGreaterThanZero = "Lower range must be greater than zero";
         internal const string UpperRangeMissing = "Enter an upper range";
         internal const string RangeTypeMissing = "Select how you want to define the upper range";
         internal const string DuplicateListPriceTierError = "A tier with these details already exists";
@@ -23,7 +24,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Admin.Validators.ListPrices
 
             RuleFor(m => m.LowerRange)
                 .NotNull()
-                .WithMessage(LowerRangeMissing);
+                .WithMessage(LowerRangeMissing)
+                .GreaterThan(0)
+                .WithMessage(LowerRangeGreaterThanZero);
 
             RuleFor(m => m.UpperRange)
                 .NotNull()

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Validators/ListPrices/AddTieredPriceTierModelValidatorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Admin/Validators/ListPrices/AddTieredPriceTierModelValidatorTests.cs
@@ -69,6 +69,21 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Admin.Validators.List
 
         [Theory]
         [MockAutoData]
+        public static void Validate_LowerRangeEqualsZero_SetsModelError(
+            AddEditTieredPriceTierModel model,
+            AddEditTieredPriceTierModelValidator validator)
+        {
+            model.LowerRange = 0;
+            model.InputPrice = "3.14";
+
+            var result = validator.TestValidate(model);
+
+            result.ShouldHaveValidationErrorFor(m => m.LowerRange)
+                .WithErrorMessage(AddEditTieredPriceTierModelValidator.LowerRangeGreaterThanZero);
+        }
+
+        [Theory]
+        [MockAutoData]
         public static void Validate_UpperRangeMissing_SetsModelError(
             AddEditTieredPriceTierModel model,
             AddEditTieredPriceTierModelValidator validator)


### PR DESCRIPTION
Adds a validation scenario for when the lower range is <= 0.

The error message used is similar to existing greater than 0 errors