### PR TITLE
Calculate one-off cost of all competition services

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Competitions/Configuration/CompetitionSolutionEntityTypeConfiguration.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Competitions/Configuration/CompetitionSolutionEntityTypeConfiguration.cs
@@ -21,8 +21,5 @@ public sealed class CompetitionSolutionEntityTypeConfiguration : IEntityTypeConf
             .HasForeignKey(x => x.CompetitionSolutionId)
             .HasConstraintName("FK_SolutionScores_Solution")
             .OnDelete(DeleteBehavior.Cascade);
-
-        builder.Ignore(x => x.AdditionalServices);
-        builder.Ignore(x => x.AssociatedServices);
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Competitions/Models/CompetitionSolution.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Competitions/Models/CompetitionSolution.cs
@@ -41,13 +41,13 @@ public class CompetitionSolution : CompetitionCatalogueItem
 
     public decimal? CalculateTotalPrice(int contractLength)
     {
-        var price = Price as IPrice;
+        IPrice price = Price;
 
         var solutionMonthlyCost =
             price?.CalculateCostPerMonth(Quantities.Sum(x => x.Quantity.GetValueOrDefault()));
         var servicesMonthlyCost = Services?.Sum(x =>
             ((IPrice)x.Price)?.CalculateCostPerMonth(x.Quantities.Sum(y => y.Quantity.GetValueOrDefault())));
-        var oneOffCost = AssociatedServices
+        var oneOffCost = Services?
             .Sum(x => ((IPrice)x.Price)?.CalculateOneOffCost(x.Quantities.Sum(y => y.Quantity.GetValueOrDefault())));
 
         return oneOffCost + ((solutionMonthlyCost + servicesMonthlyCost) * contractLength);

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Competitions/Models/CompetitionSolution.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Competitions/Models/CompetitionSolution.cs
@@ -29,13 +29,13 @@ public class CompetitionSolution : CompetitionCatalogueItem
 
     public ICollection<CompetitionCatalogueItem> Services { get; set; } = new HashSet<CompetitionCatalogueItem>();
 
-    public ICollection<CompetitionAdditionalService> AdditionalServices =>
-        Services.OfType<CompetitionAdditionalService>().ToList();
-
-    public ICollection<CompetitionAssociatedService> AssociatedServices =>
-        Services.OfType<CompetitionAssociatedService>().ToList();
-
     public ICollection<SolutionScore> Scores { get; set; } = new HashSet<SolutionScore>();
+
+    public IEnumerable<CompetitionAdditionalService> GetAdditionalServices() =>
+        Services.OfType<CompetitionAdditionalService>();
+
+    public IEnumerable<CompetitionAssociatedService> GetAssociatedServices() =>
+        Services.OfType<CompetitionAssociatedService>();
 
     public bool HasScoreType(ScoreType type) => Scores.Any(x => x.ScoreType == type);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Competitions/Models/CompetitionSolution.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/Competitions/Models/CompetitionSolution.cs
@@ -29,9 +29,11 @@ public class CompetitionSolution : CompetitionCatalogueItem
 
     public ICollection<CompetitionCatalogueItem> Services { get; set; } = new HashSet<CompetitionCatalogueItem>();
 
-    public ICollection<CompetitionAdditionalService> AdditionalServices => Services.OfType<CompetitionAdditionalService>().ToList();
+    public ICollection<CompetitionAdditionalService> AdditionalServices =>
+        Services.OfType<CompetitionAdditionalService>().ToList();
 
-    public ICollection<CompetitionAssociatedService> AssociatedServices => Services.OfType<CompetitionAssociatedService>().ToList();
+    public ICollection<CompetitionAssociatedService> AssociatedServices =>
+        Services.OfType<CompetitionAssociatedService>().ToList();
 
     public ICollection<SolutionScore> Scores { get; set; } = new HashSet<SolutionScore>();
 
@@ -50,6 +52,7 @@ public class CompetitionSolution : CompetitionCatalogueItem
         var oneOffCost = Services?
             .Sum(x => ((IPrice)x.Price)?.CalculateOneOffCost(x.Quantities.Sum(y => y.Quantity.GetValueOrDefault())));
 
-        return oneOffCost + ((solutionMonthlyCost + servicesMonthlyCost) * contractLength);
+        return ((solutionMonthlyCost.GetValueOrDefault() + servicesMonthlyCost.GetValueOrDefault()) * contractLength)
+            + oneOffCost.GetValueOrDefault();
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/Competitions/CompetitionsService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/Competitions/CompetitionsService.cs
@@ -714,7 +714,7 @@ public class CompetitionsService : ICompetitionsService
             .FirstOrDefaultAsync(x => x.Organisation.InternalIdentifier == internalOrgId && x.Id == competitionId);
 
         var solution = competition.CompetitionSolutions.FirstOrDefault(x => x.CatalogueItemId == solutionId);
-        var associatedService = solution?.AssociatedServices.FirstOrDefault(x => x.CatalogueItemId == serviceId);
+        var associatedService = solution?.GetAssociatedServices().FirstOrDefault(x => x.CatalogueItemId == serviceId);
         if (associatedService == null) return;
 
         if (associatedService.Price is not null)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Controllers/CompetitionHubController.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Controllers/CompetitionHubController.cs
@@ -93,7 +93,7 @@ public class CompetitionHubController : Controller
         if (solution is null) return BadRequest();
 
         var associatedServices = await associatedServicesService.GetPublishedAssociatedServicesForCatalogueItem(solutionId, PracticeReorganisationTypeEnum.None);
-        var selectedAssociatedServices = solution.AssociatedServices;
+        var selectedAssociatedServices = solution.GetAssociatedServices();
 
         var model = new CompetitionSolutionHubModel(internalOrgId, solution, competition)
         {
@@ -473,7 +473,7 @@ public class CompetitionHubController : Controller
         var solution = competition?.CompetitionSolutions.FirstOrDefault(x => x.CatalogueItemId == solutionId);
         if (solution == null) return BadRequest();
 
-        var service = solution.AssociatedServices.FirstOrDefault(x => x.CatalogueItemId == serviceId);
+        var service = solution.GetAssociatedServices().FirstOrDefault(x => x.CatalogueItemId == serviceId);
         if (service == null) return BadRequest();
 
         var model = new RemoveServiceModel(service.CatalogueItem)
@@ -545,7 +545,7 @@ public class CompetitionHubController : Controller
         var solution = competition.CompetitionSolutions.First(x => x.CatalogueItemId == solutionId);
 
         var currentServices =
-            solution.AssociatedServices.Select(x => x.CatalogueItem);
+            solution.GetAssociatedServices().Select(x => x.CatalogueItem);
 
         var associatedServices = await associatedServicesService.GetPublishedAssociatedServicesForCatalogueItem(solutionId, PracticeReorganisationTypeEnum.None);
 

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Models/Shared/SolutionModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Models/Shared/SolutionModel.cs
@@ -17,7 +17,7 @@ public class SolutionModel
         SolutionId = competitionSolution.CatalogueItemId;
         SolutionName = competitionSolution.CatalogueItem.Name;
         SupplierName = competitionSolution.CatalogueItem.Supplier.Name;
-        RequiredServices = competitionSolution.AdditionalServices.Where(x => x.IsRequired).Select(y => y.CatalogueItem.Name).ToList();
+        RequiredServices = competitionSolution.GetAdditionalServices().Where(x => x.IsRequired).Select(y => y.CatalogueItem.Name).ToList();
         Selected = competitionSolution.IsShortlisted;
         Summary = competitionSolution.CatalogueItem.Solution.Summary;
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionResults/ViewResults.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Competitions/Views/CompetitionResults/ViewResults.cshtml
@@ -95,7 +95,7 @@
 
                     @foreach (var nonShortlistedSolution in Model.NonShortlistedSolutions.OrderBy(x => x.CatalogueItem.Name))
                     {
-                        var requiredCompetitionServices = nonShortlistedSolution.AdditionalServices.Where(x => x.IsRequired).OrderBy(x => x.CatalogueItem.Name).ToList();
+                        var requiredCompetitionServices = nonShortlistedSolution.GetAdditionalServices().Where(x => x.IsRequired).OrderBy(x => x.CatalogueItem.Name).ToList();
                         <nhs-table-row-container>
                             <nhs-table-cell style="width:30%">
                                 @nonShortlistedSolution.CatalogueItem.Name

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/CompetitionResultsPdf/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/CompetitionResultsPdf/Index.cshtml
@@ -260,7 +260,7 @@
                         <tbody>
                             @foreach (var nonShortlistedSolution in Model.NonShortlistedSolutions.OrderBy(x => x.CatalogueItem.Name))
                             {
-                                var requiredCompetitionServices = nonShortlistedSolution.AdditionalServices.Where(x => x.IsRequired).OrderBy(x => x.CatalogueItem.Name).ToList();
+                                var requiredCompetitionServices = nonShortlistedSolution.GetAdditionalServices().Where(x => x.IsRequired).OrderBy(x => x.CatalogueItem.Name).ToList();
                                 <tr class="alternating">
                                     <td style="width:30%">
                                         @nonShortlistedSolution.CatalogueItem.Name

--- a/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/Models/Competitions/CompetitionSolutionTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/Models/Competitions/CompetitionSolutionTests.cs
@@ -183,4 +183,78 @@ public static class CompetitionSolutionTests
 
         total.Should().Be(expectedPrice);
     }
+
+    [Theory]
+    [MockAutoData]
+    public static void CalculateTotalPrice_SolutionWithServicesNoPrice_ReturnsExpected(
+        CompetitionSolution solution,
+        CompetitionAssociatedService associatedService,
+        CompetitionAdditionalService additionalService)
+    {
+        const int contractLength = 12;
+        const int price = 1000;
+        const int quantity = 5;
+        const int expectedPrice = price * quantity;
+
+        additionalService.Price = associatedService.Price = null;
+        additionalService.Quantities = associatedService.Quantities = [];
+
+        solution.Services = [associatedService, additionalService];
+        solution.Price = new CompetitionCatalogueItemPrice
+        {
+            CataloguePriceCalculationType = CataloguePriceCalculationType.Volume,
+            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerServiceRecipient,
+            ProvisioningType = ProvisioningType.Patient,
+            BillingPeriod = TimeUnit.PerYear,
+            Tiers = [new CompetitionCatalogueItemPriceTier { LowerRange = 0, UpperRange = null, Price = price }],
+        };
+        solution.Quantities = [new CompetitionItemQuantity { Quantity = quantity }];
+
+        var total = solution.CalculateTotalPrice(contractLength);
+
+        total.Should().Be(expectedPrice);
+    }
+
+    [Theory]
+    [MockAutoData]
+    public static void CalculateTotalPrice_SolutionWithNullServices_ReturnsExpected(
+        CompetitionSolution solution)
+    {
+        const int contractLength = 12;
+        const int price = 1000;
+        const int quantity = 5;
+        const int expectedPrice = price * quantity;
+
+        solution.Services = null;
+        solution.Price = new CompetitionCatalogueItemPrice
+        {
+            CataloguePriceCalculationType = CataloguePriceCalculationType.Volume,
+            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerServiceRecipient,
+            ProvisioningType = ProvisioningType.Patient,
+            BillingPeriod = TimeUnit.PerYear,
+            Tiers = [new CompetitionCatalogueItemPriceTier { LowerRange = 0, UpperRange = null, Price = price }],
+        };
+        solution.Quantities = [new CompetitionItemQuantity { Quantity = quantity }];
+
+        var total = solution.CalculateTotalPrice(contractLength);
+
+        total.Should().Be(expectedPrice);
+    }
+
+    [Theory]
+    [MockAutoData]
+    public static void CalculateTotalPrice_SolutionWithNullPrice_ReturnsExpected(
+        CompetitionSolution solution)
+    {
+        const int contractLength = 12;
+        const int expectedPrice = 0;
+
+        solution.Services = null;
+        solution.Price = null;
+        solution.Quantities = [];
+
+        var total = solution.CalculateTotalPrice(contractLength);
+
+        total.Should().Be(expectedPrice);
+    }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/Models/Competitions/CompetitionSolutionTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/Models/Competitions/CompetitionSolutionTests.cs
@@ -1,0 +1,186 @@
+﻿using FluentAssertions;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Competitions.Models;
+using NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.Attributes;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests.Models.Competitions;
+
+public static class CompetitionSolutionTests
+{
+    [Theory]
+    [MockAutoData]
+    public static void CalculateTotalPrice_SolutionNoServices_ReturnsExpected(
+        CompetitionSolution solution)
+    {
+        const int contractLength = 12;
+        const int price = 1000;
+        const int quantity = 5;
+        const int expectedPrice = price * quantity;
+
+        solution.Services = [];
+        solution.Price = new CompetitionCatalogueItemPrice
+        {
+            CataloguePriceCalculationType = CataloguePriceCalculationType.Volume,
+            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerServiceRecipient,
+            ProvisioningType = ProvisioningType.Patient,
+            BillingPeriod = TimeUnit.PerYear,
+            Tiers = [new CompetitionCatalogueItemPriceTier { LowerRange = 0, UpperRange = null, Price = price }],
+        };
+        solution.Quantities = [new CompetitionItemQuantity { Quantity = quantity }];
+
+        var total = solution.CalculateTotalPrice(contractLength);
+
+        total.Should().Be(expectedPrice);
+    }
+
+    [Theory]
+    [MockAutoData]
+    public static void CalculateTotalPrice_SolutionWithAdditionalService_ReturnsExpected(
+        CompetitionSolution solution,
+        CompetitionAdditionalService additionalService)
+    {
+        const int contractLength = 12;
+        const int price = 1000;
+        const int quantity = 5;
+        const int expectedPrice = (price * quantity) * 2;
+
+        additionalService.Price = new CompetitionCatalogueItemPrice
+        {
+            CataloguePriceCalculationType = CataloguePriceCalculationType.Volume,
+            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerServiceRecipient,
+            ProvisioningType = ProvisioningType.Patient,
+            BillingPeriod = TimeUnit.PerYear,
+            Tiers = [new CompetitionCatalogueItemPriceTier { LowerRange = 0, UpperRange = null, Price = price }],
+        };
+        additionalService.Quantities = [new CompetitionItemQuantity { Quantity = quantity }];
+
+        solution.Services = [additionalService];
+        solution.Price = new CompetitionCatalogueItemPrice
+        {
+            CataloguePriceCalculationType = CataloguePriceCalculationType.Volume,
+            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerServiceRecipient,
+            ProvisioningType = ProvisioningType.Patient,
+            BillingPeriod = TimeUnit.PerYear,
+            Tiers = [new CompetitionCatalogueItemPriceTier { LowerRange = 0, UpperRange = null, Price = price }],
+        };
+        solution.Quantities = [new CompetitionItemQuantity { Quantity = quantity }];
+
+        var total = solution.CalculateTotalPrice(contractLength);
+
+        total.Should().Be(expectedPrice);
+    }
+
+    [Theory]
+    [MockAutoData]
+    public static void CalculateTotalPrice_SolutionWithOneOffCostAdditionalService_ReturnsExpected(
+        CompetitionSolution solution,
+        CompetitionAdditionalService additionalService)
+    {
+        const int contractLength = 12;
+        const int price = 1000;
+        const int quantity = 5;
+        const int expectedPrice = (price * quantity) * 2;
+
+        additionalService.Price = new CompetitionCatalogueItemPrice
+        {
+            CataloguePriceCalculationType = CataloguePriceCalculationType.Volume,
+            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerServiceRecipient,
+            ProvisioningType = ProvisioningType.Patient,
+            BillingPeriod = null,
+            Tiers = [new CompetitionCatalogueItemPriceTier { LowerRange = 0, UpperRange = null, Price = price }],
+        };
+        additionalService.Quantities = [new CompetitionItemQuantity { Quantity = quantity }];
+
+        solution.Services = [additionalService];
+        solution.Price = new CompetitionCatalogueItemPrice
+        {
+            CataloguePriceCalculationType = CataloguePriceCalculationType.Volume,
+            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerServiceRecipient,
+            ProvisioningType = ProvisioningType.Patient,
+            BillingPeriod = TimeUnit.PerYear,
+            Tiers = [new CompetitionCatalogueItemPriceTier { LowerRange = 0, UpperRange = null, Price = price }],
+        };
+        solution.Quantities = [new CompetitionItemQuantity { Quantity = quantity }];
+
+        var total = solution.CalculateTotalPrice(contractLength);
+
+        total.Should().Be(expectedPrice);
+    }
+
+    [Theory]
+    [MockAutoData]
+    public static void CalculateTotalPrice_SolutionWithMonthlyAdditionalService_ReturnsExpected(
+        CompetitionSolution solution,
+        CompetitionAdditionalService additionalService)
+    {
+        const int contractLength = 12;
+        const int price = 1000;
+        const int quantity = 5;
+        const int expectedSolutionPrice = price * quantity;
+        const int expectedAdditionalServicePrice = (price * quantity) * 12;
+        const int expectedTotalPrice = expectedSolutionPrice + expectedAdditionalServicePrice;
+
+        additionalService.Price = new CompetitionCatalogueItemPrice
+        {
+            CataloguePriceCalculationType = CataloguePriceCalculationType.Volume,
+            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerServiceRecipient,
+            ProvisioningType = ProvisioningType.Patient,
+            BillingPeriod = TimeUnit.PerMonth,
+            Tiers = [new CompetitionCatalogueItemPriceTier { LowerRange = 0, UpperRange = null, Price = price }],
+        };
+        additionalService.Quantities = [new CompetitionItemQuantity { Quantity = quantity }];
+
+        solution.Services = [additionalService];
+        solution.Price = new CompetitionCatalogueItemPrice
+        {
+            CataloguePriceCalculationType = CataloguePriceCalculationType.Volume,
+            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerServiceRecipient,
+            ProvisioningType = ProvisioningType.Patient,
+            BillingPeriod = TimeUnit.PerYear,
+            Tiers = [new CompetitionCatalogueItemPriceTier { LowerRange = 0, UpperRange = null, Price = price }],
+        };
+        solution.Quantities = [new CompetitionItemQuantity { Quantity = quantity }];
+
+        var total = solution.CalculateTotalPrice(contractLength);
+
+        total.Should().Be(expectedTotalPrice);
+    }
+
+    [Theory]
+    [MockAutoData]
+    public static void CalculateTotalPrice_SolutionWithOneOffCostAssociatedService_ReturnsExpected(
+        CompetitionSolution solution,
+        CompetitionAssociatedService associatedService)
+    {
+        const int contractLength = 12;
+        const int price = 1000;
+        const int quantity = 5;
+        const int expectedPrice = (price * quantity) * 2;
+
+        associatedService.Price = new CompetitionCatalogueItemPrice
+        {
+            CataloguePriceCalculationType = CataloguePriceCalculationType.Volume,
+            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerServiceRecipient,
+            ProvisioningType = ProvisioningType.Patient,
+            BillingPeriod = null,
+            Tiers = [new CompetitionCatalogueItemPriceTier { LowerRange = 0, UpperRange = null, Price = price }],
+        };
+        associatedService.Quantities = [new CompetitionItemQuantity { Quantity = quantity }];
+
+        solution.Services = [associatedService];
+        solution.Price = new CompetitionCatalogueItemPrice
+        {
+            CataloguePriceCalculationType = CataloguePriceCalculationType.Volume,
+            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerServiceRecipient,
+            ProvisioningType = ProvisioningType.Patient,
+            BillingPeriod = TimeUnit.PerYear,
+            Tiers = [new CompetitionCatalogueItemPriceTier { LowerRange = 0, UpperRange = null, Price = price }],
+        };
+        solution.Quantities = [new CompetitionItemQuantity { Quantity = quantity }];
+
+        var total = solution.CalculateTotalPrice(contractLength);
+
+        total.Should().Be(expectedPrice);
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/Models/Competitions/CompetitionSolutionTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/Models/Competitions/CompetitionSolutionTests.cs
@@ -217,6 +217,57 @@ public static class CompetitionSolutionTests
 
     [Theory]
     [MockAutoData]
+    public static void CalculateTotalPrice_SolutionWithServicesAndPrices_ReturnsExpected(
+        CompetitionSolution solution,
+        CompetitionAssociatedService associatedService,
+        CompetitionAdditionalService additionalService)
+    {
+        const int contractLength = 12;
+        const int price = 1000;
+        const int quantity = 5;
+        const int solutionAndAssociatedServicePrice = (price * quantity) * 2;
+        const int additionalServicePrice = (price * quantity) * 12;
+        const int expectedPrice = solutionAndAssociatedServicePrice + additionalServicePrice;
+
+        associatedService.Price = new CompetitionCatalogueItemPrice
+        {
+            CataloguePriceCalculationType = CataloguePriceCalculationType.Volume,
+            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerServiceRecipient,
+            ProvisioningType = ProvisioningType.Patient,
+            BillingPeriod = null,
+            Tiers = [new CompetitionCatalogueItemPriceTier { LowerRange = 0, UpperRange = null, Price = price }],
+        };
+
+        additionalService.Price = new CompetitionCatalogueItemPrice
+        {
+            CataloguePriceCalculationType = CataloguePriceCalculationType.Volume,
+            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerServiceRecipient,
+            ProvisioningType = ProvisioningType.Patient,
+            BillingPeriod = TimeUnit.PerMonth,
+            Tiers = [new CompetitionCatalogueItemPriceTier { LowerRange = 0, UpperRange = null, Price = price }],
+        };
+
+        associatedService.Quantities = [new CompetitionItemQuantity { Quantity = quantity }];
+        additionalService.Quantities = [new CompetitionItemQuantity { Quantity = quantity }];
+
+        solution.Services = [associatedService, additionalService];
+        solution.Price = new CompetitionCatalogueItemPrice
+        {
+            CataloguePriceCalculationType = CataloguePriceCalculationType.Volume,
+            CataloguePriceQuantityCalculationType = CataloguePriceQuantityCalculationType.PerServiceRecipient,
+            ProvisioningType = ProvisioningType.Patient,
+            BillingPeriod = TimeUnit.PerYear,
+            Tiers = [new CompetitionCatalogueItemPriceTier { LowerRange = 0, UpperRange = null, Price = price }],
+        };
+        solution.Quantities = [new CompetitionItemQuantity { Quantity = quantity }];
+
+        var total = solution.CalculateTotalPrice(contractLength);
+
+        total.Should().Be(expectedPrice);
+    }
+
+    [Theory]
+    [MockAutoData]
     public static void CalculateTotalPrice_SolutionWithNullServices_ReturnsExpected(
         CompetitionSolution solution)
     {


### PR DESCRIPTION
Resolves an issue where Additional Services were not factored in the one-off cost calculations