### PR TITLE
Add page object model folder and classes for the order journey

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.WebApp/appsettings.development.json
+++ b/src/NHSD.GPIT.BuyingCatalogue.WebApp/appsettings.development.json
@@ -6,6 +6,9 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
+  "recaptchaSettings": {
+    "isEnabled": false
+  },
   "analytics": {
     "adobe": {
       "fileName": "launch-e817a46c2dc5-development.min.js"
@@ -15,7 +18,7 @@
     }
   },
   "azureBlobSettings": {
-    "connectionString": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10003/devstoreaccount1;",
+    "connectionString": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10003/devstoreaccount1;"
   },
   "callOffTerms": {
     "url": "https://digital.nhs.uk/"

--- a/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Base/BasePage.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Base/BasePage.cs
@@ -1,0 +1,30 @@
+﻿using System.Text.RegularExpressions;
+using Microsoft.Playwright;
+using static Microsoft.Playwright.Assertions;
+
+namespace NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Base;
+
+public abstract class BasePage
+{
+    protected readonly IPage Page;
+
+    protected BasePage(IPage page)
+    {
+        Page = page;
+    }
+
+    protected async Task ClickSaveAndContinueAsync() =>
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Save and continue" }).ClickAsync();
+
+    protected async Task ClickSaveAndContinueLinkAsync() =>
+        await Page.GetByRole(AriaRole.Link, new() { Name = "Save and continue" }).ClickAsync();
+
+    protected async Task ClickContinueLinkAsync() =>
+        await Page.GetByRole(AriaRole.Link, new() { Name = "Continue" }).ClickAsync();
+
+    protected async Task AssertHeadingAsync(string heading) =>
+        await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = heading })).ToBeVisibleAsync();
+
+    protected async Task AssertUrlContainsAsync(string fragment) =>
+        await Expect(Page).ToHaveURLAsync(new Regex(fragment));
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Login/LoginPage.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Login/LoginPage.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Playwright;
+using NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Base;
+
+namespace NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Login;
+
+public class LoginPage : BasePage
+{
+    private ILocator LoginLink => Page.GetByRole(AriaRole.Link, new() { Name = "Log in" });
+    private ILocator EmailInput => Page.GetByLabel("Email");
+    private ILocator PasswordInput => Page.GetByLabel("Password");
+    private ILocator LoginButton => Page.GetByRole(AriaRole.Button, new() { Name = "Log in" });
+
+    public LoginPage(IPage page) : base(page) { }
+
+    public async Task NavigateAsync(string baseUrl)
+    {
+        await Page.GotoAsync(baseUrl);
+        await LoginLink.ClickAsync();
+    }
+
+    public async Task LoginAsync(string email, string password)
+    {
+        await EmailInput.FillAsync(email);
+        await PasswordInput.FillAsync(password);
+        await LoginButton.ClickAsync();
+    }
+
+    public async Task AssertOnLoginPageAsync() =>
+        await AssertUrlContainsAsync("login");
+
+    public async Task AssertLoginSuccessfulAsync() =>
+        await AssertHeadingAsync("Your organisation's dashboard");
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/Dashboard/OrderingDashboardPage.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/Dashboard/OrderingDashboardPage.cs
@@ -1,0 +1,26 @@
+﻿using System.Text.RegularExpressions;
+using Microsoft.Playwright;
+using NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Base;
+
+namespace NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Ordering.Dashboard;
+
+public class OrderingDashboardPage : BasePage
+{
+    public OrderingDashboardPage(IPage page) : base(page) { }
+
+    public async Task AssertOnDashboardAsync() =>
+        await AssertHeadingAsync("Your organisation's dashboard");
+
+    public async Task GoToOrdersAsync()
+    {        
+        await Page.Locator("li.nhsuk-card-group__item").Filter(new() { HasText = "orders" })
+                      .GetByRole(AriaRole.Link, new() { Name = "View orders" })
+                      .ClickAsync();
+        await AssertHeadingAsync("Your organisation's orders");
+    }
+
+    public async Task CreateNewOrderAsync()
+    {
+        await Page.GetByRole(AriaRole.Link, new() { Name = "Create new order" }).ClickAsync();
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/OrderType/OrderTypePage.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/OrderType/OrderTypePage.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Playwright;
+using NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Base;
+
+namespace NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Ordering.OrderType;
+
+public enum OrderTypeOption { CatalogueSolution, AssociatedService }
+public enum FrameworkType { TechInnovation }
+
+public class OrderTypePage : BasePage
+{
+    private ILocator StartOrderButton => Page.GetByRole(AriaRole.Button, new() { Name = "Start order" });
+    private ILocator CatalogueOptionLink => Page.GetByText("Catalogue solution and other");
+    private ILocator AssociatedOptionLink => Page.GetByText("Associated service only");
+
+    public OrderTypePage(IPage page) : base(page) { }
+
+    public async Task SelectOrderTypeAsync(OrderTypeOption orderType = OrderTypeOption.CatalogueSolution)
+    {
+        await StartOrderButton.ClickAsync();
+
+        switch (orderType)
+        {
+            case OrderTypeOption.CatalogueSolution: await CatalogueOptionLink.ClickAsync(); break;
+            case OrderTypeOption.AssociatedService: await AssociatedOptionLink.ClickAsync(); break;
+        }
+
+        await ClickSaveAndContinueAsync();
+    }
+
+    public async Task SelectFrameworkAsync(FrameworkType framework = FrameworkType.TechInnovation)
+    {
+        var name = framework switch
+        {
+            FrameworkType.TechInnovation => "Tech Innovation",
+            _ => throw new ArgumentOutOfRangeException(nameof(framework))
+        };
+
+        await Page.GetByRole(AriaRole.Radio, new() { Name = name }).CheckAsync();
+        await ClickSaveAndContinueAsync();
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepFour/ReviewOrderPage.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepFour/ReviewOrderPage.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Playwright;
+using NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Base;
+
+namespace NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Ordering.StepFour;
+
+public class ReviewOrderPage : BasePage
+{
+    private ILocator NavigationLink => Page.GetByRole(AriaRole.Link, new() { Name = "Review and complete order" });
+    private ILocator CompleteOrderButton => Page.GetByRole(AriaRole.Button, new() { Name = "Complete order" });
+
+    public ReviewOrderPage(IPage page) : base(page) { }
+
+    public async Task NavigateAsync()
+    {
+        await NavigationLink.ClickAsync();
+        await AssertHeadingAsync("Review and complete order");
+    }
+
+    public async Task CompleteOrderAsync()
+    {
+        await CompleteOrderButton.ClickAsync();
+        await AssertHeadingAsync("Order completed");
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepOne/OrderDescriptionPage.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepOne/OrderDescriptionPage.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Playwright;
+using NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Base;
+
+namespace NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Ordering.StepOne;
+
+public class OrderDescriptionPage : BasePage
+{
+    private ILocator NavigationLink => Page.GetByRole(AriaRole.Link, new() { Name = "Order description" });
+    private ILocator DescriptionInput => Page.GetByRole(AriaRole.Textbox, new() { Name = "Order description" });
+
+    public OrderDescriptionPage(IPage page) : base(page) { }
+
+    public async Task NavigateAsync() =>
+        await NavigationLink.ClickAsync();
+
+    public async Task EnterDescriptionAsync(string description)
+    {
+        await DescriptionInput.ClearAsync();
+        await DescriptionInput.FillAsync(description);
+        await ClickSaveAndContinueAsync();
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepOne/PrimaryContactPage.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepOne/PrimaryContactPage.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Playwright;
+using NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Base;
+
+namespace NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Ordering.StepOne;
+
+public class PrimaryContactPage : BasePage
+{
+    private ILocator NavigationLink => Page.GetByRole(AriaRole.Link, new() { Name = "Primary contact details" });
+    private ILocator FirstNameInput => Page.GetByRole(AriaRole.Textbox, new() { Name = "First name" });
+    private ILocator LastNameInput => Page.GetByRole(AriaRole.Textbox, new() { Name = "Last name" });
+    private ILocator PhoneInput => Page.GetByRole(AriaRole.Textbox, new() { Name = "Telephone number" });
+    private ILocator EmailInput => Page.GetByRole(AriaRole.Textbox, new() { Name = "Email address" });
+
+    public PrimaryContactPage(IPage page) : base(page) { }
+
+    public async Task NavigateAsync() =>
+        await NavigationLink.ClickAsync();
+
+    public async Task EnterContactDetailsAsync(string firstName, string lastName, string phone, string email)
+    {
+        await FirstNameInput.FillAsync(firstName);
+        await LastNameInput.FillAsync(lastName);
+        await PhoneInput.FillAsync(phone);
+        await EmailInput.FillAsync(email);
+        await ClickSaveAndContinueAsync();
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepOne/SupplierPage.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepOne/SupplierPage.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Playwright;
+using NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Base;
+
+namespace NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Ordering.StepOne;
+
+public class SupplierPage : BasePage
+{
+    private ILocator NavigationLink => Page.GetByRole(AriaRole.Link, new() { Name = "Supplier information and" });
+    private ILocator SupplierInput => Page.Locator("input[role='combobox']:visible");
+    private ILocator SuggestionsList => Page.Locator("ul[role='listbox']:visible");
+    private ILocator YesRadio => Page.GetByLabel("Yes");
+    private ILocator ConfirmButton => Page.GetByRole(AriaRole.Button, new() { Name = "Confirm supplier" });
+
+    public SupplierPage(IPage page) : base(page) { }
+
+    public async Task NavigateAsync() =>
+        await NavigationLink.ClickAsync();
+
+    public async Task SearchAndSelectSupplierAsync(string supplierName)
+    {
+        await SupplierInput.WaitForAsync(new() { State = WaitForSelectorState.Visible });
+        await SupplierInput.ClickAsync();
+        await SupplierInput.FillAsync(string.Empty);
+        await SupplierInput.PressSequentiallyAsync(supplierName);
+
+        await SuggestionsList.WaitForAsync(new() { State = WaitForSelectorState.Visible });
+        await SuggestionsList.GetByText(supplierName, new() { Exact = true }).ClickAsync();
+
+        await ClickSaveAndContinueAsync();
+    }
+
+    public async Task ConfirmSupplierAsync()
+    {
+        await YesRadio.CheckAsync();
+        await ConfirmButton.ClickAsync();
+        await AssertHeadingAsync("Supplier contact details");
+        await ClickSaveAndContinueAsync();
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepOne/TimescalesPage.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepOne/TimescalesPage.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Playwright;
+using NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Base;
+
+namespace NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Ordering.StepOne;
+
+public class TimescalesPage : BasePage
+{
+    private ILocator NavigationLink => Page.GetByRole(AriaRole.Link, new() { Name = "Timescales for call-off agreement" });
+    private ILocator DayInput => Page.GetByRole(AriaRole.Textbox, new() { Name = "Day" });
+    private ILocator MonthInput => Page.GetByRole(AriaRole.Textbox, new() { Name = "Month", Exact = true });
+    private ILocator YearInput => Page.GetByRole(AriaRole.Textbox, new() { Name = "Year" });
+    private ILocator InitialPeriodInput => Page.GetByRole(AriaRole.Textbox, new() { Name = "What is the call-off agreement initial period (in months)?" });
+    private ILocator DurationInput => Page.GetByRole(AriaRole.Textbox, new() { Name = "What is the call-off agreement duration (in months)?" });
+
+    public TimescalesPage(IPage page) : base(page) { }
+
+    public async Task NavigateAsync() =>
+        await NavigationLink.ClickAsync();
+
+    public async Task EnterTimescalesAsync(string day, string month, string year, string initialPeriod, string duration)
+    {
+        await AssertHeadingAsync("Timescales for call-off agreement");
+        await DayInput.FillAsync(day);
+        await MonthInput.FillAsync(month);
+        await YearInput.FillAsync(year);
+        await InitialPeriodInput.FillAsync(initialPeriod);
+        await DurationInput.FillAsync(duration);
+        await ClickSaveAndContinueAsync();
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepThree/DataProcessingPage.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepThree/DataProcessingPage.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Playwright;
+using NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Base;
+
+namespace NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Ordering.StepThree;
+
+public class DataProcessingPage : BasePage
+{
+    private ILocator NavigationLink => Page.GetByRole(AriaRole.Link, new() { Name = "Data processing information" });
+
+    public DataProcessingPage(IPage page) : base(page) { }
+
+    public async Task NavigateAndContinueAsync()
+    {
+        await NavigationLink.ClickAsync();
+        await AssertHeadingAsync("Data processing information");
+        await ClickSaveAndContinueAsync();
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepThree/DeclarationPage.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepThree/DeclarationPage.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Playwright;
+using NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Base;
+
+namespace NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Ordering.StepThree;
+
+public class DeclarationPage : BasePage
+{
+    private ILocator NavigationLink => Page.GetByRole(AriaRole.Link, new() { Name = "Declaration" });
+    private ILocator AgreeCheckbox => Page.GetByRole(AriaRole.Checkbox, new() { Name = "I understand and agree to the" });
+
+    public DeclarationPage(IPage page) : base(page) { }
+
+    public async Task NavigateAndAgreeAsync()
+    {
+        await NavigationLink.ClickAsync();
+        await AssertHeadingAsync("Declaration");
+        await AgreeCheckbox.CheckAsync();
+        await ClickSaveAndContinueAsync();
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepThree/ImplementationMilestonesPage.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepThree/ImplementationMilestonesPage.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Playwright;
+using NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Base;
+
+namespace NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Ordering.StepThree;
+
+public class ImplementationMilestonesPage : BasePage
+{
+    private ILocator NavigationLink => Page.GetByRole(AriaRole.Link, new() { Name = "Implementation milestones and payment triggers" });
+
+    public ImplementationMilestonesPage(IPage page) : base(page) { }
+
+    public async Task NavigateAndContinueAsync()
+    {
+        await NavigationLink.ClickAsync();
+        await AssertHeadingAsync("Implementation milestones and payment triggers");
+        await ClickSaveAndContinueAsync();
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepTwo/FundingSourcesPage.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepTwo/FundingSourcesPage.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Playwright;
+using NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Base;
+
+namespace NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Ordering.StepTwo;
+
+public class FundingSourcesPage : BasePage
+{
+    private ILocator NavigationLink => Page.GetByRole(AriaRole.Link, new() { Name = "Select funding sources" });
+
+    public FundingSourcesPage(IPage page) : base(page) { }
+
+    public async Task NavigateAsync() =>
+        await NavigationLink.ClickAsync();
+
+    public async Task SelectFundingAsync(string solutionName, string fundingType)
+    {
+        await AssertHeadingAsync("Funding sources");
+        await Page.GetByRole(AriaRole.Row)
+            .Filter(new() { HasText = solutionName })
+            .GetByRole(AriaRole.Link, new() { Name = "Start" })
+            .ClickAsync();
+        await Page.GetByRole(AriaRole.Radio, new() { Name = fundingType }).CheckAsync();
+        await ClickSaveAndContinueAsync();
+        await AssertHeadingAsync("Funding sources");
+        await ClickSaveAndContinueAsync();
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepTwo/PlannedDeliveryDatesPage.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepTwo/PlannedDeliveryDatesPage.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Playwright;
+using NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Base;
+
+namespace NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Ordering.StepTwo;
+
+public class PlannedDeliveryDatesPage : BasePage
+{
+    private ILocator NavigationLink => Page.GetByRole(AriaRole.Link, new() { Name = "Planned delivery dates" });
+    private ILocator DayInput => Page.GetByRole(AriaRole.Textbox, new() { Name = "Day" });
+    private ILocator MonthInput => Page.GetByRole(AriaRole.Textbox, new() { Name = "Month" });
+    private ILocator YearInput => Page.GetByRole(AriaRole.Textbox, new() { Name = "Year" });
+    private ILocator YesRadio => Page.GetByRole(AriaRole.Radio, new() { Name = "Yes" });
+
+    public PlannedDeliveryDatesPage(IPage page) : base(page) { }
+
+    public async Task NavigateAsync() =>
+        await NavigationLink.ClickAsync();
+
+    public async Task EnterDeliveryDateAsync(string day, string month, string year)
+    {
+        await AssertHeadingAsync("Planned delivery date");
+        await DayInput.FillAsync(day);
+        await MonthInput.FillAsync(month);
+        await YearInput.FillAsync(year);
+        await YesRadio.CheckAsync();
+        await ClickSaveAndContinueAsync();
+        await AssertHeadingAsync("Review planned delivery dates");
+        await ClickSaveAndContinueLinkAsync();
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepTwo/QuantityPage.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepTwo/QuantityPage.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Playwright;
+using NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Base;
+
+namespace NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Ordering.StepTwo;
+
+public class QuantityPage : BasePage
+{
+    private ILocator StartLink => Page.GetByRole(AriaRole.Link, new() { Name = "Start" });
+    private ILocator SelectLink => Page.GetByRole(AriaRole.Link, new() { Name = "Select" });
+
+    public QuantityPage(IPage page) : base(page) { }
+
+    public async Task EnterQuantitiesAsync(Dictionary<string, string> practiceQuantities)
+    {
+        await AssertHeadingAsync("Catalogue solution and services");
+        await StartLink.ClickAsync();
+
+        await AssertHeadingAsync("Quantity of catalogue solution");
+        await SelectLink.ClickAsync();
+
+        foreach (var (practice, quantity) in practiceQuantities)
+            await Page.GetByRole(AriaRole.Row, new() { Name = practice })
+                .GetByLabel("Patient total")
+                .FillAsync(quantity);
+
+        await ClickSaveAndContinueAsync();
+        await AssertHeadingAsync("Quantity of catalogue solution");
+        await ClickSaveAndContinueAsync();
+
+        await AssertHeadingAsync("Confirm quantities");
+        await ClickContinueLinkAsync();
+
+        await AssertHeadingAsync("Edit solutions and services");
+        await ClickSaveAndContinueLinkAsync();
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepTwo/ServiceRecipientsPage.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepTwo/ServiceRecipientsPage.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.Playwright;
+using NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Base;
+
+namespace NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Ordering.StepTwo;
+
+public class ServiceRecipientsPage : BasePage
+{
+    private ILocator NavigationLink => Page.GetByRole(AriaRole.Link, new() { Name = "service recipients" });
+    private ILocator ManualOption => Page.GetByLabel("Add service recipients manually");
+    private ILocator SelectLink => Page.GetByRole(AriaRole.Link, new() { Name = "Select" });
+
+    public ServiceRecipientsPage(IPage page) : base(page) { }
+
+    public async Task NavigateAsync() =>
+        await NavigationLink.ClickAsync();
+
+    public async Task SelectRecipientsManuallyAsync(string sublocation, string[] practices)
+    {
+        await ManualOption.CheckAsync();
+        await ClickSaveAndContinueAsync();
+        await SelectSublocationAsync(sublocation);
+        await SelectPracticesAsync(practices);
+        await ConfirmRecipientsAsync();
+    }
+
+    private async Task SelectSublocationAsync(string sublocation)
+    {
+        await AssertHeadingAsync("Select sublocations for this order");
+        await Page.GetByRole(AriaRole.Checkbox, new() { Name = sublocation }).CheckAsync();
+        await ClickSaveAndContinueAsync();
+    }
+
+    private async Task SelectPracticesAsync(string[] practices)
+    {
+        await AssertHeadingAsync("Confirm sublocations");
+        await SelectLink.ClickAsync();
+
+        foreach (var practice in practices)
+            await Page.GetByRole(AriaRole.Checkbox, new() { Name = practice }).CheckAsync();
+
+        await ClickSaveAndContinueAsync();
+        await AssertHeadingAsync("Confirm sublocations");
+        await ClickSaveAndContinueAsync();
+    }
+
+    private async Task ConfirmRecipientsAsync()
+    {
+        await AssertHeadingAsync("Confirm service recipients");
+        await ClickSaveAndContinueLinkAsync();
+    }
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepTwo/SolutionsAndServicesPage.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.PlaywrightTests/Pages/Ordering/StepTwo/SolutionsAndServicesPage.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Playwright;
+using NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Base;
+
+namespace NHSD.GPIT.BuyingCatalogue.PlaywrightTests.Pages.Ordering.StepTwo;
+
+public class SolutionsAndServicesPage : BasePage
+{
+    private ILocator NavigationLink => Page.GetByRole(AriaRole.Link, new() { Name = "Solutions and services" });
+    private ILocator StartLink => Page.GetByRole(AriaRole.Link, new() { Name = "Start" });
+
+    public SolutionsAndServicesPage(IPage page) : base(page) { }
+
+    public async Task NavigateAsync() =>
+        await NavigationLink.ClickAsync();
+
+    public async Task SelectCatalogueSolutionAsync(string solutionName)
+    {
+        await AssertHeadingAsync("Catalogue solutions");
+        await Page.GetByRole(AriaRole.Radio, new() { Name = solutionName }).CheckAsync();
+        await ClickSaveAndContinueAsync();
+    }
+
+    public async Task SelectPriceAsync()
+    {
+        await AssertHeadingAsync("Catalogue solution and services");
+        await StartLink.ClickAsync();
+        await AssertHeadingAsync("Price of Catalogue solution");
+        await ClickSaveAndContinueAsync();
+    }
+}


### PR DESCRIPTION
Builds on the core framework for end-to-end test automation.
Created assertions to Playwright's Expect() for built-in auto-retry to reduce flakiness.
Centralised locators within each page object for easier maintenance.