### PR TITLE
Add bespoke milestones indicator to CSV

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Csv/CsvService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Csv/CsvService.cs
@@ -186,6 +186,9 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Csv
                 .Include(x => x.OrderItemSublocationRecipients)
                 .ThenInclude(x => x.OrderItem)
                 .ThenInclude(x => x.OrderItemFunding)
+                .Include(x => x.OrderItemSublocationRecipients)
+                .ThenInclude(x => x.OrderItem)
+                .ThenInclude(x => x.Order)
                 .AsNoTracking()
                 .Where(or => or.OrderId == orderId)
                 .SelectMany(
@@ -198,11 +201,11 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Csv
                         OdsCode = or.Order.OrderingParty.ExternalIdentifier,
                         OrganisationName = or.Order.OrderingParty.Name,
                         SubIcbCode = !(oir.OrderItem.OrderItemPrice as IPrice).IsPerServiceRecipient()
-                                ? string.Empty
-                                : or.ParentSublocation.SublocationOdsCode,
+                            ? string.Empty
+                            : or.ParentSublocation.SublocationOdsCode,
                         SubIcbName = !(oir.OrderItem.OrderItemPrice as IPrice).IsPerServiceRecipient()
-                                ? string.Empty
-                                : or.ParentSublocation.SublocationOrganisation.Name,
+                            ? string.Empty
+                            : or.ParentSublocation.SublocationOrganisation.Name,
                         CommencementDate = or.Order.CommencementDate,
                         ServiceRecipientId =
                             !(oir.OrderItem.OrderItemPrice as IPrice).IsPerServiceRecipient()
@@ -229,7 +232,8 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Csv
                         UnitTime = TimeUnitDescription(billingPeriods[oir.OrderItem.CatalogueItemId]),
                         EstimationPeriod = TimeUnitDescription(oir.OrderItem.EstimationPeriod),
                         Price = (oir.OrderItem.OrderItemPrice.CataloguePriceType == CataloguePriceType.Tiered
-                            && oir.OrderItem.OrderItemPrice.CataloguePriceCalculationType == CataloguePriceCalculationType.Cumulative)
+                            && oir.OrderItem.OrderItemPrice.CataloguePriceCalculationType
+                            == CataloguePriceCalculationType.Cumulative)
                             ? null
                             : prices[oir.OrderItem.CatalogueItemId],
                         OrderType = (int)oir.OrderItem.OrderItemPrice.ProvisioningType,
@@ -255,6 +259,10 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Csv
                             == CataloguePriceCalculationType.Cumulative
                                 ? GetTieredArray(oir.OrderItem.OrderItemPrice.OrderItemPriceTiers)
                                 : string.Empty,
+                        HasBespokeMilestones = or.Order.Contract.ContractBilling.ContractBillingItems.Any(x =>
+                                x.CatalogueItemId == oir.OrderItem.CatalogueItemId)
+                            || (oir.OrderItem.CatalogueItem.CatalogueItemType != CatalogueItemType.AssociatedService
+                                && or.Order.Contract.ImplementationPlan.Milestones.Count > 0),
                     })
                 .ToListAsync();
 

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Csv/FullOrderCsvModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Csv/FullOrderCsvModel.cs
@@ -75,5 +75,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Csv
         public string SubIcbCode { get; set; }
 
         public string SubIcbName { get; set; }
+
+        public bool HasBespokeMilestones { get; set; }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Csv/FullOrderCsvModelMap.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Csv/FullOrderCsvModelMap.cs
@@ -1,4 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using CsvHelper;
+using CsvHelper.Configuration;
+using CsvHelper.TypeConversion;
+using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
 
 namespace NHSD.GPIT.BuyingCatalogue.Services.Csv
 {
@@ -36,6 +41,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Csv
             new(nameof(FullOrderCsvModel.TieredArray), "Tiered Array"),
             new(nameof(FullOrderCsvModel.InitialTerm), "Initial Term"),
             new(nameof(FullOrderCsvModel.MaximumTerm), "Contract Length (Months)"),
+            new(nameof(FullOrderCsvModel.HasBespokeMilestones), "Bespoke Milestones"),
         };
 
         public FullOrderCsvModelMap()
