### PR TITLE
Move framework expiry to standalone page

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.Framework/Models/SelectOption.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Framework/Models/SelectOption.cs
@@ -14,16 +14,14 @@ namespace NHSD.GPIT.BuyingCatalogue.Framework.Models
             Value = value;
             Advice = null;
             Selected = false;
-            Disabled = false;
         }
 
-        public SelectOption(string text, TValue value, bool selected = false, bool disabled = false)
+        public SelectOption(string text, TValue value, bool selected = false)
         {
             Text = text;
             Value = value;
             Advice = null;
             Selected = selected;
-            Disabled = disabled;
         }
 
         public SelectOption(string text, string advice, TValue value)
@@ -41,8 +39,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Framework.Models
         public TValue Value { get; set; }
 
         public bool Selected { get; set; }
-
-        public bool Disabled { get; set; }
 
         public static bool operator ==(SelectOption<TValue> left, SelectOption<TValue> right)
         {
@@ -73,8 +69,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Framework.Models
 
             return (Text ?? string.Empty).Equals(other.Text ?? string.Empty, StringComparison.Ordinal)
                 && (Advice ?? string.Empty).Equals(other.Advice ?? string.Empty, StringComparison.Ordinal)
-                && (Value?.ToString() ?? string.Empty).Equals(other.Value?.ToString() ?? string.Empty, StringComparison.Ordinal)
-                && Disabled.Equals(other.Disabled);
+                && (Value?.ToString() ?? string.Empty).Equals(other.Value?.ToString() ?? string.Empty, StringComparison.Ordinal);
         }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/OrderTriageController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/OrderTriageController.cs
@@ -120,12 +120,12 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers
 
             var availableFrameworks = (await frameworkService
                 .GetFrameworks())
