### PR TITLE
Terraform: Correctly import web app certificate

### DIFF
--- a/terraform/webapp/modules/bc_webapp_pri/custom_domain_binding.tf
+++ b/terraform/webapp/modules/bc_webapp_pri/custom_domain_binding.tf
@@ -1,8 +1,20 @@
+resource "azurerm_app_service_certificate" "webapp" {
+  name                = "webapp_cert"
+  resource_group_name = var.rg_name
+  location            = var.region
+  key_vault_secret_id = var.keyvault_cert_id
+}
+
 resource "azurerm_app_service_custom_hostname_binding" "webapp_host_binding" {
   hostname            = var.app_dns_url
   app_service_name    = azurerm_linux_web_app.webapp.name
   resource_group_name = var.rg_name
   count               = var.create_host_binding
+}
+
+resource "azurerm_app_service_certificate_binding" "webapp_cert_binding" {
+  hostname_binding_id = azurerm_app_service_custom_hostname_binding.webapp_host_binding.id
   ssl_state           = "SniEnabled"
-  thumbprint          = var.ssl_thumbprint
+  certificate_id      = var.ssl_cert_id
+  count               = var.create_host_binding
 }

--- a/terraform/webapp/modules/bc_webapp_pri/custom_domain_binding.tf
+++ b/terraform/webapp/modules/bc_webapp_pri/custom_domain_binding.tf
@@ -13,8 +13,8 @@ resource "azurerm_app_service_custom_hostname_binding" "webapp_host_binding" {
 }
 
 resource "azurerm_app_service_certificate_binding" "webapp_cert_binding" {
-  hostname_binding_id = azurerm_app_service_custom_hostname_binding.webapp_host_binding.id
+  hostname_binding_id = join("", azurerm_app_service_custom_hostname_binding.webapp_host_binding[*].id)
   ssl_state           = "SniEnabled"
-  certificate_id      = var.ssl_cert_id
+  certificate_id      = azurerm_app_service_certificate.webapp.id
   count               = var.create_host_binding
 }

--- a/terraform/webapp/modules/bc_webapp_pri/variables.tf
+++ b/terraform/webapp/modules/bc_webapp_pri/variables.tf
@@ -34,10 +34,6 @@ variable "always_on" {
   type = string
 }
 
-variable "cert_name" {
-  type = string
-}
-
 variable "aspnet_environment" {
   type = string
 }
@@ -78,7 +74,11 @@ variable "create_host_binding" {
   type = string
 }
 
-variable "ssl_thumbprint" {
+variable "keyvault_cert_id" {
+  type = string
+}
+
+variable "ssl_cert_id" {
   type = string
 }
 

--- a/terraform/webapp/modules/bc_webapp_pri/variables.tf
+++ b/terraform/webapp/modules/bc_webapp_pri/variables.tf
@@ -78,10 +78,6 @@ variable "keyvault_cert_id" {
   type = string
 }
 
-variable "ssl_cert_id" {
-  type = string
-}
-
 variable "notify_api_key" {
   type = string
 }

--- a/terraform/webapp/webapp.tf
+++ b/terraform/webapp/webapp.tf
@@ -10,7 +10,6 @@ module "webapp" {
   sku_size                        = local.is_live_environment ? "P2v2" : "S1"
   repository_name                 = "nhsd/buying-catalogue/nhsdgpitbuyingcataloguewebapp"
   always_on                       = local.shortenv == "production" ? "true" : "false"
-  cert_name                       = var.certname
   aspnet_environment              = var.environment
   instrumentation_key             = azurerm_application_insights.appinsights.instrumentation_key
   primary_vpn                     = var.primary_vpn
@@ -21,7 +20,8 @@ module "webapp" {
   docker_registry_id              = data.azurerm_container_registry.acr.id
   create_slot                     = local.is_live_environment ? 1 : 0
   create_host_binding             = !local.use_app_gateway ? 1 : 0
-  ssl_thumbprint                  = data.azurerm_key_vault_certificate.ssl_cert.thumbprint
+  ssl_cert_id                     = data.azurerm_key_vault_certificate.ssl_cert.id
+  keyvault_cert_id                = data.azurerm_key_vault_secret.ssl_cert.id
   notify_api_key                  = var.notify_api_key
   blob_storage_connection_string  = module.documentstorageaccount.primary_connection_string
   recaptcha_site_key              = var.recaptcha_site_key

--- a/terraform/webapp/webapp.tf
+++ b/terraform/webapp/webapp.tf
@@ -20,7 +20,6 @@ module "webapp" {
   docker_registry_id              = data.azurerm_container_registry.acr.id
   create_slot                     = local.is_live_environment ? 1 : 0
   create_host_binding             = !local.use_app_gateway ? 1 : 0
-  ssl_cert_id                     = data.azurerm_key_vault_certificate.ssl_cert.id
   keyvault_cert_id                = data.azurerm_key_vault_secret.ssl_cert.id
   notify_api_key                  = var.notify_api_key
   blob_storage_connection_string  = module.documentstorageaccount.primary_connection_string

--- a/terraform/webapp/webapp_bindings.tf
+++ b/terraform/webapp/webapp_bindings.tf
@@ -1,6 +1,0 @@
-resource "azurerm_app_service_certificate" "webapp" {
-  name                = "webapp_cert"
-  resource_group_name = azurerm_resource_group.webapp.name
-  location            = var.region
-  key_vault_secret_id = data.azurerm_key_vault_secret.ssl_cert.id
-}

--- a/terraform/webapp/z_imported_secrets_core.tf
+++ b/terraform/webapp/z_imported_secrets_core.tf
@@ -7,8 +7,3 @@ data "azurerm_key_vault_secret" "ssl_cert" {
   name         = "${var.certname}-star"
   key_vault_id = data.azurerm_key_vault.keyvault_core.id
 }
-
-data "azurerm_key_vault_certificate" "ssl_cert" {
-  name         = "${var.certname}-star"
-  key_vault_id = data.azurerm_key_vault.keyvault_core.id
-}


### PR DESCRIPTION
This resolves a race-condition whereby the App Service hostname binding was being assigned a certificate thumbprint when the App Service certificate may not yet have been imported. 

I've coupled these together by moving the `azurerm_app_service_certificate` resource down into the webapp module and using the output certificate ID from `azurerm_app_service_certificate` in the subsequent `azurerm_app_service_certificate_binding`.

This removes the race-condition and ensures the certificate has been imported. It's also clearer and easier to read hence why I opted for this approach rather than simply adding a `depends_on` between the webapp module and the `azurerm_app_service_certificate`

Additionally, I've fixed several flaky tests