### PR TITLE
Remove billing items quantity

### DIFF
--- a/database/NHSD.GPITBuyingCatalogue.Database/Ordering/Tables/ContractBillingItems.sql
+++ b/database/NHSD.GPITBuyingCatalogue.Database/Ordering/Tables/ContractBillingItems.sql
@@ -4,7 +4,7 @@
     ContractBillingId int NOT NULL, 
     OrderId int NOT NULL,
     CatalogueItemId nvarchar(14) NOT NULL,
-    Quantity int NOT NULL,
+    Quantity int NULL,
     CONSTRAINT PK_ContractBillingItems PRIMARY KEY (Id),
     CONSTRAINT FK_ContractBillingItems_ContractBilling FOREIGN KEY (ContractBillingId) REFERENCES ordering.ContractBilling(Id) ON DELETE CASCADE,
     CONSTRAINT FK_ContractBillingItems_OrderItem FOREIGN KEY (OrderId, CatalogueItemId) REFERENCES ordering.OrderItems(OrderId, CatalogueItemId),

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Configuration/ContractBillingItemEntityTypeConfiguration.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Configuration/ContractBillingItemEntityTypeConfiguration.cs
@@ -15,7 +15,6 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Configuration
             builder.Property(x => x.ContractBillingId).IsRequired();
             builder.Property(x => x.OrderId).IsRequired();
             builder.Property(x => x.CatalogueItemId).IsRequired();
-            builder.Property(x => x.Quantity).IsRequired();
 
             builder.HasOne(x => x.ContractBilling)
                 .WithMany(x => x.ContractBillingItems)

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/ContractBillingItem.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/ContractBillingItem.cs
@@ -10,8 +10,6 @@
 
         public CatalogueItemId CatalogueItemId { get; set; }
 
-        public int Quantity { get; set; }
-
         public ContractBilling ContractBilling { get; set; }
 
         public OrderItem OrderItem { get; set; }

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Contracts/IContractBillingService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/Contracts/IContractBillingService.cs
@@ -13,8 +13,7 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Contracts
             int contractId,
             CatalogueItemId catalogueItemId,
             string name,
-            string paymentTrigger,
-            int quantity);
+            string paymentTrigger);
 
         Task<ContractBillingItem> GetContractBillingItem(int orderId, int itemId);
 
@@ -23,8 +22,7 @@ namespace NHSD.GPIT.BuyingCatalogue.ServiceContracts.Contracts
             int itemId,
             CatalogueItemId catalogueItemId,
             string name,
-            string paymentTrigger,
-            int quantity);
+            string paymentTrigger);
 
         Task DeleteContractBillingItem(int orderId, int itemId);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Contracts/ContractBillingService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Contracts/ContractBillingService.cs
@@ -30,7 +30,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Contracts
             return contract;
         }
 
-        public async Task AddBespokeContractBillingItem(int orderId, int contractId, CatalogueItemId catalogueItemId, string name, string paymentTrigger, int quantity)
+        public async Task AddBespokeContractBillingItem(int orderId, int contractId, CatalogueItemId catalogueItemId, string name, string paymentTrigger)
         {
             if (string.IsNullOrEmpty(name))
                 throw new ArgumentNullException(nameof(name));
@@ -51,7 +51,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Contracts
             {
                 OrderItem = associatedService,
                 Milestone = new ImplementationPlanMilestone() { Title = name, PaymentTrigger = paymentTrigger, },
-                Quantity = quantity,
             });
             await dbContext.SaveChangesAsync();
         }
@@ -65,7 +64,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Contracts
                 .FirstOrDefaultAsync(x => x.Id == itemId && x.OrderId == orderId);
         }
 
-        public async Task EditContractBillingItem(int orderId, int itemId, CatalogueItemId catalogueItemId, string name, string paymentTrigger, int quantity)
+        public async Task EditContractBillingItem(int orderId, int itemId, CatalogueItemId catalogueItemId, string name, string paymentTrigger)
         {
             if (string.IsNullOrEmpty(name))
                 throw new ArgumentNullException(nameof(name));
@@ -85,7 +84,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Contracts
             item.OrderItem = associatedService;
             item.Milestone.Title = name;
             item.Milestone.PaymentTrigger = paymentTrigger;
-            item.Quantity = quantity;
 
             await dbContext.SaveChangesAsync();
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/Contracts/ContractBillingController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Controllers/Contracts/ContractBillingController.cs
@@ -94,7 +94,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.Contracts
                 return NotFound();
 
             var contract = await contractsService.GetContract(order.Id);
-            await contractBillingService.AddBespokeContractBillingItem(order.Id, contract.Id, model.SelectedOrderItemId, model.Name, model.PaymentTrigger, model.Quantity.GetValueOrDefault());
+            await contractBillingService.AddBespokeContractBillingItem(order.Id, contract.Id, model.SelectedOrderItemId, model.Name, model.PaymentTrigger);
 
             return RedirectToAction(nameof(Index), new { internalOrgId, callOffId });
         }