-                    .OrderBy(f => f.IsExpired)
-                    .ThenBy(f => f.Name)
+                    .Where(x => !x.IsExpired)
+                    .OrderBy(x => x.Name)
                     .ToList();
 
             var model = new SelectFrameworkModel(
-                organisation.Name,
+                organisation,
                 availableFrameworks,
                 selectedFrameworkId)
             {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/OrderTriage/SelectFrameworkModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/OrderTriage/SelectFrameworkModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Organisations.Models;
 using NHSD.GPIT.BuyingCatalogue.Framework.Models;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Models;
 
@@ -14,15 +15,18 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.OrderTriage
         {
         }
 
-        public SelectFrameworkModel(string organisationName, IList<EntityFramework.Catalogue.Models.Framework> frameworks, string selectedFrameworkId)
+        public SelectFrameworkModel(Organisation organisation, IList<EntityFramework.Catalogue.Models.Framework> frameworks, string selectedFrameworkId)
         {
-            OrganisationName = organisationName;
+            InternalOrgId = organisation.InternalIdentifier;
+            OrganisationName = organisation.Name;
             SelectedFrameworkId = selectedFrameworkId;
 
             Frameworks = frameworks
-                .Select(f => new SelectOption<string>($"{f.ShortName}{(f.IsExpired ? " (Expired)" : string.Empty)}", f.Id, disabled: f.IsExpired))
+                .Select(f => new SelectOption<string>($"{f.ShortName}", f.Id))
                 .ToList();
         }
+
+        public string InternalOrgId { get; set; }
 
         public string OrganisationName { get; set; }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/ReadyToStart.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/ReadyToStart.cshtml
@@ -1,10 +1,11 @@
-﻿@using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers
+﻿@using Microsoft.AspNetCore.Mvc.TagHelpers
+@using NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
+@using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers
+@using NHSD.GPIT.BuyingCatalogue.WebApp.Models
+@using ValidationSummaryTagHelper = Microsoft.AspNetCore.Mvc.TagHelpers.ValidationSummaryTagHelper
 @model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.Orders.ReadyToStartModel
 @{
     ViewBag.Title = "Before you start an order";
-}
-
-@section Scripts {
 }
 
 <div>
@@ -15,7 +16,8 @@
                 <nhs-validation-summary />
                 <nhs-page-title title="@ViewBag.Title"
                                 caption="@Model!.OrganisationName" />
-                <partial name="Partials/_FrameworkExpiredAlert" />
+                <partial name="Partials/_FrameworkExpiredAlert"
+                         model="@(new NavBaseModel { BackLink = Url.Action(nameof(OrderController.ReadyToStart), typeof(OrderController).ControllerName(), new { area = typeof(OrderController).AreaName(), internalOrgId = Model.InternalOrgId }) })"/>
                 <nhs-page-title advice="Before you start your order, you should know:" />
                 <ul>
                     <li>the framework you’re ordering from</li>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/OrderTriage/SelectFramework.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/OrderTriage/SelectFramework.cshtml
@@ -1,33 +1,52 @@
-﻿@model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.OrderTriage.SelectFrameworkModel
+﻿@using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers
+@model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.OrderTriage.SelectFrameworkModel
 @{
     ViewBag.Title = "Which framework are you buying from?";
 }
 
 <div>
-    <partial name="Partials/_BackLink" model="Model" />
+    <partial name="Partials/_BackLink" model="Model"/>
     <div class="nhsuk-grid-row nhsuk-u-margin-bottom-6">
         <div class="nhsuk-grid-column-two-thirds">
-            <nhs-validation-summary RadioId="@nameof(Model.SelectedFrameworkId)" />
+            <nhs-validation-summary RadioId="@nameof(Model.SelectedFrameworkId)"/>
             <nhs-page-title title="@ViewBag.Title"
                             caption="@Model.OrganisationName"
-                            advice="Select the procurement framework that the solution you want to order is available on." />
-            <form method="post">
-                <input type="hidden" asp-for="OrganisationName" />
-                <input type="hidden" asp-for="BackLink" />
-                <nhs-fieldset-form-label asp-for="SelectedFrameworkId">
-                    @for (int i = 0; i < Model.Frameworks.Count; i++)
-                    {
-                        <input type="hidden" asp-for="Frameworks[i].Text" />
-                        <input type="hidden" asp-for="Frameworks[i].Value" />
-                    }
-                    <nhs-radio-buttons asp-for="SelectedFrameworkId"
-                                       values="@Model.Frameworks.Cast<object>()"
-                                       display-name="Text"
-                                       value-name="Value"
-                                       disabled-name="Disabled"/>
-                </nhs-fieldset-form-label>
-                <nhs-submit-button class="nhsuk-u-margin-top-4" />
-            </form>
+                            advice="Select the procurement framework that the solution you want to order is available on."/>
+            @if (Model.Frameworks.Any())
+            {
+                <form method="post">
+                    <input type="hidden" asp-for="OrganisationName"/>
+                    <input type="hidden" asp-for="BackLink"/>
+                    <nhs-fieldset-form-label asp-for="SelectedFrameworkId">
+                        @for (var i = 0; i < Model.Frameworks.Count; i++)
+                        {
+                            <input type="hidden" asp-for="Frameworks[i].Text"/>
+                            <input type="hidden" asp-for="Frameworks[i].Value"/>
+                        }
+                        <nhs-radio-buttons asp-for="SelectedFrameworkId"
+                                           values="@Model.Frameworks.Cast<object>()"
+                                           display-name="Text"
+                                           value-name="Value"/>
+                    </nhs-fieldset-form-label>
+                    <nhs-submit-button class="nhsuk-u-margin-top-4"/>
+                </form>
+            }
+            else
+            {
+                <nhs-warning-callout label-text="Frameworks expired">
+                    <p>There are no valid frameworks and you cannot continue with this order.</p>
+
+                    <a asp-action="@nameof(HomeController.FrameworksExpired)"
+                       asp-controller="@typeof(HomeController).ControllerName()"
+                       asp-route-backLink="@(Url.Action(nameof(OrderTriageController.SelectFramework), typeof(OrderTriageController).ControllerName(), new { area = typeof(OrderTriageController).AreaName(), orderType = Model.OrderType, }))">Find
+                        out what framework expiry means for you</a>
+                </nhs-warning-callout>
+
+                <vc:nhs-anchor-button type="Primary" text="Back to dashboard" url="@(Url.Action(
+                                                                                       nameof(DashboardController.Organisation),
+                                                                                       typeof(DashboardController).ControllerName(),
+                                                                                       new { area = typeof(DashboardController).AreaName(), internalOrgId = Model.InternalOrgId }))"/>
+            }
         </div>
     </div>
 </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Solutions/Views/Solutions/Index.cshtml
@@ -1,10 +1,16 @@
-﻿@using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
-@using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers;
+﻿@using Microsoft.AspNetCore.Mvc.TagHelpers
+@using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
+@using NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
+@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsModalSearch
+@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.Components.NhsSuggestionSearch
+@using NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.Card
+@using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Controllers
+@using NHSD.GPIT.BuyingCatalogue.WebApp.Models
 
 @model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Solutions.Models.SolutionsModel;
 @{
-    var PageTitle = Model.GetPageTitle();
-    ViewBag.Title = PageTitle.Title;
+    var pageTitle = Model.GetPageTitle();
+    ViewBag.Title = pageTitle.Title;
     Layout = "~/Views/Shared/Layouts/_AllBannersLayout.cshtml";
     ViewData["nhsuk-width-container"] = "bc-wider-container";
 }