@@ -71,6 +77,10 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Csv
             Map(o => o.TieredArray).Index(27).Name(GetName(nameof(FullOrderCsvModel.TieredArray)));
             Map(o => o.InitialTerm).Index(28).Name(GetName(nameof(FullOrderCsvModel.InitialTerm)));
             Map(o => o.MaximumTerm).Index(29).Name(GetName(nameof(FullOrderCsvModel.MaximumTerm)));
+            Map(o => o.HasBespokeMilestones)
+                .Index(30)
+                .Name(GetName(nameof(FullOrderCsvModel.HasBespokeMilestones)))
+                .TypeConverter<YesNoTypeConverter>();
         }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Csv/YesNoTypeConverter.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Csv/YesNoTypeConverter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using CsvHelper;
+using CsvHelper.Configuration;
+using CsvHelper.TypeConversion;
+using NHSD.GPIT.BuyingCatalogue.Framework.Extensions;
+
+namespace NHSD.GPIT.BuyingCatalogue.Services.Csv;
+
+public sealed class YesNoTypeConverter : TypeConverter
+{
+    public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
+        => string.Equals(text, "Yes", StringComparison.OrdinalIgnoreCase);
+
+    public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+    {
+        return value is not bool boolValue
+            ? base.ConvertToString(value, row, memberMapData)
+            : boolValue.ToYesNo();
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Csv/CsvServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Csv/CsvServiceTests.cs
@@ -56,6 +56,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Csv
             "Tiered Array",
             "Initial Term",
             "Contract Length (Months)",
+            "Bespoke Milestones",
         ];
 
         private static IEnumerable<string> MergerFields =>
@@ -249,7 +250,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Csv
             OrderSublocationRecipient recipient = BuildOrderRecipient(fixture, [orderItem]);
             await SaveOrderWithRecipients(
                 order,
-                orderItem,
+                [orderItem],
                 [recipient],
                 dbContext);
 
@@ -265,6 +266,125 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Csv
             record.ServiceRecipientId.Should().Be(recipient.RecipientOdsCode);
             record.ServiceRecipientName.Should().Be(recipient.RecipientOdsOrganisation.Name);
             record.ServiceRecipientItemId.Should().Be($"{order.CallOffId}-{recipient.RecipientOdsCode}-{orderItem.CatalogueItemId}");
+        }
+
+        [Theory]
+        [MockInMemoryDbInlineAutoData(ProvisioningType.OnDemand)]
+        [MockInMemoryDbInlineAutoData(ProvisioningType.Declarative)]
+        [MockInMemoryDbInlineAutoData(ProvisioningType.Patient)]
+        public static async Task CreateFullOrderCsv_WithImplementationPlan_SetsBespokeMilestones(
+            ProvisioningType provisioningType,
+            Order order,
+            CsvService service,
+            Solution solution,
+            AssociatedService associatedService,
+            ImplementationPlan implementationPlan,
+            List<ImplementationPlanMilestone> implementationPlanMilestones,
+            [Frozen] BuyingCatalogueDbContext dbContext,
+            IFixture fixture)
+        {
+            implementationPlan.Milestones = implementationPlanMilestones;
+
+            order.OrderType = OrderTypeEnum.Solution;
+            order.Contract = new() { ImplementationPlan = implementationPlan, };
+
+            var solutionOrderItem = BuildOrderItem(
+                fixture,
+                solution.CatalogueItem,
+                OrderItemFundingType.LocalFunding,
+                provisioningType,
+                CataloguePriceQuantityCalculationType.PerServiceRecipient);
+
+            var associatedServiceOrderItem = BuildOrderItem(
+                fixture,
+                associatedService.CatalogueItem,
+                OrderItemFundingType.LocalFunding,
+                provisioningType,
+                CataloguePriceQuantityCalculationType.PerServiceRecipient);
+
+            OrderSublocationRecipient recipient = BuildOrderRecipient(
+                fixture,
+                [solutionOrderItem, associatedServiceOrderItem]);
+            await SaveOrderWithRecipients(
+                order,
+                [solutionOrderItem, associatedServiceOrderItem],
+                [recipient],
+                dbContext);
+
+            await using var fullOrderStream = new MemoryStream();
+            await service.CreateFullOrderCsvAsync(order.Id, order.OrderType, fullOrderStream);
+            fullOrderStream.Position = 0;
+
+            List<FullOrderCsvModel> records = GetRows<FullOrderCsvModel>(fullOrderStream, new FullOrderCsvModelMap());
+
+            records.Count.Should().Be(2);
+
+            var solutionRecord = records.First(x => x.ProductId == solutionOrderItem.CatalogueItemId.ToString());
+            var associatedServiceRecord =
+                records.First(x => x.ProductId == associatedServiceOrderItem.CatalogueItemId.ToString());
+
+            solutionRecord.HasBespokeMilestones.Should().BeTrue();
+            associatedServiceRecord.HasBespokeMilestones.Should().BeFalse();
+        }
+
+        [Theory]
+        [MockInMemoryDbInlineAutoData(ProvisioningType.OnDemand)]
+        [MockInMemoryDbInlineAutoData(ProvisioningType.Declarative)]
+        [MockInMemoryDbInlineAutoData(ProvisioningType.Patient)]
+        public static async Task CreateFullOrderCsv_WithAssociatedServiceMilestones_SetsBespokeMilestones(
+            ProvisioningType provisioningType,
+            Order order,
+            CsvService service,
+            Solution solution,
+            AssociatedService associatedService,
+            ContractBilling contractBilling,
+            List<ContractBillingItem> contractBillingItems,
+            [Frozen] BuyingCatalogueDbContext dbContext,
+            IFixture fixture)
+        {
+            contractBillingItems.ForEach(x => x.CatalogueItemId = associatedService.CatalogueItemId);
+            contractBilling.ContractBillingItems = contractBillingItems;
+
+            order.OrderType = OrderTypeEnum.Solution;
+            order.Contract = new() { ContractBilling = contractBilling, };
+
+            var solutionOrderItem = BuildOrderItem(
+                fixture,
+                solution.CatalogueItem,
+                OrderItemFundingType.LocalFunding,
+                provisioningType,
+                CataloguePriceQuantityCalculationType.PerServiceRecipient);
+
+            var associatedServiceOrderItem = BuildOrderItem(
+                fixture,
+                associatedService.CatalogueItem,
+                OrderItemFundingType.LocalFunding,
+                provisioningType,
+                CataloguePriceQuantityCalculationType.PerServiceRecipient);
+
+            OrderSublocationRecipient recipient = BuildOrderRecipient(
+                fixture,
+                [solutionOrderItem, associatedServiceOrderItem]);
+            await SaveOrderWithRecipients(
+                order,
+                [solutionOrderItem, associatedServiceOrderItem],
+                [recipient],
+                dbContext);
+
+            await using var fullOrderStream = new MemoryStream();
+            await service.CreateFullOrderCsvAsync(order.Id, order.OrderType, fullOrderStream);
+            fullOrderStream.Position = 0;
+
+            List<FullOrderCsvModel> records = GetRows<FullOrderCsvModel>(fullOrderStream, new FullOrderCsvModelMap());
+
+            records.Count.Should().Be(2);
+
+            var solutionRecord = records.First(x => x.ProductId == solutionOrderItem.CatalogueItemId.ToString());
+            var associatedServiceRecord =
+                records.First(x => x.ProductId == associatedServiceOrderItem.CatalogueItemId.ToString());
+
+            solutionRecord.HasBespokeMilestones.Should().BeFalse();
+            associatedServiceRecord.HasBespokeMilestones.Should().BeTrue();
         }
 
         [Theory]
