### PR TITLE
[24298] & [24349] - Update Next Steps Content & Download Button Content

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/Orders/CompletedModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/Orders/CompletedModel.cs
@@ -20,9 +20,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.Orders
             ? string.Format(TitleText, " amendment")
             : string.Format(TitleText, string.Empty);
 
-        public override string Advice => Order.IsAmendment
-            ? string.Format(AdviceText, " amendments")
-            : string.Format(AdviceText, string.Empty);
+        public override string Advice => AdviceText;
 
         public string InternalOrgId { get; set; }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/Orders/CompletedModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/Orders/CompletedModel.cs
@@ -7,7 +7,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.Orders
     {
         public const string TitleText = "Order{0} completed";
 
-        public const string AdviceText = "You’ve successfully completed your Call-off Order Form{0}. Make sure you carry out the listed tasks where relevant to finalise your procurement. We’ll send these tasks to the email address you’ve provided.";
+        public const string AdviceText = "You’ve successfully completed your order Form{0}. Make sure you carry out the listed tasks where relevant to finalise your procurement. We’ll send these tasks to the email address you’ve provided.";
 
         public CompletedModel(string internalOrgId, Order order)
         {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/Orders/CompletedModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/Orders/CompletedModel.cs
@@ -7,7 +7,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.Orders
     {
         public const string TitleText = "Order{0} completed";
 
-        public const string AdviceText = "You’ve successfully completed your order Form{0}. Make sure you carry out the listed tasks where relevant to finalise your procurement. We’ll send these tasks to the email address you’ve provided.";
+        public const string AdviceText = "You’ve successfully completed your order. Make sure you carry out the listed tasks where relevant to finalise your procurement. We’ll send these tasks to the email address you’ve provided.";
 
         public CompletedModel(string internalOrgId, Order order)
         {

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/Completed.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/Completed.cshtml
@@ -24,46 +24,54 @@
 
         <h2 class="nhsuk-u-margin-bottom-5">Next steps</h2>
         <nhs-step-list>
-            <nhs-step-list-item label-text="Get your order signed">
-                Send a copy of your completed order form to the supplier for signature.
+            <nhs-step-list-item label-text="download your order summary using the button at the bottom of this page"/>
+            <nhs-step-list-item label-text="contact the NHS England finance team">
+                email england.dsicfinance@nhs.net to get a call off order form completed
             </nhs-step-list-item>
-            @if (!Model.Order.OrderType.AssociatedServicesOnly)
-            {
-                <nhs-step-list-item label-text="Include the Data Processing Template">
-                    <a href="https://gpitbjss.atlassian.net/wiki/spaces/BG/pages/12207980954/Order+form+template+Data+processing+information" target="_blank">Download the Data Processing Template (opens in a new tab)</a> and send it to the supplier along with your order for them to complete.
-                </nhs-step-list-item>
-            }
-            <nhs-step-list-item label-text="Let us know about your order">
-                Return a signed copy of your order form to gpitf.commercial1@nhs.net and dsicfinance@nhs.net.
+            <nhs-step-list-item label-text="contact the supplier and send them a copy of the following:">
+                <ul>
+                    <li>your completed call off order form for them to sign</li>
+                    @if (!Model.Order.OrderType.AssociatedServicesOnly)
+                    {
+                        <li>
+                            the <a href="https://nhse-dsic.atlassian.net/wiki/spaces/BG/pages/12207980954/Order+form+template+Data+processing+information">data processing template</a> for completion
+                        </li>
+                    }
+                </ul>
             </nhs-step-list-item>
-            <nhs-step-list-item label-text="Centrally funded payments">
-                For the items on your order using your central allocation, the NHS finance team will process the payments for you.
+            <nhs-step-list-item label-text="sign your call off order form">
+                ensure the integrated care board (ICB) signature is completed
             </nhs-step-list-item>
-            <nhs-step-list-item label-text="Locally funded payments">
-                For the items on your order using local funding, you’ll need to contact the supplier to arrange payment.
+            <nhs-step-list-item label-text="send a signed copy of your call off order form to all of the following:">
+                <ul>
+                    <li>gpitf.commercial1@nhs.net</li>
+                    <li>england.dsicfinance@nhs.net</li>
+                    <li>gpit.techinnovation@nhs.net</li>
+                    <li>commercial.procurementhub@nhs.net</li>
+                </ul>
             </nhs-step-list-item>
-            <nhs-step-list-item label-text="Preparing for data migration">
-                If you’ve ordered a migration, read information on how to <a href="https://digital.nhs.uk/services/gp-it-futures-systems/clinical-system-migration-guide" target="_blank">prepare and plan for the transfer of data to your new solution (opens in a new tab)</a>.
+            <nhs-step-list-item label-text="if your order includes a data migration">
+                read our <a href="https://digital.nhs.uk/services/digital-services-for-integrated-care/clinical-system-migration-guide">clinical system migration guide</a>
             </nhs-step-list-item>
-            @if (Model.Order.OrderType.AssociatedServicesOnly)
-            {
-                <nhs-step-list-item label-text="Once associated services are in use">
-                    After associated services, such as training, migration or practice mergers and splits have been provided, inform dsicfinance@nhs.net so the NHS finance team can start paying the supplier.
-                </nhs-step-list-item>
-            }
-            else
-            {
-                <nhs-step-list-item label-text="Once solutions and services are in use">
-                    Enter the activation dates on the order tracker so we can start paying for centrally funded orders.
-                </nhs-step-list-item>
-            }
+            <nhs-step-list-item label-text="once your solution is in use">
+                enter the actual delivery dates on the order tracker via your teams channel for all orders. If you require any help contact england.dsicfinance@nhs.net
+            </nhs-step-list-item>
+            <nhs-step-list-item label-text="if your order includes associated services, e.g training, migration or practice mergers and splits">
+                inform england.dsicfinance@nhs.net of the actual date
+            </nhs-step-list-item>
+            <nhs-step-list-item label-text="for items using centrally funded payments">
+                the NHS England finance team will process the payments for you once you have confirmed successful delivery on the order tracker
+            </nhs-step-list-item>
+            <nhs-step-list-item label-text="for items using locally funded payments">
+                you'll need to contact the supplier to arrange payment
+            </nhs-step-list-item>
         </nhs-step-list>
 
         <nhs-button-group>
             <vc:nhs-anchor-button text="Return to orders dashboard"
                                      type="Primary"
                                      url="@Model.BackLink" />
-            <vc:nhs-anchor-button text="Download order (PDF)"
+            <vc:nhs-anchor-button text="Download Order Summary (PDF)"
                                      type="Secondary"
                                      url="@Url.Action(
                                               nameof(OrderController.Download),

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/Summary.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/Summary.cshtml
@@ -490,7 +490,7 @@
                         }
                     }
 
-                    <vc:nhs-anchor-button text="Download order (PDF)"
+                    <vc:nhs-anchor-button text="Download Order Summary (PDF)"
                                              type="Secondary"
                                              url="@Url.Action(nameof(OrderController.Download), typeof(OrderController).ControllerName(), new { Model.InternalOrgId, Model.CallOffId })"/>
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/wwwroot/scss/_step-container.scss
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/wwwroot/scss/_step-container.scss
@@ -1,16 +1,21 @@
 ﻿.bc-step-container {
-    margin-left: 20px;
-    display: block;
-    position: relative;
+  margin-left: 20px;
+  display: block;
+  position: relative;
+}
+
+ul.bc-step-list__items li .bc-step-list__header {
+  color: #000;
+  position: relative;
+  font-weight: bold;
 }
 
 .bc-step-container ul.bc-step-list__items {
-    margin: 0;
-    padding: 0;
-    display: inline-block;
-}
+  margin: 0;
+  padding: 0;
+  display: inline-block;
 
-.bc-step-container ul.bc-step-list__items li {
+  >li {
     list-style: none;
     margin: auto;
     margin-left: 10px;
@@ -18,26 +23,21 @@
     border-left: 2px dashed #005eb8;
     padding: 0 0 20px 40px;
     position: relative;
-}
 
-.bc-step-container ul.bc-step-list__items li:last-child {
-    border-left: 0;
-}
+    &:last-child {
+      border-left: 0;
+    }
 
-.bc-step-container ul.bc-step-list__items li::before {
-    position: absolute;
-    left: -21px;
-    top: -5px;
-    content: " ";
-    border: 10px solid #005eb8;
-    border-radius: 500%;
-    background: #fff;
-    height: 40px;
-    width: 40px;
-}
-
-ul.bc-step-list__items li .bc-step-list__header {
-    color: #000;
-    position: relative;
-    font-weight: bold;
+    &::before {
+      position: absolute;
+      left: -21px;
+      top: -5px;
+      content: " ";
+      border: 10px solid #005eb8;
+      border-radius: 500%;
+      background: #fff;
+      height: 40px;
+      width: 40px;
+    }
+  }
 }


### PR DESCRIPTION
## Changes
- This PR updates the content of the download button at the bottom of the following pages:
1. Next Steps page
2. Review and complete order page
3. Order confirmed page

- This PR updates the content of the Next steps page

## Validation

### Next Steps Page
#### Associated services
<img width="366" height="842" alt="image" src="https://github.com/user-attachments/assets/1bb99ae9-a5f1-43a5-b4fe-facee8f56f12" />

#### Completed order
<img width="357" height="862" alt="image" src="https://github.com/user-attachments/assets/727316b7-9e5c-4bf6-9c30-9f3a48d1a5a6" />

### Review and complete order page
<img width="521" height="166" alt="image" src="https://github.com/user-attachments/assets/a3872ddc-b720-44b8-a822-4e3939c3d196" />

### Order confirmed page
<img width="412" height="242" alt="image" src="https://github.com/user-attachments/assets/70270fd9-d4aa-40e4-8173-a64a5cb40020" />



