### PR TITLE
Competition accessibility fixes

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/CatalogueItemId.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/CatalogueItemId.cs
@@ -1,22 +1,16 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Globalization;
 using System.Text.Json.Serialization;
-using System.Text.RegularExpressions;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.TypeConverters;
 using static System.FormattableString;
 
 namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
 {
     [TypeConverter(typeof(CatalogueItemIdTypeConverter))]
-    public readonly struct CatalogueItemId
+    public readonly struct CatalogueItemId : IEquatable<CatalogueItemId>
     {
         public const int MaxItemIdLength = 7;
         public const int MaxSupplierId = 999999;
-
-        private const string Pattern = @"^(?<supplierId>\d{1,6})-(?<itemId>\S{1,7})$";
-
-        private static readonly Lazy<Regex> Regex = new(() => new Regex(Pattern, RegexOptions.Compiled));
 
         [JsonConstructor]
         public CatalogueItemId(int supplierId, string itemId)
@@ -48,22 +42,34 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
             return !(left == right);
         }
 
-        public static (bool Success, CatalogueItemId Id) Parse(string catalogueItemId)
+        public static bool TryParse(string catalogueItemId, out CatalogueItemId id)
         {
-            var match = Regex.Value.Match(catalogueItemId);
-            if (!match.Success)
-                return (false, default);
+            id = default;
 
-            var supplierId = int.Parse(match.Groups["supplierId"].Value, CultureInfo.InvariantCulture);
-            var itemId = match.Groups["itemId"].Value;
+            if (string.IsNullOrWhiteSpace(catalogueItemId))
+                return false;
 
-            return (true, new CatalogueItemId(supplierId, itemId));
+            var catalogueId = catalogueItemId.AsSpan();
+            var dashIndex = catalogueId.IndexOf('-');
+
+            if (dashIndex == -1)
+                return false;
+
+            if (!int.TryParse(catalogueId[..dashIndex], out var supplierId))
+                return false;
+
+            var itemId = catalogueId[(dashIndex + 1)..];
+            if (itemId.IsEmpty)
+                return false;
+
+            id = new CatalogueItemId(supplierId, itemId.ToString());
+
+            return true;
         }
 
         public static CatalogueItemId ParseExact(string catalogueItemId)
         {
-            (bool success, CatalogueItemId id) = Parse(catalogueItemId);
-            if (!success)
+            if (!TryParse(catalogueItemId, out var id))
                 throw new FormatException();
 
             return id;
@@ -99,10 +105,15 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
 
         public CatalogueItemId NextAssociatedServiceId()
         {
-            if (!int.TryParse(ItemId.Replace("S-", string.Empty), out var itemId))
+            const string associatedServiceIdPrefix = "S-";
+
+            var itemIdSpan = ItemId.AsSpan();
+            if (!itemIdSpan.StartsWith(associatedServiceIdPrefix) || !int.TryParse(
+                    itemIdSpan[(itemIdSpan.IndexOf("-") + 1)..],
+                    out var itemId))
                 throw new FormatException();
 
-            return new CatalogueItemId(SupplierId, $"S-{itemId + 1:D3}");
+            return new CatalogueItemId(SupplierId, $"{associatedServiceIdPrefix}{itemId + 1:D3}");
         }
 
         public CatalogueItemId NextAdditionalServiceId()

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Capabilities/Gen2UploadService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Capabilities/Gen2UploadService.cs
@@ -76,7 +76,7 @@ public class Gen2UploadService : CsvServiceBase, IGen2UploadService
 
         var catalogueItemIdValid = !string.IsNullOrWhiteSpace(baseRecord.SolutionId)
             && Gen2ValidationRegex.CatalogueItemIdRegex().IsMatch(baseRecord.SolutionId)
-            && CatalogueItemId.Parse(baseRecord.SolutionId).Success;
+            && CatalogueItemId.TryParse(baseRecord.SolutionId, out _);
 
         var capabilityIdValid = !string.IsNullOrWhiteSpace(baseRecord.CapabilityId)
             && Gen2ValidationRegex.CapabilityIdRegex().IsMatch(baseRecord.CapabilityId);

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/InputBoxes/TextAreaTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/InputBoxes/TextAreaTagHelper.cs
@@ -93,7 +93,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
             {
                 builder.MergeAttribute(
                     TagHelperConstants.AriaDescribedBy,
-                    TagBuilder.CreateSanitizedId(string.Join(' ', describedBy), " "));
+                    string.Join(' ', describedBy.Select(x => TagBuilder.CreateSanitizedId(x, "_"))));
             }
 
             if (TagHelperFunctions.CheckIfModelStateHasErrors(ViewContext, For))

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/InputBoxes/TextInputTagHelper.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components/Views/Shared/TagHelpers/InputBoxes/TextInputTagHelper.cs
@@ -124,7 +124,7 @@ namespace NHSD.GPIT.BuyingCatalogue.UI.Components.TagHelpers
             {
                 builder.MergeAttribute(
                     TagHelperConstants.AriaDescribedBy,
-                    TagBuilder.CreateSanitizedId(string.Join(' ', describedBy), " "));
+                    string.Join(' ', describedBy.Select(x => TagBuilder.CreateSanitizedId(x, "_"))));
             }
 
             if (TagHelperFunctions.GetCustomAttributes<PasswordAttribute>(For)?.Any() == true)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionScoring/Features.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionScoring/Features.cshtml