@@ -293,7 +413,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Csv
             OrderSublocationRecipient recipient = BuildOrderRecipient(fixture, [orderItem]);
             await SaveOrderWithRecipients(
                 order,
-                orderItem,
+                [orderItem],
                 [recipient],
                 dbContext);
 
@@ -340,7 +460,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Csv
             OrderSublocationRecipient recipient = BuildOrderRecipient(fixture, [orderItem]);
             await SaveOrderWithRecipients(
                 order,
-                orderItem,
+                [orderItem],
                 [recipient],
                 dbContext);
 
@@ -388,7 +508,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Csv
             OrderSublocationRecipient recipient2 = BuildOrderRecipient(fixture, [orderItem]);
             await SaveOrderWithRecipients(
                 order,
-                orderItem,
+                [orderItem],
                 [recipient1, recipient2],
                 dbContext);
 
@@ -440,7 +560,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Csv
             OrderSublocationRecipient recipient2 = BuildOrderRecipient(fixture, [orderItem]);
             await SaveOrderWithRecipients(
                 order,
-                orderItem,
+                [orderItem],
                 [recipient1, recipient2],
                 dbContext);
 
@@ -677,11 +797,11 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Csv
 
         private static async Task SaveOrderWithRecipients(
             Order order,
-            OrderItem orderItem,
+            ICollection<OrderItem> orderItems,
             ICollection<OrderSublocationRecipient> recipients,
             BuyingCatalogueDbContext dbContext)
         {
-            order.OrderItems = new HashSet<OrderItem> { orderItem };
+            order.OrderItems = orderItems.ToHashSet();
 
             order.OrderSublocations = order.OrderSublocations.Take(1).ToList();
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Csv/YesNoTypeConverterTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Csv/YesNoTypeConverterTests.cs
@@ -1,0 +1,38 @@
+﻿using CsvHelper;
+using CsvHelper.Configuration;
+using FluentAssertions;
+using NHSD.GPIT.BuyingCatalogue.Services.Csv;
+using NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.Attributes;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Csv;
+
+public static class YesNoTypeConverterTests
+{
+    [Theory]
+    [MockInlineAutoData("Yes", true)]
+    [MockInlineAutoData("YES", true)]
+    [MockInlineAutoData("yes", true)]
+    [MockInlineAutoData("YeS", true)]
+    [MockInlineAutoData("No", false)]
+    [MockInlineAutoData("no", false)]
+    [MockInlineAutoData("", false)]
+    public static void ConvertFromString_ReturnsExpected(
+        string text,
+        bool expected,
+        IReaderRow readerRow,
+        MemberMapData memberMap,
+        YesNoTypeConverter converter)
+        => converter.ConvertFromString(text, readerRow, memberMap).Should().Be(expected);
+
+    [Theory]
+    [MockInlineAutoData(true, "Yes")]
+    [MockInlineAutoData(false, "No")]
+    public static void ConvertToString_ReturnsExpected(
+        bool value,
+        string expected,
+        IWriterRow writerRow,
+        MemberMapData memberMap,
+        YesNoTypeConverter converter)
+        => converter.ConvertToString(value, writerRow, memberMap).Should().Be(expected);
+}


### PR DESCRIPTION
# Changes

This change adds a new column to the CSV for an order that is used to represent whether any bespoke milestones have been added for a solution or associated service.

The column will display a value of "Yes" when the following conditions are met
* Implementation plan specified - solution and additional services
* Bespoke billing specified - associated services

Adding bespoke billing requirements (for an associated service) will not influence the outout for a solution or additional service. The same applies to associated services with regards to the implementation plan.

# Validation

## No implementation plan or bespoke billing

<img width="582" height="213" alt="image" src="https://github.com/user-attachments/assets/e97314a7-44d0-44d6-8a68-6b7cbc3b6b47" />

## Bespoke billing for an associated service, no implementation plan

<img width="582" height="213" alt="image" src="https://github.com/user-attachments/assets/4f0f4735-b2e5-4236-9edf-f0750618a446" />

## Implementation plan. No bespoke billing

<img width="582" height="213" alt="image" src="https://github.com/user-attachments/assets/d19a861c-0489-4132-a0ef-e95ad4d1c575" />
