### PR TITLE
Use correct hint ID for aria-describedby attribute

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/FieldSet/FieldSetFormContainerTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/FieldSet/FieldSetFormContainerTagHelper.cs
@@ -35,7 +35,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.FieldS
             var formGroup = TagHelperBuilders.GetFormGroupBuilder();
             var fieldset = GetFieldsetBuilder(formName, LabelHint);
             var fieldsetheading = GetFieldSetLegendHeadingBuilder(SelectedSize, LabelText);
-            var hint = TagHelperBuilders.GetLabelHintBuilder(For, LabelHint, formName);
+            var hint = TagHelperBuilders.GetLabelHintBuilder(LabelHint, formName);
             var errorMessage = BuildErrorMessage(formName);
 
             var content = await output.GetChildContentAsync();

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/FieldSet/FieldSetFormLabelTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/FieldSet/FieldSetFormLabelTagHelper.cs
@@ -58,7 +58,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
 
             var labelHint = parentChildContext.IsTimeInput ? TimeInputConstants.TimeInputHint : LabelHint;
 
-            var hint = TagHelperBuilders.GetLabelHintBuilder(For, labelHint, formName);
+            var hint = TagHelperBuilders.GetLabelHintBuilder(labelHint, formName);
 
             var errorMessage = BuildErrorMessage(formName);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Helpers/TagHelperBuilders.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/Helpers/TagHelperBuilders.cs
@@ -85,17 +85,15 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
             return builder;
         }
 