@@ -131,7 +131,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.Contracts
             if (order?.GetAssociatedService(model.SelectedOrderItemId) is null)
                 return NotFound();
 
-            await contractBillingService.EditContractBillingItem(order.Id, model.ItemId, model.SelectedOrderItemId, model.Name, model.PaymentTrigger, model.Quantity.GetValueOrDefault());
+            await contractBillingService.EditContractBillingItem(order.Id, model.ItemId, model.SelectedOrderItemId, model.Name, model.PaymentTrigger);
 
             return RedirectToAction(nameof(Index), new { internalOrgId, callOffId });
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/Contracts/ContractBilling/ContractBillingItemModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/Contracts/ContractBilling/ContractBillingItemModel.cs
@@ -32,7 +32,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.Contracts.Contrac
             SelectedOrderItemId = item.OrderItem.CatalogueItemId;
             Name = item.Milestone?.Title;
             PaymentTrigger = item.Milestone?.PaymentTrigger;
-            Quantity = item.Quantity;
         }
 
         public bool IsEdit => ItemId != 0;
@@ -50,10 +49,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.Contracts.Contrac
 
         [StringLength(500)]
         public string PaymentTrigger { get; set; }
-
-        [Description("Quantity")]
-        [ModelBinder(typeof(NumberModelBinder))]
-        public int? Quantity { get; set; }
 
         public override string Advice => IsEdit ? "Edit this associated service milestone." : "Add an associated service milestone.";
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Validators/Contracts/ContractBilling/ContractBillingItemModelValidator.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Validators/Contracts/ContractBilling/ContractBillingItemModelValidator.cs
@@ -8,7 +8,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Validators.Contracts.Con
         public const string NameRequiredErrorMessage = "Enter a milestone name";
         public const string PaymentTriggerRequiredErrorMessage = "Enter a milestone payment trigger";
         public const string AssociatedServiceRequiredErrorMessage = "Enter an associated service name";
-        public const string QuantityRequiredErrorMessage = "Enter the number of units to be billed";
 
         public ContractBillingItemModelValidator()
         {
@@ -23,10 +22,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Validators.Contracts.Con
             RuleFor(x => x.PaymentTrigger)
                 .NotEmpty()
                 .WithMessage(PaymentTriggerRequiredErrorMessage);
-
-            RuleFor(x => x.Quantity)
-                .NotEmpty()
-                .WithMessage(QuantityRequiredErrorMessage);
         }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/ContractBilling/ContractBillingItem.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/ContractBilling/ContractBillingItem.cshtml
@@ -36,10 +36,6 @@
                 <nhs-textarea asp-for="PaymentTrigger"
                               label-text="Milestone payment trigger"
                               label-hint="Provide a description of how this milestone will trigger payments as part of this order."/>
-                
-                <nhs-input asp-for="Quantity" input-width="Five"
-                              label-text="Number of units to be billed on milestone achievement"
-                              label-hint="Enter the number of associated service units that will be billable once this milestone is achieved." />
 
                 <nhs-button-group>
                     <nhs-submit-button text="Save and continue"/>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Shared/ContractBillingItemTable.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Shared/ContractBillingItemTable.cshtml
@@ -1,42 +1,37 @@
 ﻿@using NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Controllers.Contracts
 @model NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.Shared.ContractBillingItemTableModel
 
