### PR TITLE
Bugfix: Use product price for validation in order journey

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/SolutionSelection/PricesController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/SolutionSelection/PricesController.cs
@@ -190,7 +190,10 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.SolutionSele
             var orderItem = order.OrderItem(catalogueItemId);
             var price = orderItem.OrderItemPrice;
 
-            var model = new ConfirmPriceModel(price, catalogueItem)
+            var catalogueItemPrice =
+                catalogueItem.CataloguePrices.FirstOrDefault(x => x.CataloguePriceId == price.CataloguePriceId);
+
+            var model = new ConfirmPriceModel(catalogueItem, catalogueItemPrice, price)
             {
                 BackLink = Url.Action(route.ActionName, route.ControllerName, route.RouteValues),
                 Source = source,

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SolutionSelection/PricesControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/SolutionSelection/PricesControllerTests.cs
@@ -242,14 +242,18 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Sol
             CallOffId callOffId,
             EntityFramework.Ordering.Models.Order order,
             RoutingResult routingResult,
+            List<CataloguePrice> prices,
             [Frozen] IRoutingService routingService,
             [Frozen] IOrderService mockOrderService,
             [Frozen] IListPriceService listPriceService,
             PricesController controller)
         {
             var orderItem = order.OrderItems.First();
+            var price = prices.First();
 
+            orderItem.OrderItemPrice.CataloguePriceId = price.CataloguePriceId;
             orderItem.CatalogueItem.CatalogueItemType = CatalogueItemType.Solution;
+            orderItem.CatalogueItem.CataloguePrices = prices;
 
             mockOrderService.GetOrderWithOrderItems(callOffId, internalOrgId).Returns(new OrderWrapper(order));
             listPriceService.GetCatalogueItemWithPublishedListPrices(orderItem.CatalogueItemId).Returns(orderItem.CatalogueItem);
@@ -258,7 +262,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Sol
             var result = await controller.EditPrice(internalOrgId, callOffId, orderItem.CatalogueItemId);
 
             var actualResult = result.Should().BeOfType<ViewResult>().Subject;
-            var expected = new ConfirmPriceModel(orderItem.OrderItemPrice, orderItem.CatalogueItem);
+            var expected = new ConfirmPriceModel(orderItem.CatalogueItem, price, orderItem.OrderItemPrice);
 
             actualResult.Model.Should().BeEquivalentTo(expected, m => m.Excluding(o => o.BackLink));
         }
@@ -278,9 +282,11 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Sol
             PricesController controller)
         {
             var orderItem = order.OrderItems.First();
+            var price = availablePrices.First();
 
             orderItem.CatalogueItem = catalogueItem;
             orderItem.CatalogueItemId = catalogueItem.Id;
+            orderItem.OrderItemPrice.CataloguePriceId = price.CataloguePriceId;
 
             catalogueItem.CatalogueItemType = CatalogueItemType.Solution;
             catalogueItem.CataloguePrices = availablePrices;
@@ -292,7 +298,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Sol
             var result = await controller.EditPrice(internalOrgId, callOffId, orderItem.CatalogueItemId);
 
             var actualResult = result.Should().BeOfType<ViewResult>().Subject;
-            var expected = new ConfirmPriceModel(orderItem.OrderItemPrice, orderItem.CatalogueItem);
+            var expected = new ConfirmPriceModel(orderItem.CatalogueItem, price, orderItem.OrderItemPrice);
 
             actualResult.Model.Should().BeEquivalentTo(expected, x => x.Excluding(m => m.BackLink));
         }


### PR DESCRIPTION
There's currently a bug in the ordering journey whereby the order price is used in the validation for the pricing constraints, whereas it should use the original list price to constrain the order price to prevent buyers from exceeding the list price value.

For example, if a user wants to purchase a product with a price of £1.26 and then user has negotiated a better price of £0.01. If the user later tries to change the price from £0.01 to £1.00 then a validation error is thrown as it believes £0.01 is the original price and not £1.26