### PR TITLE
Insert distinct workoff plans

### DIFF
--- a/database/NHSD.GPITBuyingCatalogue.Database/PostDeployment/MigrateWorkOffPlans.sql
+++ b/database/NHSD.GPITBuyingCatalogue.Database/PostDeployment/MigrateWorkOffPlans.sql
@@ -1,5 +1,5 @@
 ﻿IF NOT EXISTS(SELECT * FROM catalogue.InProgressSolutionStandards)
 BEGIN
     INSERT INTO catalogue.InProgressSolutionStandards([SolutionId], [StandardId])
-    SELECT [SolutionId], [StandardId] FROM catalogue.WorkOffPlans
+    SELECT DISTINCT [SolutionId], [StandardId] FROM catalogue.WorkOffPlans
 END


### PR DESCRIPTION
Schematically, a solution could have multiple work-off plans for a single standard. I'm not sure if this is valid in practical terms. For now the migration script will insert distinct ID pairings