-<div class="nhsuk-u-margin-bottom-9">
-    <nhs-table label-text="@Model.Title">
-        <nhs-table-column>Associated service name</nhs-table-column>
-        <nhs-table-column>Milestone name</nhs-table-column>
-        <nhs-table-column>Payment trigger</nhs-table-column>
-        <nhs-table-column>Billed units</nhs-table-column>
-        @if (Model.IsAction)
-        {
-            <nhs-table-column><span class="nhsuk-u-visually-hidden">Change action</span></nhs-table-column>
-            <nhs-table-column><span class="nhsuk-u-visually-hidden">Delete action</span></nhs-table-column>
-        }
-        @foreach (var item in Model.ContractBillingItems)
-        {
-            <nhs-table-row-container>
-                <nhs-table-cell>@item.OrderItem.CatalogueItem.Name</nhs-table-cell>
-                <nhs-table-cell style="word-break:break-word">@item.Milestone.Title</nhs-table-cell>
-                <nhs-table-cell style="word-break:break-word">@item.Milestone.PaymentTrigger</nhs-table-cell>
-                <nhs-table-cell>@item.Quantity</nhs-table-cell>
-                @if (Model.IsAction)
-                {
-                    <nhs-table-cell>
-                        <span data-test-id="milestone-edit-link">
-                            <a asp-action="@nameof(ContractBillingController.EditMilestone)"
-                               asp-controller="@typeof(ContractBillingController).ControllerName()"
-                               asp-route-internalOrgId="@Model.InternalOrgId"
-                               asp-route-callOffId="@Model.CallOffId"
-                               asp-route-itemId="@item.Id">Change</a>
-                        </span>
-                    </nhs-table-cell>
-                    <nhs-table-cell>
-                        <vc:nhs-delete-button url="@Url.Action(nameof(ContractBillingController.DeleteContractBillingItem), typeof(ContractBillingController).ControllerName(), new { internalOrgId = Model.InternalOrgId, callOffId = Model.CallOffId, itemId = item.Id })"
-                                              text="Delete" />
-                    </nhs-table-cell>
-                }
-            </nhs-table-row-container>
-        }
-    </nhs-table>
-</div>
-
+<nhs-table label-text="@Model.Title">
+    <nhs-table-column>Associated service name</nhs-table-column>
+    <nhs-table-column>Milestone name</nhs-table-column>
+    <nhs-table-column>Payment trigger</nhs-table-column>
+    @if (Model.IsAction)
+    {
+        <nhs-table-column><span class="nhsuk-u-visually-hidden">Change action</span></nhs-table-column>
+        <nhs-table-column><span class="nhsuk-u-visually-hidden">Delete action</span></nhs-table-column>
+    }
+    @foreach (var item in Model.ContractBillingItems)
+    {
+        <nhs-table-row-container>
+            <nhs-table-cell>@item.OrderItem.CatalogueItem.Name</nhs-table-cell>
+            <nhs-table-cell style="word-break:break-word">@item.Milestone.Title</nhs-table-cell>
+            <nhs-table-cell style="word-break:break-word">@item.Milestone.PaymentTrigger</nhs-table-cell>
+            @if (Model.IsAction)
+            {
+                <nhs-table-cell>
+                    <span data-test-id="milestone-edit-link">
+                        <a asp-action="@nameof(ContractBillingController.EditMilestone)"
+                           asp-controller="@typeof(ContractBillingController).ControllerName()"
+                           asp-route-internalOrgId="@Model.InternalOrgId"
+                           asp-route-callOffId="@Model.CallOffId"
+                           asp-route-itemId="@item.Id">Change</a>
+                    </span>
+                </nhs-table-cell>
+                <nhs-table-cell>
+                    <vc:nhs-delete-button url="@Url.Action(nameof(ContractBillingController.DeleteContractBillingItem), typeof(ContractBillingController).ControllerName(), new { internalOrgId = Model.InternalOrgId, callOffId = Model.CallOffId, itemId = item.Id })"
+                                          text="Delete" />
+                </nhs-table-cell>
+            }
+        </nhs-table-row-container>
+    }
+</nhs-table>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
@@ -519,7 +519,6 @@
                                                 <th>Associated service name</th>
                                                 <th>Milestone name</th>
                                                 <th>Payment trigger</th>
-                                                <th>Number of units to be billed</th>
                                             </tr>
                                         </thead>
                                         <tbody>
@@ -529,7 +528,6 @@
                                                     <td>@item.OrderItem.CatalogueItem.Name</td>
                                                     <td>@item.Milestone.Title</td>
                                                     <td>@item.Milestone.PaymentTrigger</td>
-                                                    <td>@item.Quantity</td>
                                                 </tr>
                                             }
                                         </tbody>

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Contracts/ContractBillingServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Contracts/ContractBillingServiceTests.cs
@@ -94,7 +94,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Contracts
             int contractId,
             CatalogueItemId catalogueItemId,
             string paymentTrigger,
-            int quantity,
             ContractBillingService service)
         {
             FluentActions
@@ -119,7 +118,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Contracts
             int contractId,
             CatalogueItemId catalogueItemId,
             string name,
-            int quantity,
             ContractBillingService service)
         {
             FluentActions
@@ -141,7 +139,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Contracts
             CatalogueItemId catalogueItemId,
             string paymentTrigger,
             string name,
-            int quantity,
             Contract contract,
             Order order,
             ContractBillingService service)
