### PR TITLE
[Per unit quantities] Reflect service recipient quantity for all price types

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/Order.Custom.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/Order.Custom.cs
@@ -316,7 +316,6 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
                         InitialiseOrderItem(
                             item.CatalogueItem.Id,
                             item.OrderItemPrice?.Clone(),
-                            item.Quantity,
                             item.EstimationPeriod));
                 }
             }
@@ -375,12 +374,10 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
         private OrderItem InitialiseOrderItem(
             CatalogueItemId catalogueItemId,
             OrderItemPrice orderItemPrice,
-            int? quantity,
             TimeUnit? estimationPeriod)
         {
             var orderItem = InitialiseOrderItem(catalogueItemId);
             orderItem.OrderItemPrice = orderItemPrice;
-            orderItem.Quantity = quantity;
             orderItem.EstimationPeriod = estimationPeriod;
             return orderItem;
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/OrderItem.Custom.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/OrderItem.Custom.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Extensions;
-using NHSD.GPIT.BuyingCatalogue.EntityFramework.Interfaces;
 
 namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
 {
@@ -14,9 +13,7 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
             if (OrderItemPrice == null)
                 return 0;
 
-            return Quantity.HasValue
-                ? Quantity ?? 0
-                : recipients?.Sum(r => r.GetQuantityForItem(CatalogueItemId) ?? 0) ?? 0;
+            return Quantity ?? recipients?.Sum(r => r.GetQuantityForItem(CatalogueItemId) ?? 0) ?? 0;
         }
 
         public bool IsReadyForReview(bool isAmendment, ICollection<OrderSublocationRecipient> recipients)

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/OrderItem.Custom.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/OrderItem.Custom.cs
@@ -14,9 +14,9 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
             if (OrderItemPrice == null)
                 return 0;
 
-            return ((IPrice)OrderItemPrice).IsPerServiceRecipient()
-                ? recipients?.Sum(r => r.GetQuantityForItem(CatalogueItemId) ?? 0) ?? 0
-                : Quantity ?? 0;
+            return Quantity.HasValue
+                ? Quantity ?? 0
+                : recipients?.Sum(r => r.GetQuantityForItem(CatalogueItemId) ?? 0) ?? 0;
         }
 
         public bool IsReadyForReview(bool isAmendment, ICollection<OrderSublocationRecipient> recipients)

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/OrderItem.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Ordering/Models/OrderItem.cs
@@ -46,7 +46,6 @@ namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models
             OrderItemPrice = OrderItemPrice?.Clone(),
             EstimationPeriod = EstimationPeriod,
             CatalogueItem = CatalogueItem,
-            Quantity = Quantity,
             OrderItemFunding = OrderItemFunding?.Clone(),
         };
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Csv/CsvService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Csv/CsvService.cs
@@ -200,19 +200,19 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Csv
                         CallOffId = or.Order.CallOffId,
                         OdsCode = or.Order.OrderingParty.ExternalIdentifier,
                         OrganisationName = or.Order.OrderingParty.Name,
-                        SubIcbCode = !(oir.OrderItem.OrderItemPrice as IPrice).IsPerServiceRecipient()
+                        SubIcbCode = oir.OrderItem.Quantity.HasValue
                             ? string.Empty
                             : or.ParentSublocation.SublocationOdsCode,
-                        SubIcbName = !(oir.OrderItem.OrderItemPrice as IPrice).IsPerServiceRecipient()
+                        SubIcbName = oir.OrderItem.Quantity.HasValue
                             ? string.Empty
                             : or.ParentSublocation.SublocationOrganisation.Name,
                         CommencementDate = or.Order.CommencementDate,
                         ServiceRecipientId =
-                            !(oir.OrderItem.OrderItemPrice as IPrice).IsPerServiceRecipient()
+                            oir.OrderItem.Quantity.HasValue
                                 ? or.Order.OrderingParty.ExternalIdentifier
                                 : or.RecipientOdsCode,
                         ServiceRecipientName =
-                            !(oir.OrderItem.OrderItemPrice as IPrice).IsPerServiceRecipient()
+                            oir.OrderItem.Quantity.HasValue
                                 ? or.Order.OrderingParty.Name
                                 : or.RecipientOdsOrganisation.Name,
                         SupplierId = $"{supplierId}",
@@ -296,12 +296,8 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Csv
                         CallOffId = or.Order.CallOffId,
                         OdsCode = or.Order.OrderingParty.ExternalIdentifier,
                         OrganisationName = or.Order.OrderingParty.Name,
