### PR TITLE
NuGet update and order PDF bugfix

### DIFF
--- a/src/BuyingCatalogueFunction/BuyingCatalogueFunction.csproj
+++ b/src/BuyingCatalogueFunction/BuyingCatalogueFunction.csproj
@@ -5,22 +5,25 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Queues" Version="12.24.0" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.25.0" />
     <PackageReference Include="CsvHelper" Version="30.0.1" />
-    <PackageReference Include="Flurl.Http" Version="3.2.4" />
+    <PackageReference Include="Flurl.Http" Version="4.0.2" />
     <PackageReference Include="GovukNotify" Version="6.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.8.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.50.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.16.3" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage" Version="6.8.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.3" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage" Version="6.8.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.4" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
-    <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="SharpZipLib" Version="1.4.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.14.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageReference Include="morelinq" Version="4.4.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
+    <PackageReference Include="SharpZipLib" Version="1.4.2" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/NHSD.GPIT.BuyingCatalogue.EntityFramework.csproj
+++ b/src/NHSD.GPIT.BuyingCatalogue.EntityFramework/NHSD.GPIT.BuyingCatalogue.EntityFramework.csproj
@@ -24,19 +24,21 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Humanizer.Core" Version="3.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Enums.NET" Version="4.0.0" />
+    <PackageReference Include="Enums.NET" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/src/NHSD.GPIT.BuyingCatalogue.Framework/NHSD.GPIT.BuyingCatalogue.Framework.csproj
+++ b/src/NHSD.GPIT.BuyingCatalogue.Framework/NHSD.GPIT.BuyingCatalogue.Framework.csproj
@@ -17,13 +17,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.7" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/NHSD.GPIT.BuyingCatalogue.ServiceContracts.csproj
+++ b/src/NHSD.GPIT.BuyingCatalogue.ServiceContracts/NHSD.GPIT.BuyingCatalogue.ServiceContracts.csproj
@@ -16,14 +16,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.26.0" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.24.0" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="10.0.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.25.0" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="10.0.7" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/NHSD.GPIT.BuyingCatalogue.Services.csproj
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/NHSD.GPIT.BuyingCatalogue.Services.csproj
@@ -23,20 +23,20 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.26.0" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.24.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.25.0" />
     <PackageReference Include="CsvHelper" Version="27.2.1" />
-    <PackageReference Include="Flurl.Http" Version="3.2.4" />
+    <PackageReference Include="Flurl.Http" Version="4.0.2" />
     <PackageReference Include="GovukNotify" Version="6.0.0" />
-    <PackageReference Include="LinqKit.Microsoft.EntityFrameworkCore" Version="8.1.5" />
-    <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="Scrutor" Version="4.1.0" />
+    <PackageReference Include="LinqKit.Microsoft.EntityFrameworkCore" Version="10.0.11" />
+    <PackageReference Include="morelinq" Version="4.4.0" />
+    <PackageReference Include="Scrutor" Version="7.0.0" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components.WebApp/NHSD.GPIT.BuyingCatalogue.UI.Components.WebApp.csproj
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components.WebApp/NHSD.GPIT.BuyingCatalogue.UI.Components.WebApp.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.1" />
-    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.3.3">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.7" />
+    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components.WebApp/tsconfig.json
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components.WebApp/tsconfig.json
@@ -4,7 +4,7 @@
     "noEmitOnError": true,
     "removeComments": false,
     "sourceMap": true,