@@ -185,7 +182,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Contracts
             CatalogueItemId catalogueItemId,
             string paymentTrigger,
             string name,
-            int quantity,
             Order order,
             Contract contract,
             ContractBillingService service)
@@ -271,7 +267,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Contracts
            int itemId,
            CatalogueItemId catalogueItemId,
            string paymentTrigger,
-           int quantity,
            ContractBillingService service)
         {
             FluentActions
@@ -296,7 +291,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Contracts
             int itemId,
             CatalogueItemId catalogueItemId,
             string name,
-            int quantity,
             ContractBillingService service)
         {
             FluentActions
@@ -318,7 +312,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Contracts
             string paymentTrigger,
             CatalogueItemId catalogueItemId,
             string name,
-            int quantity,
             OrderItem orderItem,
             ContractBillingItem item,
             Order order,

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Contracts/ContractBillingServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Contracts/ContractBillingServiceTests.cs
@@ -104,8 +104,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Contracts
                         contractId,
                         catalogueItemId,
                         name,
-                        paymentTrigger,
-                        quantity))
+                        paymentTrigger))
                 .Should()
                 .ThrowAsync<ArgumentNullException>(nameof(name));
         }
@@ -130,8 +129,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Contracts
                         contractId,
                         catalogueItemId,
                         name,
-                        paymentTrigger,
-                        quantity))
+                        paymentTrigger))
                 .Should()
                 .ThrowAsync<ArgumentNullException>(nameof(paymentTrigger));
         }
@@ -167,8 +165,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Contracts
                 contract.Id,
                 catalogueItemId,
                 name,
-                paymentTrigger,
-                quantity);
+                paymentTrigger);
 
             var actual = await context.Contracts.FirstAsync(f => f.Id == contract.Id);
             actual.ContractBilling.Should().NotBeNull();
@@ -179,7 +176,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Contracts
             newMilestone.CatalogueItemId.Should().Be(catalogueItemId);
             newMilestone.Milestone.Title.Should().Be(name);
             newMilestone.Milestone.PaymentTrigger.Should().Be(paymentTrigger);
-            newMilestone.Quantity.Should().Be(quantity);
         }
 
         [Theory]
@@ -215,8 +211,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Contracts
                 contract.Id,
                 catalogueItemId,
                 name,
-                paymentTrigger,
-                quantity);
+                paymentTrigger);
 
             var actual = await context.Contracts.FirstAsync(f => f.Id == contract.Id);
             actual.ContractBilling.Should().NotBeNull();
@@ -264,7 +259,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Contracts
             output.CatalogueItemId.Should().Be(contractBillingItem.CatalogueItemId);
             output.Milestone.Title.Should().Be(contractBillingItem.Milestone.Title);
             output.Milestone.PaymentTrigger.Should().Be(contractBillingItem.Milestone.PaymentTrigger);
-            output.Quantity.Should().Be(contractBillingItem.Quantity);
         }
 
         [Theory]
@@ -287,8 +281,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Contracts
                         itemId,
                         catalogueItemId,
                         name,
-                        paymentTrigger,
-                        quantity))
+                        paymentTrigger))
                 .Should()
                 .ThrowAsync<ArgumentNullException>(nameof(name));
         }
@@ -313,8 +306,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Contracts
                         itemId,
                         catalogueItemId,
                         name,
-                        paymentTrigger,
-                        quantity))
+                        paymentTrigger))
                 .Should()
                 .ThrowAsync<ArgumentNullException>(nameof(paymentTrigger));
         }
@@ -355,21 +347,18 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Contracts
             before.CatalogueItemId.Should().Be(item.CatalogueItemId);
             before.Milestone.Title.Should().Be(item.Milestone.Title);
             before.Milestone.PaymentTrigger.Should().Be(item.Milestone.PaymentTrigger);
-            before.Quantity.Should().Be(item.Quantity);
 
             await service.EditContractBillingItem(
                 order.Id,
                 item.Id,
                 catalogueItemId,
                 name,
-                paymentTrigger,
-                quantity);
+                paymentTrigger);
 
             var after = await context.ContractBillingItems.Include(x => x.Milestone).FirstAsync(f => f.Id == item.Id);
             after.CatalogueItemId.Should().Be(catalogueItemId);
             after.Milestone.Title.Should().Be(name);
             after.Milestone.PaymentTrigger.Should().Be(paymentTrigger);
