### PR TITLE
Bugfix: Use price weighted score for competition scoring

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Competitions/CompetitionsService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Competitions/CompetitionsService.cs
@@ -773,14 +773,14 @@ public class CompetitionsService : ICompetitionsService
         foreach (var competitionSolution in competition.CompetitionSolutions)
         {
             var priceScore = competitionSolution.GetScoreByType(ScoreType.Price);
-            var nonPriceScores = competitionSolution.Scores.Where(x => x.ScoreType is not ScoreType.Price).ToList();
 
+            var nonPriceScores = competitionSolution.Scores.Where(x => x.ScoreType is not ScoreType.Price).ToList();
             var nonPriceScoreSum = nonPriceScores.Sum(x => x.WeightedScore);
             var nonPriceWeightedScore = CompetitionFormulas.CalculateWeightedScore(
                 nonPriceScoreSum,
                 competition.Weightings?.NonPrice.GetValueOrDefault() ?? 0);
 
-            var totalScore = nonPriceWeightedScore + priceScore.Score;
+            var totalScore = nonPriceWeightedScore + priceScore.WeightedScore;
             solutionsAndScores[competitionSolution] = totalScore;
         }
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Competitions/CompetitionsServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Competitions/CompetitionsServiceTests.cs
@@ -2373,35 +2373,51 @@ public static class CompetitionsServiceTests
 
     [Theory]
     [MockAutoData]
-    public static void SetWinningSolution(
+    public static void SetWinningSolution_SetsExpectedWinningSolution(
         Competition competition,
         CompetitionSolution winningSolution,
+        CompetitionSolution secondWinningSolution,
         CompetitionSolution nonWinningSolution)
     {
-        winningSolution.IsWinningSolution = true;
+        winningSolution.IsWinningSolution = false;
         winningSolution.Scores = new List<SolutionScore>
         {
-            new(ScoreType.Price, 5, 3.5M),
-            new(ScoreType.Implementation, 5, 3.5M),
-            new(ScoreType.Interoperability, 3, 0.75M),
-            new(ScoreType.ServiceLevel, 2, 0.5M),
+            new(ScoreType.Price, 1, 0.3M),
+            new(ScoreType.Features, 5, 2M),
+            new(ScoreType.Implementation, 5, 1.5M),
+            new(ScoreType.Interoperability, 5, 1.5M),
+        };
+
+        secondWinningSolution.IsWinningSolution = false;
+        secondWinningSolution.Scores = new List<SolutionScore>
+        {
+            new(ScoreType.Price, 1, 0.3M),
+            new(ScoreType.Features, 5, 2M),
+            new(ScoreType.Implementation, 5, 1.5M),
+            new(ScoreType.Interoperability, 5, 1.5M),
         };
 
         nonWinningSolution.IsWinningSolution = false;
         nonWinningSolution.Scores = new List<SolutionScore>
         {
-            new(ScoreType.Price, 2, 1.4M),
-            new(ScoreType.Implementation, 5, 3.5M),
-            new(ScoreType.Interoperability, 3, 0.75M),
-            new(ScoreType.ServiceLevel, 2, 0.5M),
+            new(ScoreType.Price, 5, 1.5M),
+            new(ScoreType.Features, 3, 1.2M),
+            new(ScoreType.Implementation, 3, 0.9M),
+            new(ScoreType.Interoperability, 3, 0.9M),
         };
 
-        competition.Weightings = new() { Price = 70, NonPrice = 30 };
-        competition.CompetitionSolutions = new List<CompetitionSolution> { winningSolution, nonWinningSolution };
+        competition.Weightings = new() { Price = 30, NonPrice = 70 };
+        competition.NonPriceElements = new()
+        {
+            NonPriceWeights = new() { Features = 40, Implementation = 30, Interoperability = 30 },
+        };
+
+        competition.CompetitionSolutions = new List<CompetitionSolution> { winningSolution, secondWinningSolution, nonWinningSolution };
 
         CompetitionsService.SetWinningSolution(competition);
 
         winningSolution.IsWinningSolution.Should().BeTrue();
+        secondWinningSolution.IsWinningSolution.Should().BeTrue();
         nonWinningSolution.IsWinningSolution.Should().BeFalse();
     }
 


### PR DESCRIPTION
The competition journey currently uses the full price score + the non-price element weighted score when calculating the winners which results in incorrect results when non-price elements are weighted higher than price (I.E; a user wants non-price to influence the results more than price).

While a score should only be as high as 5, this bug means that a solution score could be set to 7.1 out of 5 and is then picked as the winner.

When the user views the results page, they're then given the weighted scores correctly making it all the more confusing as to why a solution with a lower score won the competition.

The test case reflects the scenario whereby there are joint-winning solutions and one non-winning solution has a higher price score but lower non-price scores.