@@ -15,29 +21,30 @@
 
 <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
-        <nhs-page-title model="@PageTitle" />
+        <nhs-page-title model="@pageTitle"/>
         @if (!Model.SearchCriteriaApplied)
         {
-            <partial name="Partials/_FrameworkExpiredAlert" />
+            <partial name="Partials/_FrameworkExpiredAlert"
+                     model="@(new NavBaseModel { BackLink = Url.Action(nameof(SolutionsController.Index), typeof(SolutionsController).ControllerName(), new { area = typeof(SolutionsController).AreaName() }) })"/>
         }
         <div class="nhsuk-grid-row">
             <div class="nhsuk-grid-column-one-third nshuk-card">
-                <partial name="_AdditionalFilters" model="@(Model.AdditionalFilters)" />
+                <partial name="_AdditionalFilters" model="@(Model.AdditionalFilters)"/>
             </div>
 
             <div class="nhsuk-grid-column-two-thirds" id="search">
                 <nhs-card title="Search Catalogue Solutions">
                     <div id="search-by">
                         <vc:nhs-suggestion-search id="marketing-suggestion-search"
-                                                    ajax-url="@Url.Action(nameof(SolutionsController.FilterSearchSuggestions), typeof(SolutionsController).ControllerName())"
-                                                    title-text="Search by supplier or solution name"
-                                                    query-parameter-name="search" />
+                                                  ajax-url="@Url.Action(nameof(SolutionsController.FilterSearchSuggestions), typeof(SolutionsController).ControllerName())"
+                                                  title-text="Search by supplier or solution name"
+                                                  query-parameter-name="search"/>
                     </div>
                 </nhs-card>
             </div>
 
             <div class="nhsuk-grid-column-two-thirds" id="solutions-list">
-                <partial name="SearchResults" model="@Model.ResultsModel" />
+                <partial name="SearchResults" model="@Model.ResultsModel"/>
             </div>
         </div>
     </div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Controllers/HomeController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Controllers/HomeController.cs
@@ -57,6 +57,18 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Controllers
         [HttpGet("accessibility-statement")]
         public IActionResult AccessibilityStatement() => View();
 
+        public IActionResult FrameworksExpired(string backLink = null)
+        {
+            var model = new NavBaseModel
+            {
+                BackLink = string.IsNullOrWhiteSpace(backLink)
+                    ? Url.Action(nameof(HomeController.Index), typeof(HomeController))
+                    : backLink,
+            };
+
+            return View(model);
+        }
+
         [HttpGet("unauthorized")]
         public IActionResult NotAuthorized() => View();
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Home/FrameworksExpired.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Home/FrameworksExpired.cshtml
@@ -1,0 +1,27 @@
+@model NavBaseModel
+
+@{
+    ViewBag.Title = "What framework expiry means for you";
+}
+
+<partial name="Partials/_BackLink" model="Model" />
+
+<div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+        <nhs-page-title title="@ViewBag.Title" />
+
+        <h2>GP IT Futures framework</h2>
+        <p>Lot 1 of the GP IT Futures framework expired on 31 March 2023. This means you can no longer carry out new procurements of solutions and services offered under that framework. However, if your Integrated Care Board uses multiple suppliers across its estate, practices may still choose to migrate to one of those existing suppliers.</p>
+        <p>Continuity contracts have been put in place to ensure that you continue to have access to your purchased solutions and services between 1 April 2023 and the go live date of the replacement framework, which is scheduled for 2024.</p>
+
+        <h2>Digital First Online Consultation and Video Consultation framework</h2>
+        <p>The DFOCVC framework expired on 31 March 2024. This means you can no longer carry out new procurements of solutions and services offered under that framework.</p>
+
+        <h2>Need help?</h2>
+        <p>For help using the Buying Catalogue, email the <a href="mailto:commercial.procurementhub@nhs.net">commercial.procurementhub@nhs.net</a> or complete the online contact form.</p>
+        <vc:nhs-action-link url="@Url.Action(
+                                     nameof(ProcurementHubController.Index),
+                                     typeof(ProcurementHubController).ControllerName())"
+                            text="Contact procurement hub" />
+    </div>
+</div>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/Partials/_FrameworkExpiredAlert.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/Shared/Partials/_FrameworkExpiredAlert.cshtml
@@ -1,15 +1,10 @@
-﻿<nhs-warning-callout label-text="GP IT Futures and DFOCVC frameworks expired" id="framework-expired-warning">
-    <p>The GP IT Futures and Digital First Online Consultation and Video Consultation (DFOCVC) frameworks have both now expired.</p>
-    
-    <nhs-details label-text="Find out what framework expiry means for you">
-        <h3>GP IT Futures framework</h3>
-        <p>Lot 1 of the GP IT Futures framework expired on 31 March 2023. This means you can no longer carry out new procurements of solutions and services offered under that framework. However, if your Integrated Care Board uses multiple suppliers across its estate, practices may still choose to migrate to one of those existing suppliers.</p>
-        <p>Continuity contracts have been put in place to ensure that you continue to have access to your purchased solutions and services between 1 April 2023 and the go live date of the replacement framework, which is scheduled for 2024.</p>
+﻿@model NavBaseModel
 