-    "target": "es5"
+    "target": "es6"
   },
   "include": [
     "wwwroot/ts"

--- a/src/NHSD.GPIT.BuyingCatalogue.UI.Components.WebApp/tsconfig.json
+++ b/src/NHSD.GPIT.BuyingCatalogue.UI.Components.WebApp/tsconfig.json
@@ -4,7 +4,8 @@
     "noEmitOnError": true,
     "removeComments": false,
     "sourceMap": true,
-    "target": "es6"
+    "target": "es6",
+    "strictNullChecks": false
   },
   "include": [
     "wwwroot/ts"

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/Orders/SummaryModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Models/Orders/SummaryModel.cs
@@ -74,23 +74,31 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Areas.Orders.Models.Orders
                 ? "You can download a summary of this terminated contract for your records."
                 : "You can download and review your order summary here.";
 
-        public AmendOrderItemModel BuildAmendOrderItemModel(OrderItem item, string solutionName = null)
+        public AmendOrderItemModel BuildAmendOrderItemModel(
+            OrderItem item,
+            string solutionName = null,
+            bool fromPreviousRevision = false)
         {
             var orderLinkedList = new LinkedList<Order>([.. OrderWrapper.PreviousOrders, OrderWrapper.Order]);
             var previous = orderLinkedList.Find(item.Order)?.Previous;
+
             var recipients = item.CatalogueItem.CatalogueItemType == CatalogueItemType.AssociatedService
                 ? item.Order.DetermineOrderRecipients(previous?.Value, item.CatalogueItemId)
                 : RolledUp.GetOrderRecipients().ToList();
+
             var previousRecipients = item.CatalogueItem.CatalogueItemType == CatalogueItemType.AssociatedService
                 ? []
                 : Previous?.GetOrderRecipients().ToList();
-            var itemName = item.CatalogueItem.CatalogueItemType == CatalogueItemType.AssociatedService && solutionName != null
-                ? $"{solutionName} - {item.CatalogueItem.Name}"
-                : item.CatalogueItem.Name;
-            var fromPreviousRevision = item.CatalogueItem.CatalogueItemType == CatalogueItemType.AssociatedService && item.Order.Revision < OrderWrapper.Order.Revision;
+
+            var itemName = item.CatalogueItem.CatalogueItemType == CatalogueItemType.AssociatedService
+                && solutionName != null
+                    ? $"{solutionName} - {item.CatalogueItem.Name}"
+                    : item.CatalogueItem.Name;
+
             var callOffId = item.CatalogueItem.CatalogueItemType == CatalogueItemType.AssociatedService
                 ? item.Order.CallOffId
                 : CallOffId;
+
             return new AmendOrderItemModel(
                 callOffId,
                 Order.OrderType,

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/Summary.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/Order/Summary.cshtml
@@ -352,7 +352,7 @@
                             <nhs-expander-content>
                                 @foreach (var associatedService in group)
                                 {
-                                    var itemModel = Model.BuildAmendOrderItemModel(associatedService, solutionName);
+                                    var itemModel = Model.BuildAmendOrderItemModel(associatedService, solutionName, true);
                                     itemModel.IsCardView = true;
                                     <partial name="_OrderItemSummary" model="@itemModel" />
                                 }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/TaskList/TaskListOrderItem.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Areas/Orders/Views/TaskList/TaskListOrderItem.cshtml
@@ -51,7 +51,7 @@
             else
             {
                 string actionName, actionText;
-                if (Model.FromPreviousRevision && Model.IsAmendment)
+                if (Model.IsAmendment)
                 {
                     (actionName, actionText) = (nameof(PricesController.ViewPrice), "View");
                 }
@@ -78,7 +78,7 @@
         <nhs-table-cell>
             @if (Model.QuantityStatus != TaskProgress.CannotStart)
             {
-                @if (Model.FromPreviousRevision && Model.IsAmendment 
+                @if (Model.IsAmendment
                      && Model.QuantityStatus != TaskProgress.InProgress && Model.QuantityStatus != TaskProgress.NotStarted && !Model.HasNewRecipients)
                 {
                     var viewAction = Model.IsAssociatedService

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Models/OrderSummaryModel.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Models/OrderSummaryModel.cs
@@ -49,7 +49,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Models
 
         public bool HasSpecificRequirements => BespokeBilling != null && BespokeBilling.Requirements.Any();
 
-        public AmendOrderItemModel BuildAmendOrderItemModel(OrderItem solution, string solutionName = null)
+        public AmendOrderItemModel BuildAmendOrderItemModel(OrderItem solution, string solutionName = null, bool fromPreviousRevision = false)
         {
             var orderLinkedList = new LinkedList<Order>([.. OrderWrapper.PreviousOrders, OrderWrapper.Order]);
             var previous = orderLinkedList.Find(solution.Order)?.Previous;
@@ -76,8 +76,7 @@ namespace NHSD.GPIT.BuyingCatalogue.WebApp.Models
             {
                 OrderWrapper = OrderWrapper,
                 ItemName = itemName,
-                FromPreviousRevision = solution.CatalogueItem.CatalogueItemType != CatalogueItemType.Solution
-                    && solution.Order.Revision < OrderWrapper.Order.Revision,
+                FromPreviousRevision = fromPreviousRevision,
             };
 
             if (Order.OrderType.MergerOrSplit)

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/NHSD.GPIT.BuyingCatalogue.WebApp.csproj
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/NHSD.GPIT.BuyingCatalogue.WebApp.csproj
@@ -30,26 +30,30 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.17.0" />
-    <PackageReference Include="Enums.NET" Version="4.0.0" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Enums.NET" Version="5.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.0.2" />
-    <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="10.0.1" />
-    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.3.3">
+    <PackageReference Include="Humanizer.Core" Version="3.0.10" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.14.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="10.0.7" />
+    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="6.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="NuGet.Packaging" Version="7.3.1" />
     <PackageReference Include="NuGet.Protocol" Version="7.3.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
-    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-    <PackageReference Include="Serilog.Sinks.Seq" Version="6.0.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="5.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/Views/OrderSummary/Index.cshtml
@@ -324,7 +324,7 @@
                                 <h3>@group.Key</h3>
                                 @foreach (var service in group)
                                 {
-                                    var itemModel = Model.BuildAmendOrderItemModel(service, solutionName);
+                                    var itemModel = Model.BuildAmendOrderItemModel(service, solutionName, true);
                                     <partial name="OrderItem" model="@itemModel" />
                                 }
                             }

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/tsconfig.json
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/tsconfig.json
@@ -6,6 +6,8 @@
     "removeComments": true,
     "sourceMap": true,
     "target": "es6",
+    "strictNullChecks": false,
+    "noImplicitThis": false,
     "outDir": "wwwroot/js",
     "rootDir": "wwwroot/ts",
     "lib": [

--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/wwwroot/ts/suggestionSearchConfig.ts
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/wwwroot/ts/suggestionSearchConfig.ts
@@ -10,7 +10,7 @@ type SourceFunction = (
 interface AccessibleAutocompleteOptions {
     element: HTMLElement;
     id: string;
-    source: string[] | SourceFunction;
+    source: (query: string, populateResults: (values: string[]) => void) => void;
     name?: string;
     confirmOnBlur?: boolean;
     onConfirm?(confirmed: string): void;

--- a/tests/BuyingCatalogueFunctionUnitTests/BuyingCatalogueFunctionUnitTests.csproj
+++ b/tests/BuyingCatalogueFunctionUnitTests/BuyingCatalogueFunctionUnitTests.csproj
@@ -15,17 +15,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.17.0" />
-    <PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NSubstitute" Version="4.4.0" />
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.Idioms" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/BuyingCatalogueFunctionUnitTests/EpicsAndCapabilities/Services/CapabilityServiceTests.cs
+++ b/tests/BuyingCatalogueFunctionUnitTests/EpicsAndCapabilities/Services/CapabilityServiceTests.cs
@@ -8,13 +8,9 @@ using AutoFixture.Xunit2;
 using BuyingCatalogueFunction.EpicsAndCapabilities.Models;
 using BuyingCatalogueFunction.EpicsAndCapabilities.Services;
 using FluentAssertions;
-using Microsoft.CodeAnalysis.Elfie.Diagnostics;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Catalogue.Models;
-using NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.Attributes;
-using NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.AutoFixtureCustomisations;
 using Xunit;
 
 namespace BuyingCatalogueFunctionTests.EpicsAndCapabilities.Services

--- a/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework/NHSD.GPIT.BuyingCatalogue.E2ETests.Framework.csproj
@@ -7,13 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="34.0.2" />
+    <PackageReference Include="Bogus" Version="35.6.5" />
     <PackageReference Include="DotNetSeleniumExtras.PageObjects" Version="3.11.0" />
     <PackageReference Include="FluentAssertions" Version="[7.1.0,8.0.0)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1" />
-    <PackageReference Include="Polly" Version="7.2.3" />
-    <PackageReference Include="Selenium.Support" Version="4.35.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.35.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+    <PackageReference Include="Selenium.Support" Version="4.43.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.43.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
   </ItemGroup>
 

--- a/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests/NHSD.GPIT.BuyingCatalogue.EntityFramework.UnitTests.csproj
@@ -16,19 +16,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
-      <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PackageReference Include="AutoFixture.Idioms" Version="4.18.1" />
+      <PackageReference Include="coverlet.collector" Version="10.0.0">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
       <PackageReference Include="FluentAssertions" Version="[7.1.0,8.0.0)" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
       <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="xunit" Version="2.9.3" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>

--- a/tests/NHSD.GPIT.BuyingCatalogue.Framework.UnitTests/NHSD.GPIT.BuyingCatalogue.Framework.UnitTests.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Framework.UnitTests/NHSD.GPIT.BuyingCatalogue.Framework.UnitTests.csproj
@@ -17,23 +17,24 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="AutoFixture.Idioms" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="[7.1.0,8.0.0)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NSubstitute" Version="4.4.0 " />
+    <PackageReference Include="Humanizer.Core" Version="3.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/NHSD.GPIT.BuyingCatalogue.RegressionTests.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.RegressionTests/NHSD.GPIT.BuyingCatalogue.RegressionTests.csproj
@@ -9,21 +9,22 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="[7.1.0,8.0.0)" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Selenium.Support" Version="4.35.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.35.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
+    <PackageReference Include="Humanizer.Core" Version="3.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Selenium.Support" Version="4.43.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.43.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="140.0.7339.8000" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="147.0.7727.11700" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/NHSD.GPIT.BuyingCatalogue.ServiceContracts.UnitTests/NHSD.GPIT.BuyingCatalogue.ServiceContracts.UnitTests.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.ServiceContracts.UnitTests/NHSD.GPIT.BuyingCatalogue.ServiceContracts.UnitTests.csproj
@@ -17,23 +17,23 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.17.0" />
-    <PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
-    <PackageReference Include="AutoFixture.xUnit2" Version="4.17.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.Idioms" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.xUnit2" Version="4.18.1" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="[7.1.0,8.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="10.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NSubstitute" Version="4.4.0 " />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="10.0.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests.csproj
@@ -17,25 +17,25 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.17.0" />
-    <PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
-    <PackageReference Include="AutoFixture.xUnit2" Version="4.17.0" />
-    <PackageReference Include="Bogus" Version="34.0.2" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.Idioms" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.xUnit2" Version="4.18.1" />
+    <PackageReference Include="Bogus" Version="35.6.5" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="[7.1.0,8.0.0)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NSubstitute" Version="4.4.0 " />
-    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/NHSD.GPIT.BuyingCatalogue.UI.Components.UnitTests/NHSD.GPIT.BuyingCatalogue.UI.Components.UnitTests.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.UI.Components.UnitTests/NHSD.GPIT.BuyingCatalogue.UI.Components.UnitTests.csproj
@@ -15,20 +15,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.xUnit2" Version="4.17.0" />
-    <PackageReference Include="Bogus" Version="34.0.2" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="AutoFixture.xUnit2" Version="4.18.1" />
+    <PackageReference Include="Bogus" Version="35.6.5" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="[7.1.0,8.0.0)" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/NHSD.GPIT.BuyingCatalogue.UnitTest.Framework/NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.UnitTest.Framework/NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.csproj
@@ -18,23 +18,23 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.17.0" />
-    <PackageReference Include="AutoFixture.xUnit2" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.xUnit2" Version="4.18.1" />
     <PackageReference Include="FluentAssertions" Version="[7.1.0,8.0.0)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="10.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NSubstitute" Version="4.4.0 " />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="10.0.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.csproj
+++ b/tests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests/NHSD.GPIT.BuyingCatalogue.WebApp.UnitTests.csproj
@@ -17,23 +17,23 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />
-    <PackageReference Include="AutoFixture.xUnit2" Version="4.17.0" />
-    <PackageReference Include="Bogus" Version="34.0.2" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="AutoFixture.Idioms" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.xUnit2" Version="4.18.1" />
+    <PackageReference Include="Bogus" Version="35.6.5" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="[7.1.0,8.0.0)" />
     <PackageReference Include="FluentValidation" Version="11.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NSubstitute" Version="4.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
# Description

1. Update NuGet versions due to known vulnerabilities
2. Resolve Order PDF bug for orders. `OrderItem.Order` isn't cloned as part of the `OrderWrapper` logic so it's best to explicitly set `fromPreviousRevision` to true when dealing with associated services from previous orders. Otherwise it'll throw exceptions when generating the Order PDF as there's an attempt to access `OrderItem.Order` for solutions and additional services when it would be null