### PR TITLE
[Bugfix] Include catalogue item for non-shortlisted solution services

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Competitions/CompetitionsService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Competitions/CompetitionsService.cs
@@ -267,6 +267,7 @@ public class CompetitionsService : ICompetitionsService
         => await dbContext.CompetitionSolutions.IgnoreQueryFilters()
             .Include(x => x.CatalogueItem.Supplier)
             .Include(x => x.Services)
+            .ThenInclude(x => x.CatalogueItem)
             .Where(
                 x => x.CompetitionId == competitionId && x.Competition.Organisation.InternalIdentifier == internalOrgId
                     && !x.IsShortlisted)


### PR DESCRIPTION
Includes the Catalogue Item of an Additional Service in the query for non-shortlisted Solutions