-        <h3>Digital First Online Consultation and Video Consultation framework</h3>
-        <p>The DFOCVC framework expired on 31 March 2024. This means you can no longer carry out new procurements of solutions and services offered under that framework.</p>
-        <p>The National Commercial & Procurement Hub can support service continuity enquiries via <a href="mailto:commercial.procurementhub@nhs.net">commercial.procurementhub@nhs.net</a>.</p>
-    </nhs-details>
+<nhs-warning-callout label-text="GP IT Futures and DFOCVC frameworks expired" id="framework-expired-warning">
+    <p>The GP IT Futures and Digital First Online Consultation and Video Consultation (DFOCVC) frameworks have both now
+        expired.</p>
 
-
+    <a asp-action="@nameof(HomeController.FrameworksExpired)"
+       asp-controller="@typeof(HomeController).ControllerName()"
+       asp-route-backLink="@(Model.BackLink)">Find out what framework expiry means for you</a>
 </nhs-warning-callout>

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/OrderTriageControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/OrderTriageControllerTests.cs
@@ -197,7 +197,9 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers
             List<EntityFramework.Catalogue.Models.Framework> frameworks,
             OrderTriageController controller)
         {
-            var expectedModel = new SelectFrameworkModel(organisation.Name, frameworks.OrderBy(f => f.IsExpired).ThenBy(f => f.Name).ToList(), null);
+            frameworks.ForEach(x => x.IsExpired = false);
+            frameworks.First().IsExpired = true;
+            var expectedModel = new SelectFrameworkModel(organisation, frameworks.Where(f => !f.IsExpired).OrderBy(f => f.Name).ToList(), null);
 
             service
                 .GetOrganisationByInternalIdentifier(organisation.InternalIdentifier)

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/OrderTriage/SelectFrameworkModelTest.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/OrderTriage/SelectFrameworkModelTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Organisations.Models;
 using NHSD.GPIT.BuyingCatalogue.Framework.Models;
 using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.OrderTriage;
 using Xunit;
@@ -12,20 +13,20 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.OrderTri
         [Theory]
         [MockAutoData]
         public static void PropertiesCorrectlySet(
-            string organisationName,
+            Organisation organisation,
             IList<EntityFramework.Catalogue.Models.Framework> frameworks,
             string selectedFrameworkId)
         {
             var expectedFrameworks = frameworks.Select(
                     f => new SelectOption<string>(
-                        $"{f.ShortName}{(f.IsExpired ? " (Expired)" : string.Empty)}",
-                        f.Id,
-                        disabled: f.IsExpired))
+                        $"{f.ShortName}",
+                        f.Id))
                 .ToList();
 
-            var model = new SelectFrameworkModel(organisationName, frameworks, selectedFrameworkId);
+            var model = new SelectFrameworkModel(organisation, frameworks, selectedFrameworkId);
 
-            model.OrganisationName.Should().Be(organisationName);
+            model.OrganisationName.Should().Be(organisation.Name);
+            model.InternalOrgId.Should().Be(organisation.InternalIdentifier);
             model.SelectedFrameworkId.Should().Be(selectedFrameworkId);
             model.Frameworks.Should().BeEquivalentTo(expectedFrameworks);
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Controllers/HomeControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Controllers/HomeControllerTests.cs
@@ -208,5 +208,19 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Controllers
             result.Should().NotBeNull();
             result.ViewName.Should().BeNull();
         }
+
+        [Theory]
+        [MockInlineAutoData(null)]
+        [MockInlineAutoData(" ")]
+        [MockInlineAutoData("url")]
+        public static void Get_FrameworksExpired_ReturnsView(
+            string backLink,
+            HomeController controller)
+        {
+            var result = controller.FrameworksExpired(backLink).As<ViewResult>();
+
+            result.Should().NotBeNull();
+            result.Model.Should().BeOfType<NavBaseModel>();
+        }
     }
 }


### PR DESCRIPTION
* Moves the framework expiry callout to a standalone page
* Removes the `Disabled` support for `SelectOption<T>`
* Removes expired frameworks for the order triage journey
* Prevents order creation if there are no procurement frameworks