-        public static TagBuilder GetLabelHintBuilder(ModelExpression aspFor, string hintText, string formName = null)
+        public static TagBuilder GetLabelHintBuilder(string hintText, string formName)
         {
-            if ((string.IsNullOrEmpty(aspFor?.Name) && string.IsNullOrEmpty(formName))
+            if (string.IsNullOrEmpty(formName)
                 || string.IsNullOrEmpty(hintText))
                 return null;
 
-            var name = !string.IsNullOrEmpty(aspFor?.Name) ? aspFor.Name : formName;
-
             var builder = new TagBuilder(TagHelperConstants.Div);
 
-            builder.GenerateId($"{name}-hint", "_");
+            builder.GenerateId($"{formName}-hint", "_");
             builder.AddCssClass(TagHelperConstants.NhsHint);
 
             builder.InnerHtml.AppendHtml(hintText);

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/InputBoxes/BookendedTextInputTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/InputBoxes/BookendedTextInputTagHelper.cs
@@ -53,7 +53,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.InputB
             var formGroup = GetGovFormGroupBuilder();
             var label = TagHelperBuilders.GetLabelBuilder(ViewContext, For, htmlGenerator, null, LabelText);
             SetLabelAriaDescription(label);
-            var hint = TagHelperBuilders.GetLabelHintBuilder(For, LabelHint, null);
+            var hint = TagHelperBuilders.GetLabelHintBuilder(LabelHint, For.Name);
             var validation = TagHelperBuilders.GetValidationBuilder(ViewContext, For, htmlGenerator);
             var inputWrapper = GetInputWrapper();
 

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/InputBoxes/TextAreaTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/InputBoxes/TextAreaTagHelper.cs
@@ -47,7 +47,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
         {
             var formGroup = TagHelperBuilders.GetFormGroupBuilder();
             var label = TagHelperBuilders.GetLabelBuilder(ViewContext, For, htmlGenerator, null, LabelText);
-            var hint = TagHelperBuilders.GetLabelHintBuilder(For, LabelHint, null);
+            var hint = TagHelperBuilders.GetLabelHintBuilder(LabelHint, For.Name);
             var validation = TagHelperBuilders.GetValidationBuilder(ViewContext, For, htmlGenerator);
             var input = GetInputBuilder();
             var counter = TagHelperBuilders.GetCounterBuilder(For, DefaultMaxLength, CharacterCountEnabled);
@@ -93,7 +93,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
             {
                 builder.MergeAttribute(
                     TagHelperConstants.AriaDescribedBy,
-                    TagBuilder.CreateSanitizedId(string.Join(' ', describedBy), "_"));
+                    TagBuilder.CreateSanitizedId(string.Join(' ', describedBy), " "));
             }
 
             if (TagHelperFunctions.CheckIfModelStateHasErrors(ViewContext, For))

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/InputBoxes/TextInputTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/InputBoxes/TextInputTagHelper.cs
@@ -72,7 +72,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
 
             var formGroup = TagHelperBuilders.GetFormGroupBuilder();
             var label = TagHelperBuilders.GetLabelBuilder(ViewContext, For, htmlGenerator, null, LabelText);
-            var hint = TagHelperBuilders.GetLabelHintBuilder(For, LabelHint, null);
+            var hint = TagHelperBuilders.GetLabelHintBuilder(LabelHint, For.Name);
             var validation = TagHelperBuilders.GetValidationBuilder(ViewContext, For, htmlGenerator, VisuallyHiddenError);
             var input = GetInputBuilder();
             var counter = TagHelperBuilders.GetCounterBuilder(For, DefaultMaxLength, CharacterCountEnabled);
@@ -124,7 +124,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
             {
                 builder.MergeAttribute(
                     TagHelperConstants.AriaDescribedBy,
-                    TagBuilder.CreateSanitizedId(string.Join(' ', describedBy), "_"));
+                    TagBuilder.CreateSanitizedId(string.Join(' ', describedBy), " "));
             }
 
             if (TagHelperFunctions.GetCustomAttributes<PasswordAttribute>(For)?.Any() == true)

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/SelectList/SelectListTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/SelectList/SelectListTagHelper.cs
@@ -61,7 +61,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
                 ? TagHelperBuilders.GetInlineLabelBuilder(ViewContext, For, htmlGenerator, null, LabelText)
                 : TagHelperBuilders.GetLabelBuilder(ViewContext, For, htmlGenerator, null, LabelText);
             var errorMessage = TagHelperBuilders.GetValidationBuilder(ViewContext, For, htmlGenerator);
-            var hint = TagHelperBuilders.GetLabelHintBuilder(For, LabelHint);
+            var hint = TagHelperBuilders.GetLabelHintBuilder(LabelHint, For.Name);
 
             var selectList = TagHelperBuilders.GetSelectListBuilder(
                 htmlGenerator,

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/TimeInput/NhsTimeInputTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/TimeInput/NhsTimeInputTagHelper.cs
@@ -32,7 +32,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.Views.Shared.TagHelpers.TimeIn
 
             var formGroup = TagHelperBuilders.GetFormGroupBuilder();
             var label = TagHelperBuilders.GetLabelBuilder(ViewContext, For, htmlGenerator, null, LabelText);
-            var hint = TagHelperBuilders.GetLabelHintBuilder(For, TimeInputConstants.TimeInputHint);
+            var hint = TagHelperBuilders.GetLabelHintBuilder(TimeInputConstants.TimeInputHint, For.Name);
             var validation = TagHelperBuilders.GetValidationBuilder(ViewContext, For, htmlGenerator);
             var input = GetInputBuilder();
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Identity/Controllers/AccountControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Identity/Controllers/AccountControllerTests.cs
@@ -677,8 +677,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Identity.Controllers
                 mockSignInManager,
                 passwordService: mockPasswordService);
 
-            var result = Assert.ThrowsAsync<InvalidOperationException>(async () => await controller.ResetPassword(model));
-            result.Result.Message.Should().Be("Unexpected errors whilst resetting password: " + errorMessage);
+            var result = await Assert.ThrowsAsync<InvalidOperationException>(() => controller.ResetPassword(model));
+            result.Message.Should().Be("Unexpected errors whilst resetting password: " + errorMessage);
 
             await mockPasswordService
                 .Received()
@@ -730,7 +730,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Identity.Controllers
 
         [Theory]
         [MockAutoData]
-        public static void UpdatePassword_UnexpectedErrors_ThrowsException(
+        public static async Task UpdatePassword_UnexpectedErrors_ThrowsException(
             UserManager<AspNetUser> mockUserManager,
             SignInManager<AspNetUser> mockSignInManager,
             UpdatePasswordViewModel model,
@@ -762,8 +762,8 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Identity.Controllers
                 HttpContext = new DefaultHttpContext { User = userPrincipal, },
             };
 
-            var result = Assert.ThrowsAsync<InvalidOperationException>(async () => await controller.UpdatePassword(model));
-            result.Result.Message.Should().Be("Unexpected errors whilst updating password: " + errorMessage);
+            var result = await Assert.ThrowsAsync<InvalidOperationException>(() => controller.UpdatePassword(model));
+            result.Message.Should().Be("Unexpected errors whilst updating password: " + errorMessage);
         }
 
         [Theory]


### PR DESCRIPTION
We use different ID formats depending on the context of the page. In some cases it's an array of elements denoted by an indexer. In other cases it's a single element with a name.

![image](https://github.com/user-attachments/assets/e0f3c400-b564-4417-b451-1ff06cf760a8)

This moves the name logic out of the hint label builder as it's the upper tagbuilder that should decide the name to be used.

In cases where multiple hints existed, these were being delimited by an underscore thus resulting in an invalid element ID. For example:
1. Hint label - `my-input-hint`
2. Character count `my-input-summary`

resulted in an aria-describedby value of `my-input-hint_my-input-summary` when it should be space delimited like `my-input-hint my-input-summary`