-                        SubIcbCode = !(oir.OrderItem.OrderItemPrice as IPrice).IsPerServiceRecipient()
-                            ? string.Empty
-                            : or.ParentSublocation.SublocationOdsCode,
-                        SubIcbName = !(oir.OrderItem.OrderItemPrice as IPrice).IsPerServiceRecipient()
-                            ? string.Empty
-                            : or.ParentSublocation.SublocationOrganisation.Name,
+                        SubIcbCode = or.ParentSublocation.SublocationOdsCode,
+                        SubIcbName = or.ParentSublocation.SublocationOrganisation.Name,
                         CommencementDate = or.Order.CommencementDate,
                         ServiceRecipientId = or.RecipientOdsCode,
                         ServiceRecipientName = or.RecipientOdsOrganisation.Name,
@@ -383,12 +379,8 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.Csv
                         CallOffId = or.Order.CallOffId,
                         OdsCode = or.Order.OrderingParty.ExternalIdentifier,
                         OrganisationName = or.Order.OrderingParty.Name,
-                        SubIcbCode = !(oir.OrderItem.OrderItemPrice as IPrice).IsPerServiceRecipient()
-                            ? string.Empty
-                            : or.ParentSublocation.SublocationOdsCode,
-                        SubIcbName = !(oir.OrderItem.OrderItemPrice as IPrice).IsPerServiceRecipient()
-                            ? string.Empty
-                            : or.ParentSublocation.SublocationOrganisation.Name,
+                        SubIcbCode = or.ParentSublocation.SublocationOdsCode,
+                        SubIcbName = or.ParentSublocation.SublocationOrganisation.Name,
                         CommencementDate = or.Order.CommencementDate,
                         ServiceRecipientId = or.RecipientOdsCode,
                         ServiceRecipientName = or.RecipientOdsOrganisation.Name,

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/FundingSource/FundingSources.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/FundingSource/FundingSources.cshtml
@@ -39,7 +39,7 @@
                         </h2>
 
                         <span class="detail">