-            after.Quantity.Should().Be(quantity);
         }
 
         [Theory]

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/Contracts/ContractBillingControllerTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Controllers/Contracts/ContractBillingControllerTests.cs
@@ -201,7 +201,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Con
 
             mockContractsService.GetContract(order.Id).Returns(contract);
 
-            mockContractBillingService.AddBespokeContractBillingItem(order.Id, contract.Id, model.SelectedOrderItemId, model.Name, model.PaymentTrigger, model.Quantity.GetValueOrDefault()).Returns(Task.CompletedTask);
+            mockContractBillingService.AddBespokeContractBillingItem(order.Id, contract.Id, model.SelectedOrderItemId, model.Name, model.PaymentTrigger).Returns(Task.CompletedTask);
 
             var result = await controller.AddMilestone(internalOrgId, order.CallOffId, model);
 
@@ -297,7 +297,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Controllers.Con
 
             mockOrderService.GetOrderThin(order.CallOffId, internalOrgId).Returns(new OrderWrapper(order));
 
-            mockContractBillingService.EditContractBillingItem(order.Id, model.ItemId, model.SelectedOrderItemId, model.Name, model.PaymentTrigger, model.Quantity.GetValueOrDefault()).Returns(Task.CompletedTask);
+            mockContractBillingService.EditContractBillingItem(order.Id, model.ItemId, model.SelectedOrderItemId, model.Name, model.PaymentTrigger).Returns(Task.CompletedTask);
 
             var result = await controller.EditMilestone(internalOrgId, order.CallOffId, model);
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/Contracts/ContractBilling/ContractBillingItemModelTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Models/Contracts/ContractBilling/ContractBillingItemModelTests.cs
@@ -47,7 +47,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Models.Contract
             model.Name.Should().Be(item.Milestone?.Title);
             model.PaymentTrigger.Should().Be(item.Milestone?.PaymentTrigger);
             model.SelectedOrderItemId.Should().Be(item.OrderItem.CatalogueItemId);
-            model.Quantity.Should().Be(item.Quantity);
             model.IsEdit.Should().BeTrue();
             model.Advice.Should().Be("Edit this associated service milestone.");
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/Contracts/ContractBilling/ContractBillingItemModelValidatorTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/Areas/Order/Validators/Contracts/ContractBilling/ContractBillingItemModelValidatorTests.cs
@@ -38,20 +38,6 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.Areas.Order.Validators.Cont
 
         [Theory]
         [MockAutoData]
-        public static void Validate_Milestone_QuantityNull_SetsModelError(
-            ContractBillingItemModel model,
-            ContractBillingItemModelValidator validator)
-        {
-            model.Quantity = null;
-
-            var result = validator.TestValidate(model);
-
-            result.ShouldHaveValidationErrorFor(m => m.Quantity)
-                .WithErrorMessage(ContractBillingItemModelValidator.QuantityRequiredErrorMessage);
-        }
-
-        [Theory]
-        [MockAutoData]
         public static void Validate_Milestone_SelectedOrderItemIdNull_SetsModelError(
             ContractBillingItemModel model,
             ContractBillingItemModelValidator validator)


### PR DESCRIPTION
## Changes

This PR removes the associated service billing quantity under the billing milestone from the following pages:
1. Bespoke associated service milestone
2. Associated service milestones
3. Order summary and PDF

## Validation

### Bespoke associated service milestone

*Before*:

<img width="1512" height="1119" alt="image" src="https://github.com/user-attachments/assets/ef248993-1239-495d-aeb1-717541160393" />

*After*:

<img width="1512" height="1166" alt="image" src="https://github.com/user-attachments/assets/149e7c98-f26a-4e4b-90c0-5b8d0f9f3593" />

### Associated service milestones

*Before*:

<img width="1512" height="1119" alt="image" src="https://github.com/user-attachments/assets/1c960f9f-9c6f-4fca-8022-910087c329c7" />

*After*:

<img width="1512" height="1166" alt="image" src="https://github.com/user-attachments/assets/454ae693-8013-4a95-9348-1ff1512a7e0b" />

### Order summary

*Before*:

<img width="1512" height="1119" alt="image" src="https://github.com/user-attachments/assets/026a364a-5b22-45df-a069-597ddba59903" />

*After*:

<img width="1512" height="1119" alt="image" src="https://github.com/user-attachments/assets/d6ab5488-3688-4ef0-a8c4-6a46c5f92b4c" />