@@ -93,14 +93,14 @@
                                              label-text="What score would you give this solution?"
                                              label-hint="Score each solution between 1 and 5. The higher the score, the better you think a solution meets your needs." size="Medium">
                         <input type="hidden" asp-for="@Model.SolutionScores[i].SolutionId"/>
-                        <nhs-input asp-for="@Model.SolutionScores[i].Score" input-width="Three"/>
+                        <nhs-input label-text="Score" asp-for="@Model.SolutionScores[i].Score" input-width="Three"/>
                     </nhs-fieldset-form-label>
 
                     <nhs-fieldset-form-label asp-for="@Model.SolutionScores[i]"
                                              label-text="Why have you given this score?"
                                              label-hint="Provide a justification for the score you have given this solution." size="Medium">
                         <input type="hidden" asp-for="@Model.SolutionScores[i].SolutionId"/>
-                        <nhs-textarea asp-for="@Model.SolutionScores[i].Justification"/>
+                        <nhs-textarea label-text="Justification" asp-for="@Model.SolutionScores[i].Justification"/>
                     </nhs-fieldset-form-label>
                 </nhs-expander>
                 @if (i == Model.SolutionScores.Count - 1)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionScoring/Implementation.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionScoring/Implementation.cshtml
@@ -48,14 +48,14 @@
                                              label-text="What score would you give this solution?"
                                              label-hint="Score each solution between 1 and 5. The higher the score, the better you think a solution meets your needs." size="Medium">
                         <input type="hidden" asp-for="@Model.SolutionScores[i].SolutionId"/>
-                        <nhs-input asp-for="@Model.SolutionScores[i].Score" input-width="Three"/>
+                        <nhs-input label-text="Score" asp-for="@Model.SolutionScores[i].Score" input-width="Three"/>
                     </nhs-fieldset-form-label>
 
                     <nhs-fieldset-form-label asp-for="@Model.SolutionScores[i]"
                                              label-text="Why have you given this score?"
                                              label-hint="Provide a justification for the score you have given this solution." size="Medium">
                         <input type="hidden" asp-for="@Model.SolutionScores[i].SolutionId"/>
-                        <nhs-textarea asp-for="@Model.SolutionScores[i].Justification" />
+                        <nhs-textarea label-text="Justification" asp-for="@Model.SolutionScores[i].Justification" />
                     </nhs-fieldset-form-label>
                 </nhs-expander>
                 @if (i == Model.SolutionScores.Count - 1)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionScoring/Interoperability.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionScoring/Interoperability.cshtml
@@ -119,13 +119,13 @@
                                              label-text="What score would you give this solution?"
                                              label-hint="Score each solution between 1 and 5. The higher the score, the better you think a solution meets your needs." size="Medium">
                         <input type="hidden" asp-for="@Model.SolutionScores[i].SolutionId"/>
-                        <nhs-input asp-for="@Model.SolutionScores[i].Score" input-width="Three"/>
+                        <nhs-input label-text="Score" asp-for="@Model.SolutionScores[i].Score" input-width="Three"/>
                     </nhs-fieldset-form-label>
                     <nhs-fieldset-form-label asp-for="@Model.SolutionScores[i]"
                                              label-text="Why have you given this score?"
                                              label-hint="Provide a justification for the score you have given this solution." size="Medium">
                         <input type="hidden" asp-for="@Model.SolutionScores[i].SolutionId"/>
-                        <nhs-textarea asp-for="@Model.SolutionScores[i].Justification"/>
+                        <nhs-textarea label-text="Justification" asp-for="@Model.SolutionScores[i].Justification"/>
                     </nhs-fieldset-form-label>
 
                 </nhs-expander>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionScoring/ServiceLevel.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionScoring/ServiceLevel.cshtml