-                            <strong>@Model.OrderItemsSelectable.Where(x => x.FundingType != OrderItemFundingType.None).Count()</strong> of <strong>@Model.OrderItemsSelectable.Count()</strong> started
+                            <strong>@Model.OrderItemsSelectable.Count(x => x.FundingType != OrderItemFundingType.None)</strong> of <strong>@Model.OrderItemsSelectable.Count()</strong> started
                         </span>
                     </div>
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.Framework.UnitTests/Calculations/CataloguePriceCalculationsTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Framework.UnitTests/Calculations/CataloguePriceCalculationsTests.cs
@@ -457,6 +457,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Framework.UnitTests.Calculations
         {
             order.Revision = revision;
             var orderItem = order.OrderItems.First();
+            orderItem.Quantity = null;
             order.OrderSublocations.ForEach(sl =>
                 sl.SublocationRecipients.ForEach(sr => sr.OrderItemSublocationRecipients.Clear()));
             var orderWrapper = new OrderWrapper(order);
@@ -481,6 +482,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Framework.UnitTests.Calculations
             OrderItemPrice orderItemPrice)
         {
             orderItemPrice.BillingPeriod = TimeUnit.PerMonth;
+            orderItem.Quantity = null;
             orderItem.OrderItemPrice = orderItemPrice;
             recipient.OrderItemSublocationRecipients.Clear();
             recipient.SetQuantityForItem(orderItem.CatalogueItemId, quantity);
@@ -499,6 +501,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Framework.UnitTests.Calculations
             OrderItemPrice orderItemPrice)
         {
             orderItemPrice.BillingPeriod = TimeUnit.PerYear;
+            orderItem.Quantity = null;
             orderItem.OrderItemPrice = orderItemPrice;
             recipient.OrderItemSublocationRecipients.Clear();
             recipient.SetQuantityForItem(orderItem.CatalogueItemId, quantity);
@@ -517,11 +520,72 @@ namespace NHSD.GPIT.BuyingCatalogue.Framework.UnitTests.Calculations
             OrderItemPrice orderItemPrice)
         {
             orderItemPrice.BillingPeriod = null;
+            orderItem.Quantity = null;
             orderItem.OrderItemPrice = orderItemPrice;
             recipient.OrderItemSublocationRecipients.Clear();
             recipient.SetQuantityForItem(orderItem.CatalogueItemId, quantity);
 
             var expectedResult = ((IPrice)orderItemPrice).CalculateOneOffCost(quantity);
+
+            orderItem.TotalCost([recipient]).Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [MockAutoData]
+        public static void OrderItem_TotalCost_GlobalQuantity_PerMonth_ReturnsExpected(
+            OrderSublocationRecipient recipient,
+            int globalQuantity,
+            int recipientQuantity,
+            OrderItem orderItem,
+            OrderItemPrice orderItemPrice)
+        {
+            orderItemPrice.BillingPeriod = TimeUnit.PerMonth;
+            orderItem.Quantity = globalQuantity;
+            orderItem.OrderItemPrice = orderItemPrice;
+            recipient.OrderItemSublocationRecipients.Clear();
+            recipient.SetQuantityForItem(orderItem.CatalogueItemId, recipientQuantity);
+
+            var expectedResult = ((IPrice)orderItemPrice).CalculateCostPerMonth(globalQuantity);
+
+            orderItem.TotalCost([recipient]).Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [MockAutoData]
+        public static void OrderItem_TotalCost_GlobalQuantity_PerYear_ReturnsExpected(
+            OrderSublocationRecipient recipient,
+            int globalQuantity,
+            int recipientQuantity,
+            OrderItem orderItem,
+            OrderItemPrice orderItemPrice)
+        {
+            orderItemPrice.BillingPeriod = TimeUnit.PerYear;
+            orderItem.Quantity = globalQuantity;
+            orderItem.OrderItemPrice = orderItemPrice;
+            recipient.OrderItemSublocationRecipients.Clear();
+            recipient.SetQuantityForItem(orderItem.CatalogueItemId, recipientQuantity);
+
+            var expectedResult = ((IPrice)orderItemPrice).CalculateCostPerYear(globalQuantity);
+
+            orderItem.TotalCost([recipient]).Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [MockAutoData]
+        public static void OrderItem_TotalCost_GlobalQuantity_OneOff_ReturnsExpected(
+            OrderSublocationRecipient recipient,
+            int globalQuantity,
+            int recipientQuantity,
+            OrderItem orderItem,
+            OrderItemPrice orderItemPrice)
+        {
+            orderItemPrice.BillingPeriod = null;
+            orderItem.Quantity = globalQuantity;
+            orderItem.OrderItemPrice = orderItemPrice;
+            recipient.OrderItemSublocationRecipients.Clear();
+            recipient.SetQuantityForItem(orderItem.CatalogueItemId, recipientQuantity);
+
+            var expectedResult = ((IPrice)orderItemPrice).CalculateOneOffCost(globalQuantity);
 
             orderItem.TotalCost([recipient]).Should().Be(expectedResult);
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Csv/CsvServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Csv/CsvServiceTests.cs
@@ -674,6 +674,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Csv
             OrderSublocation workingSublocation = order.OrderSublocations.First();
 
             workingSublocation.Order = order;
+            orderItem.Quantity = null;
 
             order.OrderItems = new HashSet<OrderItem> { orderItem };
 
@@ -852,6 +853,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Csv
 
             var orderItem = fixture.Build<OrderItem>()
                 .Without(i => i.Order)
+                .Without(i => i.Quantity)
                 .With(i => i.CatalogueItem, catalogueItem)
                 .With(i => i.CatalogueItemId, catalogueItem.Id)
                 .With(i => i.OrderItemPrice, itemPrice)

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Csv/CsvServiceTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/Csv/CsvServiceTests.cs
@@ -539,7 +539,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Csv
         [Theory]
         [MockInMemoryDbInlineAutoData(ProvisioningType.OnDemand)]
         [MockInMemoryDbInlineAutoData(ProvisioningType.Declarative)]
-        public static async Task One_OrderItem_Two_Recipients_With_PerOrderItemQuantity_Results_In_One_Row(
+        public static async Task One_OrderItem_Two_Recipients_With_PerOrderItemQuantity_Results_In_Two_Rows(
             ProvisioningType provisioningType,
             Order order,
             CsvService service,
@@ -571,11 +571,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.Csv
             List<FullOrderCsvModel> records =
                 GetRows<FullOrderCsvModel>(fullOrderStream, new FullOrderCsvModelMap()).ToList();
 
-            records.Count.Should().Be(1);
-            records.First().ProductId.Should().Be(originalCatalogueItem.Id.ToString());
-            records.First().ServiceRecipientId.Should().Be(order.OrderingParty.ExternalIdentifier);
-            records.First().ServiceRecipientName.Should().Be(order.OrderingParty.Name);
-            records.First().ServiceRecipientItemId.Should().Be($"{order.CallOffId}-{order.OrderingParty.ExternalIdentifier}-{orderItem.CatalogueItemId}");
+            records.Count.Should().Be(2);
         }
 
         [Theory]


### PR DESCRIPTION
# Change

Updates the CSV and some intermediary pages to display the newer per service recipient based quantities in a manner that is backwards compatible with the existing orders which use the older order item based quantity