### PR TITLE
Update SQLPackage URL

### DIFF
--- a/database/NHSD.GPITBuyingCatalogue.Database/Dockerfile
+++ b/database/NHSD.GPITBuyingCatalogue.Database/Dockerfile
@@ -4,9 +4,9 @@ COPY database/NHSD.GPITBuyingCatalogue.Database .
 RUN dotnet build "NHSD.GPITBuyingCatalogue.Database.sqlproj" -c Release -o build
 
 FROM mcr.microsoft.com/mssql-tools:latest AS dacfx
-RUN apt-get -o Acquire::https::No-Cache=True -o Acquire::http::No-Cache=True update && apt-get install libunwind8 libicu-dev wget unzip -y
+RUN apt-get update && apt-get install libunwind8 libicu-dev wget unzip -y
 WORKDIR /deploy-db
-RUN wget https://aka.ms/sqlpackage-linux -O sqlpackage.zip \
+RUN wget https://go.microsoft.com/fwlink/?linkid=2338525 -O sqlpackage.zip \
     && mkdir sqlpackage \
     && unzip sqlpackage.zip -d /sqlpackage \
     && chmod a+x /sqlpackage/sqlpackage


### PR DESCRIPTION
The latest version of SQL package (published Feb 2026) doesn't work with the mssql-tools Docker image. This change hardcodes the SQLPackage URL and downgrades the version to the .NET 8 version of SQLPackage

This will need to be picked up in the future again to address with a permanent fix