@@ -106,14 +106,14 @@
                                              label-text="What score would you give this solution?"
                                              label-hint="Score each solution between 1 and 5. The higher the score, the better you think a solution meets your needs." size="Medium">
                         <input type="hidden" asp-for="@Model.SolutionScores[i].SolutionId"/>
-                        <nhs-input asp-for="@Model.SolutionScores[i].Score" input-width="Three"/>
+                        <nhs-input label-text="Score" asp-for="@Model.SolutionScores[i].Score" input-width="Three"/>
                     </nhs-fieldset-form-label>
 
                     <nhs-fieldset-form-label asp-for="@Model.SolutionScores[i]"
                                              label-text="Why have you given this score?"
                                              label-hint="Provide a justification for the score you have given this solution." size="Medium">
                         <input type="hidden" asp-for="@Model.SolutionScores[i].SolutionId"/>
-                        <nhs-textarea asp-for="@Model.SolutionScores[i].Justification"/>
+                        <nhs-textarea label-text="Justification" asp-for="@Model.SolutionScores[i].Justification"/>
                     </nhs-fieldset-form-label>
                 </nhs-expander>
                 @if (i == Model.SolutionScores.Count - 1)

--- a/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/Models/Ordering/CatalogueItemIdTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/Models/Ordering/CatalogueItemIdTests.cs
@@ -28,5 +28,68 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests.Models.Ordering
 
             actual.Should().BeEquivalentTo(new CatalogueItemId(supplierId, (itemId + 1).ToString("D3")));
         }
+
+        [Theory]
+        [InlineAutoData("10000-001")]
+        [InlineAutoData("10000-005A001")]
+        [InlineAutoData("10000-S-ABC")]
+        [InlineAutoData("10000-S005")]
+        [InlineAutoData("10000-S")]
+        public static void NextAssociatedServiceId_InvalidFormat_ThrowsFormatException(
+            string catalogueItemId)
+        {
+            var parsedId = CatalogueItemId.ParseExact(catalogueItemId);
+
+            FluentActions.Invoking(() => parsedId.NextAssociatedServiceId()).Should().Throw<FormatException>();
+        }
+
+        [Theory]
+        [InlineAutoData("10000-S-001", "S-002")]
+        [InlineAutoData("10000-S-005", "S-006")]
+        public static void NextAssociatedServiceId_Valid_ReturnsExpected(
+            string catalogueItemId,
+            string expectedAssociatedServiceId)
+        {
+            var parsedId = CatalogueItemId.ParseExact(catalogueItemId);
+
+            parsedId.NextAssociatedServiceId().Should().Be(new CatalogueItemId(parsedId.SupplierId, expectedAssociatedServiceId));
+        }
+
+        [Theory]
+        [InlineAutoData("10000-001", true)]
+        [InlineAutoData("10000-001A001", true)]
+        [InlineAutoData("10000-S-001", true)]
+        [InlineAutoData("", false)]
+        [InlineAutoData("0-", false)]
+        [InlineAutoData(null, false)]
+        public static void TryParse_ReturnsExpectedParsingResult(
+            string catalogueItemId,
+            bool expectedResult) => CatalogueItemId.TryParse(catalogueItemId, out _).Should().Be(expectedResult);
+
+        [Theory]
+        [InlineAutoData("10000-001", "001")]
+        [InlineAutoData("10000-001A001", "001A001")]
+        [InlineAutoData("10000-S-001", "S-001")]
+        public static void TryParse_ReturnsExpectedItemId(
+            string catalogueItemId,
+            string expectedResult)
+        {
+            _ = CatalogueItemId.TryParse(catalogueItemId, out var parsedId);
+
+            parsedId.ItemId.Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [InlineAutoData("10000-001", 10000)]
+        [InlineAutoData("10-001A001", 10)]
+        [InlineAutoData("1-S-001", 1)]
+        public static void TryParse_ReturnsExpectedSupplierId(
+            string catalogueItemId,
+            int expectedSupplierId)
+        {
+            _ = CatalogueItemId.TryParse(catalogueItemId, out var parsedId);
+
+            parsedId.SupplierId.Should().Be(expectedSupplierId);
+        }
     }
 }


### PR DESCRIPTION
1. Refactor the CatalogueItemId parsing logic to remove regex (tech debt - regex not needed for simple parsing)
2. Tweak the aria-described by again. This was sanitizing the whole attribute in one pass rather than sanitizing individual IDs and joining them all together into a single attribute value at the end
3. Accessibility improvements (described in story comments)