### PR TITLE
Remove linear dependencies in ORDER tasklist

### DIFF
--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/AssociatedServiceRequirementsStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/AssociatedServiceRequirementsStatusProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Linq;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders;
@@ -10,29 +10,27 @@ public class AssociatedServiceRequirementsStatusProvider : ITaskProgressProvider
 {
     public TaskProgress Get(OrderWrapper wrapper, OrderProgress state)
     {
-        if (wrapper?.Order == null
-            || state == null)
+        if (wrapper?.Order is null
+            || state is null)
         {
             return TaskProgress.CannotStart;
         }
 
         var order = wrapper.Order;
+
         if (!HasAssociatedServices(order))
         {
             return TaskProgress.NotApplicable;
         }
 
-        var planStatus = new[] { TaskProgress.Completed, TaskProgress.NotApplicable };
-        var requirementsEntered = order.Contract?.ContractBilling?.HasConfirmedRequirements ?? false;
+        var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
 
-        if (!planStatus.Contains(state.AssociatedServiceBilling)
-            && requirementsEntered)
+        if (!okToProgress.Contains(state.SolutionOrService))
         {
-            return TaskProgress.InProgress;
+            return TaskProgress.CannotStart;
         }
 
-        if (state.AssociatedServiceBilling != TaskProgress.Completed)
-            return TaskProgress.CannotStart;
+        var requirementsEntered = order.Contract?.ContractBilling?.HasConfirmedRequirements ?? false;
 
         return requirementsEntered
             ? TaskProgress.Completed

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/AssociatedServiceRequirementsStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/AssociatedServiceRequirementsStatusProvider.cs
@@ -1,6 +1,4 @@
-﻿using System.Linq;
-using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
-using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
+﻿using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.TaskList;
 
@@ -18,14 +16,12 @@ public class AssociatedServiceRequirementsStatusProvider : ITaskProgressProvider
 
         var order = wrapper.Order;
 
-        if (!HasAssociatedServices(order))
+        if (!TaskListStatusService.HasAssociatedServices(order))
         {
             return TaskProgress.NotApplicable;
         }
 
-        var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
-
-        if (!okToProgress.Contains(state.SolutionOrService))
+        if (!TaskListStatusService.IsTaskCompleted(state.SolutionOrService))
         {
             return TaskProgress.CannotStart;
         }
@@ -36,8 +32,4 @@ public class AssociatedServiceRequirementsStatusProvider : ITaskProgressProvider
             ? TaskProgress.Completed
             : TaskProgress.NotStarted;
     }
-
-    private static bool HasAssociatedServices(Order order) =>
-        order.OrderType.AssociatedServicesOnly
-        || order.HasAssociatedService();
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/AssociatedServicesMilestonesStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/AssociatedServicesMilestonesStatusProvider.cs
@@ -1,6 +1,4 @@
-﻿using System.Linq;
-using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
-using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
+﻿using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.TaskList;
 
@@ -18,14 +16,12 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
 
             var order = wrapper.Order;
 
-            if (!HasAssociatedServices(order))
+            if (!TaskListStatusService.HasAssociatedServices(order))
             {
                 return TaskProgress.NotApplicable;
             }
 
-            var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
-
-            if (!okToProgress.Contains(state.SolutionOrService))
+            if (!TaskListStatusService.IsTaskCompleted(state.SolutionOrService))
             {
                 return TaskProgress.CannotStart;
             }
@@ -36,9 +32,5 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
                 ? TaskProgress.Completed
                 : TaskProgress.NotStarted;
         }
-
-        private static bool HasAssociatedServices(Order order) =>
-            order.OrderType.AssociatedServicesOnly
-            || order.HasAssociatedService();
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/AssociatedServicesMilestonesStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/AssociatedServicesMilestonesStatusProvider.cs
@@ -10,8 +10,8 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
     {
         public TaskProgress Get(OrderWrapper wrapper, OrderProgress state)
         {
-            if (wrapper?.Order == null
-                || state == null)
+            if (wrapper?.Order is null
+                || state is null)
             {
                 return TaskProgress.CannotStart;
             }
@@ -23,22 +23,14 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
                 return TaskProgress.NotApplicable;
             }
 
-            var fundingSourceStatus = new[] { TaskProgress.Completed, TaskProgress.Amended };
-            var planStatus = new[] { TaskProgress.Completed, TaskProgress.NotApplicable, TaskProgress.Amended };
-            var contractBillingEntered = order.Contract?.ContractBilling is not null;
+            var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
 
-            if ((!fundingSourceStatus.Contains(state.FundingSource)
-                    || !planStatus.Contains(state.ImplementationPlan))
-                && contractBillingEntered)
+            if (!okToProgress.Contains(state.SolutionOrService))
             {
-                return TaskProgress.InProgress;
+                return TaskProgress.CannotStart;
             }
 
-            if ((state.ImplementationPlan != TaskProgress.Completed)
-                && (state.ImplementationPlan != TaskProgress.Amended)
-                && (state.ImplementationPlan != TaskProgress.NotApplicable
-                    || state.FundingSource != TaskProgress.Completed))
-                return TaskProgress.CannotStart;
+            var contractBillingEntered = order.Contract?.ContractBilling is not null;
 
             return contractBillingEntered
                 ? TaskProgress.Completed

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/CommencementDateStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/CommencementDateStatusProvider.cs
@@ -9,11 +9,9 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
     {
         public TaskProgress Get(OrderWrapper wrapper, OrderProgress state)
         {
-            var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
-
             if (wrapper?.Order is null
                 || state is null
-                || !okToProgress.Contains(state.DescriptionStatus))
+                || !TaskListStatusService.IsTaskCompleted(state.DescriptionStatus))
             {
                 return TaskProgress.CannotStart;
             }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/CommencementDateStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/CommencementDateStatusProvider.cs
@@ -9,14 +9,11 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
     {
         public TaskProgress Get(OrderWrapper wrapper, OrderProgress state)
         {
-            if (wrapper?.Order == null
-                || state == null)
-            {
-                return TaskProgress.CannotStart;
-            }
+            var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
 
-            if (state.SupplierStatus != TaskProgress.Completed
-                && state.SupplierStatus != TaskProgress.Amended)
+            if (wrapper?.Order is null
+                || state is null
+                || !okToProgress.Contains(state.DescriptionStatus))
             {
                 return TaskProgress.CannotStart;
             }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/DataProcessingStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/DataProcessingStatusProvider.cs
@@ -27,16 +27,15 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
 
         private static bool DependentTasksComplete(OrderProgress state)
         {
-            var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
-            return !(!okToProgress.Contains(state.DescriptionStatus)
-                || !okToProgress.Contains(state.OrderingPartyStatus)
-                || !okToProgress.Contains(state.SupplierStatus)
-                || !okToProgress.Contains(state.CommencementDateStatus)
-                || !okToProgress.Contains(state.ServiceRecipients)
-                || !okToProgress.Contains(state.SolutionOrService)
-                || !okToProgress.Contains(state.DeliveryDates)
-                || !okToProgress.Contains(state.FundingSource)
-                || !okToProgress.Contains(state.ImplementationPlan)
+            return !(!TaskListStatusService.IsTaskCompleted(state.DescriptionStatus)
+                || !TaskListStatusService.IsTaskCompleted(state.OrderingPartyStatus)
+                || !TaskListStatusService.IsTaskCompleted(state.SupplierStatus)
+                || !TaskListStatusService.IsTaskCompleted(state.CommencementDateStatus)
+                || !TaskListStatusService.IsTaskCompleted(state.ServiceRecipients)
+                || !TaskListStatusService.IsTaskCompleted(state.SolutionOrService)
+                || !TaskListStatusService.IsTaskCompleted(state.DeliveryDates)
+                || !TaskListStatusService.IsTaskCompleted(state.FundingSource)
+                || !TaskListStatusService.IsTaskCompleted(state.ImplementationPlan)
                 || !AssociatedServiceTaskComplete(state.AssociatedServiceBilling)
                 || !AssociatedServiceTaskComplete(state.AssociatedServiceRequirements));
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/DataProcessingStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/DataProcessingStatusProvider.cs
@@ -9,32 +9,42 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
     {
         public TaskProgress Get(OrderWrapper wrapper, OrderProgress state)
         {
-            if (wrapper?.Order == null
-                || state == null)
+            if (wrapper?.Order is null
+                || state is null)
             {
                 return TaskProgress.CannotStart;
             }
 
-            var order = wrapper.Order;
+            if (!DependentTasksComplete(state))
+            {
+                return TaskProgress.CannotStart;
+            }
 
+            return wrapper.Order.ContractFlags?.UseDefaultDataProcessing == true
+                ? TaskProgress.Completed
+                : TaskProgress.NotStarted;
+        }
+
+        private static bool DependentTasksComplete(OrderProgress state)
+        {
             var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
+            return !(!okToProgress.Contains(state.DescriptionStatus)
+                || !okToProgress.Contains(state.OrderingPartyStatus)
+                || !okToProgress.Contains(state.SupplierStatus)
+                || !okToProgress.Contains(state.CommencementDateStatus)
+                || !okToProgress.Contains(state.ServiceRecipients)
+                || !okToProgress.Contains(state.SolutionOrService)
+                || !okToProgress.Contains(state.DeliveryDates)
+                || !okToProgress.Contains(state.FundingSource)
+                || !okToProgress.Contains(state.ImplementationPlan)
+                || !AssociatedServiceTaskComplete(state.AssociatedServiceBilling)
+                || !AssociatedServiceTaskComplete(state.AssociatedServiceRequirements));
+        }
 
-            if ((!okToProgress.Contains(state.FundingSource)
-                || (state.AssociatedServiceRequirements != TaskProgress.Completed && state.AssociatedServiceRequirements != TaskProgress.NotApplicable))
-                && order.ContractFlags?.UseDefaultDataProcessing == true)
-            {
-                return TaskProgress.InProgress;
-            }
-
-            if ((state.AssociatedServiceRequirements == TaskProgress.Completed)
-                || (state.AssociatedServiceRequirements == TaskProgress.NotApplicable && okToProgress.Contains(state.ImplementationPlan)))
-            {
-                return order.ContractFlags?.UseDefaultDataProcessing == true
-                    ? TaskProgress.Completed
-                    : TaskProgress.NotStarted;
-            }
-
-            return TaskProgress.CannotStart;
+        private static bool AssociatedServiceTaskComplete(TaskProgress associatedServiceTaskState)
+        {
+            var okToProgress = new[] { TaskProgress.Completed, TaskProgress.NotApplicable };
+            return okToProgress.Contains(associatedServiceTaskState);
         }
     }
 }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/DeliveryDatesStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/DeliveryDatesStatusProvider.cs
@@ -35,9 +35,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
 
             var defaultDeliveryDateEntered = order.DeliveryDate.HasValue;
 
-            var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
-
-            if (!okToProgress.Contains(state.SolutionOrService)
+            if (!TaskListStatusService.IsTaskCompleted(state.SolutionOrService)
                 && !anyDeliveryDatesEntered)
             {
                 return TaskProgress.CannotStart;
@@ -47,7 +45,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
 
             if (allDeliveryDatesSet && (wrapper.HasNewOrderRecipients || wrapper.HasNewOrderItems))
             {
-                return order.IsAmendment ? TaskProgress.Amended : TaskProgress.Completed;
+                return TaskListStatusService.CompletedOrAmended(order.IsAmendment);
             }
 
             if ((anyDeliveryDatesEntered || defaultDeliveryDateEntered) && wrapper.HasNewOrderRecipients)

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/FundingSourceStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/FundingSourceStatusProvider.cs
@@ -19,22 +19,15 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
 
             var anyFundingSourcesEntered = AnyFundingSourcesEntered(wrapper.OrderItems);
 
-            var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
-
-            if (!okToProgress.Contains(state.SolutionOrService)
+            if (!TaskListStatusService.IsTaskCompleted(state.SolutionOrService)
                 && !anyFundingSourcesEntered)
             {
                 return TaskProgress.CannotStart;
             }
 
             return AllFundingSourcesEntered(wrapper)
-                ? CompletedOrAmended(wrapper.IsAmendment)
+                ? TaskListStatusService.CompletedOrAmended(wrapper.IsAmendment)
                 : (anyFundingSourcesEntered ? TaskProgress.InProgress : TaskProgress.NotStarted);
-        }
-
-        private static TaskProgress CompletedOrAmended(bool isAmendment)
-        {
-            return isAmendment ? TaskProgress.Amended : TaskProgress.Completed;
         }
 
         private static bool AllFundingSourcesEntered(OrderWrapper wrapper)

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/FundingSourceStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/FundingSourceStatusProvider.cs
@@ -11,8 +11,8 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
     {
         public TaskProgress Get(OrderWrapper wrapper, OrderProgress state)
         {
-            if (wrapper?.Order == null
-                || state == null)
+            if (wrapper?.Order is null
+                || state is null)
             {
                 return TaskProgress.CannotStart;
             }
@@ -21,7 +21,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
 
             var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
 
-            if (!okToProgress.Contains(state.DeliveryDates)
+            if (!okToProgress.Contains(state.SolutionOrService)
                 && !anyFundingSourcesEntered)
             {
                 return TaskProgress.CannotStart;
@@ -40,7 +40,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
         private static bool AllFundingSourcesEntered(OrderWrapper wrapper)
         {
             return wrapper.Order.SelectedFramework != null
-                && wrapper.OrderItems.Any()
+                && wrapper.OrderItems.Count != 0
                 && wrapper.OrderItems.All(x => x.OrderItemFunding != null);
         }
 

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/ImplementationPlanStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/ImplementationPlanStatusProvider.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
+﻿using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.TaskList;
 
@@ -9,11 +8,9 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
     {
         public TaskProgress Get(OrderWrapper wrapper, OrderProgress state)
         {
-            var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
-
             if (wrapper?.Order is null
                 || state is null
-                || !okToProgress.Contains(state.DescriptionStatus))
+                || !TaskListStatusService.IsTaskCompleted(state.DescriptionStatus))
             {
                 return TaskProgress.CannotStart;
             }
@@ -26,7 +23,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
             }
 
             return order.Contract?.ImplementationPlan is not null
-                ? order.IsAmendment ? TaskProgress.Amended : TaskProgress.Completed
+                ? TaskListStatusService.CompletedOrAmended(order.IsAmendment)
                 : TaskProgress.NotStarted;
         }
     }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/ImplementationPlanStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/ImplementationPlanStatusProvider.cs
@@ -9,8 +9,11 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
     {
         public TaskProgress Get(OrderWrapper wrapper, OrderProgress state)
         {
-            if (wrapper?.Order == null
-                || state == null)
+            var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
+
+            if (wrapper?.Order is null
+                || state is null
+                || !okToProgress.Contains(state.DescriptionStatus))
             {
                 return TaskProgress.CannotStart;
             }
@@ -22,16 +25,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
                 return TaskProgress.NotApplicable;
             }
 
-            var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
-
-            if (!okToProgress.Contains(state.FundingSource))
-            {
-                return order.Contract?.ImplementationPlan != null
-                    ? TaskProgress.InProgress
-                    : TaskProgress.CannotStart;
-            }
-
-            return order.Contract?.ImplementationPlan != null
+            return order.Contract?.ImplementationPlan is not null
                 ? order.IsAmendment ? TaskProgress.Amended : TaskProgress.Completed
                 : TaskProgress.NotStarted;
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/ServiceRecipientsStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/ServiceRecipientsStatusProvider.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
+﻿using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.TaskList;
 
@@ -9,11 +8,9 @@ public class ServiceRecipientsStatusProvider : ITaskProgressProvider
 {
     public TaskProgress Get(OrderWrapper wrapper, OrderProgress state)
     {
-        var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
-
         if (wrapper?.Order is null
             || state is null
-            || !okToProgress.Contains(state.DescriptionStatus))
+            || !TaskListStatusService.IsTaskCompleted(state.DescriptionStatus))
         {
             return TaskProgress.CannotStart;
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/ServiceRecipientsStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/ServiceRecipientsStatusProvider.cs
@@ -9,8 +9,11 @@ public class ServiceRecipientsStatusProvider : ITaskProgressProvider
 {
     public TaskProgress Get(OrderWrapper wrapper, OrderProgress state)
     {
+        var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
+
         if (wrapper?.Order is null
-            || state is null || state.CommencementDateStatus != TaskProgress.Completed)
+            || state is null
+            || !okToProgress.Contains(state.DescriptionStatus))
         {
             return TaskProgress.CannotStart;
         }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/SolutionOrServiceStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/SolutionOrServiceStatusProvider.cs
@@ -13,14 +13,12 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
     {
         public TaskProgress Get(OrderWrapper wrapper, OrderProgress state)
         {
-            if (wrapper?.Order == null
-                || state == null)
-            {
-                return TaskProgress.CannotStart;
-            }
-
             var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
-            if (!okToProgress.Contains(state.ServiceRecipients))
+
+            if (wrapper?.Order is null
+                || state is null
+                || !okToProgress.Contains(state.ServiceRecipients)
+                || !okToProgress.Contains(state.SupplierStatus))
             {
                 return TaskProgress.CannotStart;
             }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/SolutionOrServiceStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/SolutionOrServiceStatusProvider.cs
@@ -13,12 +13,10 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
     {
         public TaskProgress Get(OrderWrapper wrapper, OrderProgress state)
         {
-            var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
-
             if (wrapper?.Order is null
                 || state is null
-                || !okToProgress.Contains(state.ServiceRecipients)
-                || !okToProgress.Contains(state.SupplierStatus))
+                || !TaskListStatusService.IsTaskCompleted(state.ServiceRecipients)
+                || !TaskListStatusService.IsTaskCompleted(state.SupplierStatus))
             {
                 return TaskProgress.CannotStart;
             }
@@ -31,13 +29,8 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
             }
 
             return SolutionsCompleted(wrapper)
-                ? CompletedOrAmended(order.IsAmendment)
+                ? TaskListStatusService.CompletedOrAmended(order.IsAmendment)
                 : TaskProgress.InProgress;
-        }
-
-        private static TaskProgress CompletedOrAmended(bool isAmendment)
-        {
-            return isAmendment ? TaskProgress.Amended : TaskProgress.Completed;
         }
 
         private static bool ValidCatalogueItems(OrderWrapper orderWrapper)

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/SupplierStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/SupplierStatusProvider.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
+﻿using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.TaskList;
 
@@ -9,11 +8,9 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
     {
         public TaskProgress Get(OrderWrapper wrapper, OrderProgress state)
         {
-            var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
-
             if (wrapper?.Order is null
                 || state is null
-                || !okToProgress.Contains(state.DescriptionStatus))
+                || !TaskListStatusService.IsTaskCompleted(state.DescriptionStatus))
             {
                 return TaskProgress.CannotStart;
             }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/SupplierStatusProvider.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/SupplierStatusProvider.cs
@@ -1,4 +1,5 @@
-﻿using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
+﻿using System.Linq;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Orders;
 using NHSD.GPIT.BuyingCatalogue.ServiceContracts.TaskList;
 
@@ -8,26 +9,23 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers
     {
         public TaskProgress Get(OrderWrapper wrapper, OrderProgress state)
         {
-            if (wrapper?.Order == null
-                || state == null)
-            {
-                return TaskProgress.CannotStart;
-            }
+            var okToProgress = new[] { TaskProgress.Completed, TaskProgress.Amended };
 
-            if (state.OrderingPartyStatus != TaskProgress.Completed
-                && state.OrderingPartyStatus != TaskProgress.Amended)
+            if (wrapper?.Order is null
+                || state is null
+                || !okToProgress.Contains(state.DescriptionStatus))
             {
                 return TaskProgress.CannotStart;
             }
 
             var order = wrapper.Order;
 
-            if (order.Supplier == null)
+            if (order.Supplier is null)
             {
                 return TaskProgress.NotStarted;
             }
 
-            if (order.SupplierContact == null)
+            if (order.SupplierContact is null)
             {
                 return TaskProgress.InProgress;
             }

--- a/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/TaskListStatusService.cs
+++ b/src/NHSD.GPIT.BuyingCatalogue.Services/TaskList/Providers/TaskListStatusService.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
+
+namespace NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers;
+
+public static class TaskListStatusService
+{
+    private static readonly TaskProgress[] TaskCompleteStatuses = [TaskProgress.Completed, TaskProgress.Amended];
+
+    public static bool IsTaskCompleted(TaskProgress taskStatus) =>
+        TaskCompleteStatuses.Contains(taskStatus);
+
+    public static TaskProgress CompletedOrAmended(bool isAmendment) =>
+        isAmendment ? TaskProgress.Amended : TaskProgress.Completed;
+
+    public static bool HasAssociatedServices(Order order) =>
+        order == null
+        ? throw new ArgumentNullException(nameof(order))
+        : order.OrderType.AssociatedServicesOnly || order.HasAssociatedService();
+}

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/AssociatedServicesMilestonesStatusProviderTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/AssociatedServicesMilestonesStatusProviderTests.cs
@@ -13,6 +13,11 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
 {
     public static class AssociatedServicesMilestonesStatusProviderTests
     {
+        private static readonly OrderProgress ValidOrderState = new()
+        {
+            SolutionOrService = TaskProgress.Completed,
+        };
+
         [Theory]
         [MockAutoData]
         public static void Get_OrderWrapperIsNull_ReturnsCannotStart(
@@ -64,86 +69,14 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         [MockInlineAutoData(TaskProgress.NotApplicable)]
         [MockInlineAutoData(TaskProgress.NotStarted)]
         [MockInlineAutoData(TaskProgress.Optional)]
-        public static void Get_FundingSourceIncomplete_ContractBillingEntered_ReturnsInProgress(
+        public static void Get_SolutionOrServiceNotComplete_ReturnsCannotStart(
             TaskProgress status,
             Order order,
             AssociatedServicesMilestonesStatusProvider service)
         {
             var state = new OrderProgress
             {
-                FundingSource = status,
-            };
-
-            order.OrderType = OrderTypeEnum.AssociatedServiceOther;
-            order.Contract = new Contract() { ContractBilling = new ContractBilling(), };
-
-            var actual = service.Get(new OrderWrapper(order), state);
-
-            actual.Should().Be(TaskProgress.InProgress);
-        }
-
-        [Theory]
-        [MockInlineAutoData(TaskProgress.CannotStart)]
-        [MockInlineAutoData(TaskProgress.InProgress)]
-        [MockInlineAutoData(TaskProgress.NotStarted)]
-        [MockInlineAutoData(TaskProgress.Optional)]
-        public static void Get_ImplementationPlanIncomplete_ContractBillingEntered_ReturnsInProgress(
-            TaskProgress status,
-            Order order,
-            AssociatedServicesMilestonesStatusProvider service)
-        {
-            var state = new OrderProgress
-            {
-                ImplementationPlan = status,
-            };
-
-            order.OrderType = OrderTypeEnum.AssociatedServiceOther;
-            order.Contract = new Contract() { ContractBilling = new ContractBilling(), };
-
-            var actual = service.Get(new OrderWrapper(order), state);
-
-            actual.Should().Be(TaskProgress.InProgress);
-        }
-
-        [Theory]
-        [MockInlineAutoData(TaskProgress.CannotStart)]
-        [MockInlineAutoData(TaskProgress.InProgress)]
-        [MockInlineAutoData(TaskProgress.NotApplicable)]
-        [MockInlineAutoData(TaskProgress.NotStarted)]
-        [MockInlineAutoData(TaskProgress.Optional)]
-        public static void Get_FundingSourceIncomplete_ImplementationPlanNotApplicable_ReturnsCannotStart(
-            TaskProgress status,
-            Order order,
-            AssociatedServicesMilestonesStatusProvider service)
-        {
-            var state = new OrderProgress
-            {
-                FundingSource = status,
-                ImplementationPlan = TaskProgress.NotApplicable,
-            };
-
-            order.OrderType = OrderTypeEnum.AssociatedServiceOther;
-            order.Contract = null;
-
-            var actual = service.Get(new OrderWrapper(order), state);
-
-            actual.Should().Be(TaskProgress.CannotStart);
-        }
-
-        [Theory]
-        [MockInlineAutoData(TaskProgress.CannotStart)]
-        [MockInlineAutoData(TaskProgress.InProgress)]
-        [MockInlineAutoData(TaskProgress.NotStarted)]
-        [MockInlineAutoData(TaskProgress.Optional)]
-        public static void Get_ImplementationPlanIncomplete_ReturnsCannotStart(
-            TaskProgress status,
-            Order order,
-            AssociatedServicesMilestonesStatusProvider service)
-        {
-            var state = new OrderProgress
-            {
-                FundingSource = TaskProgress.Completed,
-                ImplementationPlan = status,
+                SolutionOrService = status,
             };
 
             order.OrderType = OrderTypeEnum.AssociatedServiceOther;
@@ -160,15 +93,10 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             Order order,
             AssociatedServicesMilestonesStatusProvider service)
         {
-            var state = new OrderProgress
-            {
-                ImplementationPlan = TaskProgress.Completed,
-            };
-
             order.OrderType = OrderTypeEnum.AssociatedServiceOther;
             order.Contract = null;
 
-            var actual = service.Get(new OrderWrapper(order), state);
+            var actual = service.Get(new OrderWrapper(order), ValidOrderState);
 
             actual.Should().Be(TaskProgress.NotStarted);
         }
@@ -179,15 +107,10 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             Order order,
             AssociatedServicesMilestonesStatusProvider service)
         {
-            var state = new OrderProgress
-            {
-                ImplementationPlan = TaskProgress.Completed,
-            };
-
             order.OrderType = OrderTypeEnum.AssociatedServiceOther;
             order.Contract = new Contract();
 
-            var actual = service.Get(new OrderWrapper(order), state);
+            var actual = service.Get(new OrderWrapper(order), ValidOrderState);
 
             actual.Should().Be(TaskProgress.NotStarted);
         }
@@ -198,16 +121,10 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             Order order,
             AssociatedServicesMilestonesStatusProvider service)
         {
-            var state = new OrderProgress
-            {
-                FundingSource = TaskProgress.Completed,
-                ImplementationPlan = TaskProgress.Completed,
-            };
-
             order.OrderType = OrderTypeEnum.AssociatedServiceOther;
             order.Contract = new Contract() { ContractBilling = new ContractBilling(), };
 
-            var actual = service.Get(new OrderWrapper(order), state);
+            var actual = service.Get(new OrderWrapper(order), ValidOrderState);
 
             actual.Should().Be(TaskProgress.Completed);
         }
@@ -218,16 +135,10 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             Order order,
             AssociatedServicesMilestonesStatusProvider service)
         {
-            var state = new OrderProgress
-            {
-                FundingSource = TaskProgress.Completed,
-                ImplementationPlan = TaskProgress.Completed,
-            };
-
             order.OrderType = OrderTypeEnum.AssociatedServiceOther;
             order.Contract = new Contract() { ContractBilling = new ContractBilling() { HasConfirmedRequirements = true, }, };
 
-            var actual = service.Get(new OrderWrapper(order), state);
+            var actual = service.Get(new OrderWrapper(order), ValidOrderState);
 
             actual.Should().Be(TaskProgress.Completed);
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/AssociatedServicesRequirementsStatusProviderTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/AssociatedServicesRequirementsStatusProviderTests.cs
@@ -13,133 +13,104 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers;
 
 public static class AssociatedServicesRequirementsStatusProviderTests
 {
-        [Theory]
-        [MockAutoData]
-        public static void Get_OrderWrapperIsNull_ReturnsCannotStart(
-            AssociatedServiceRequirementsStatusProvider service)
+    private static readonly OrderProgress ValidOrderState = new()
+    {
+        SolutionOrService = TaskProgress.Completed,
+    };
+
+    [Theory]
+    [MockAutoData]
+    public static void Get_OrderWrapperIsNull_ReturnsCannotStart(
+        AssociatedServiceRequirementsStatusProvider service)
+    {
+        var actual = service.Get(null, new OrderProgress());
+
+        actual.Should().Be(TaskProgress.CannotStart);
+    }
+
+    [Theory]
+    [MockAutoData]
+    public static void Get_OrderIsNull_ReturnsCannotStart(
+        AssociatedServiceRequirementsStatusProvider service)
+    {
+        var actual = service.Get(new OrderWrapper(), new OrderProgress());
+
+        actual.Should().Be(TaskProgress.CannotStart);
+    }
+
+    [Theory]
+    [MockAutoData]
+    public static void Get_StateIsNull_ReturnsCannotStart(
+        Order order,
+        AssociatedServiceRequirementsStatusProvider service)
+    {
+        var actual = service.Get(new OrderWrapper(order), null);
+
+        actual.Should().Be(TaskProgress.CannotStart);
+    }
+
+    [Theory]
+    [MockAutoData]
+    public static void Get_NoAssociatedServices_ReturnsNotApplicable(
+        Order order,
+        AssociatedServiceRequirementsStatusProvider service)
+    {
+        order.OrderType = OrderTypeEnum.Solution;
+        order.OrderItems.ForEach(x => x.CatalogueItem.CatalogueItemType = CatalogueItemType.AdditionalService);
+
+        var actual = service.Get(new OrderWrapper(order), new OrderProgress());
+
+        actual.Should().Be(TaskProgress.NotApplicable);
+    }
+
+    [Theory]
+    [MockInlineAutoData(TaskProgress.CannotStart)]
+    [MockInlineAutoData(TaskProgress.InProgress)]
+    [MockInlineAutoData(TaskProgress.NotStarted)]
+    [MockInlineAutoData(TaskProgress.Optional)]
+    public static void Get_ValidOrderStateNotComplete_ReturnsCannotStart(
+        TaskProgress status,
+        Order order,
+        AssociatedServiceRequirementsStatusProvider service)
+    {
+        var state = new OrderProgress
         {
-            var actual = service.Get(null, new OrderProgress());
+            SolutionOrService = status,
+        };
 
-            actual.Should().Be(TaskProgress.CannotStart);
-        }
+        order.OrderType = OrderTypeEnum.AssociatedServiceOther;
+        order.Contract = null;
 
-        [Theory]
-        [MockAutoData]
-        public static void Get_OrderIsNull_ReturnsCannotStart(
-            AssociatedServiceRequirementsStatusProvider service)
-        {
-            var actual = service.Get(new OrderWrapper(), new OrderProgress());
+        var actual = service.Get(new OrderWrapper(order), state);
 
-            actual.Should().Be(TaskProgress.CannotStart);
-        }
+        actual.Should().Be(TaskProgress.CannotStart);
+    }
 
-        [Theory]
-        [MockAutoData]
-        public static void Get_StateIsNull_ReturnsCannotStart(
-            Order order,
-            AssociatedServiceRequirementsStatusProvider service)
-        {
-            var actual = service.Get(new OrderWrapper(order), null);
+    [Theory]
+    [MockAutoData]
+    public static void Get_NoContractInfoEntered_ReturnsNotStarted(
+        Order order,
+        AssociatedServiceRequirementsStatusProvider service)
+    {
+        order.OrderType = OrderTypeEnum.AssociatedServiceOther;
+        order.Contract = new Contract { ContractBilling = new ContractBilling { HasConfirmedRequirements = false }, };
 
-            actual.Should().Be(TaskProgress.CannotStart);
-        }
+        var actual = service.Get(new OrderWrapper(order), ValidOrderState);
 
-        [Theory]
-        [MockAutoData]
-        public static void Get_NoAssociatedServices_ReturnsNotApplicable(
-            Order order,
-            AssociatedServiceRequirementsStatusProvider service)
-        {
-            order.OrderType = OrderTypeEnum.Solution;
-            order.OrderItems.ForEach(x => x.CatalogueItem.CatalogueItemType = CatalogueItemType.AdditionalService);
+        actual.Should().Be(TaskProgress.NotStarted);
+    }
 
-            var actual = service.Get(new OrderWrapper(order), new OrderProgress());
+    [Theory]
+    [MockAutoData]
+    public static void Get_RequirementsCompleted_ReturnsInCompleted(
+        Order order,
+        AssociatedServiceRequirementsStatusProvider service)
+    {
+        order.OrderType = OrderTypeEnum.AssociatedServiceOther;
+        order.Contract = new Contract() { ContractBilling = new ContractBilling() { HasConfirmedRequirements = true, }, };
 
-            actual.Should().Be(TaskProgress.NotApplicable);
-        }
+        var actual = service.Get(new OrderWrapper(order), ValidOrderState);
 
-        [Theory]
-        [MockInlineAutoData(TaskProgress.CannotStart)]
-        [MockInlineAutoData(TaskProgress.InProgress)]
-        [MockInlineAutoData(TaskProgress.NotStarted)]
-        [MockInlineAutoData(TaskProgress.Optional)]
-        public static void Get_MilestonesIncomplete_RequirementsEntered_ReturnsInProgress(
-            TaskProgress status,
-            Order order,
-            AssociatedServiceRequirementsStatusProvider service)
-        {
-            var state = new OrderProgress
-            {
-                AssociatedServiceBilling = status,
-            };
-
-            order.OrderType = OrderTypeEnum.AssociatedServiceOther;
-            order.Contract = new Contract { ContractBilling = new ContractBilling { HasConfirmedRequirements = true }, };
-
-            var actual = service.Get(new OrderWrapper(order), state);
-
-            actual.Should().Be(TaskProgress.InProgress);
-        }
-
-        [Theory]
-        [MockInlineAutoData(TaskProgress.CannotStart)]
-        [MockInlineAutoData(TaskProgress.InProgress)]
-        [MockInlineAutoData(TaskProgress.NotStarted)]
-        [MockInlineAutoData(TaskProgress.Optional)]
-        public static void Get_MilestonesIncomplete_ReturnsCannotStart(
-            TaskProgress status,
-            Order order,
-            AssociatedServiceRequirementsStatusProvider service)
-        {
-            var state = new OrderProgress
-            {
-                FundingSource = TaskProgress.Completed,
-                AssociatedServiceBilling = status,
-            };
-
-            order.OrderType = OrderTypeEnum.AssociatedServiceOther;
-            order.Contract = null;
-
-            var actual = service.Get(new OrderWrapper(order), state);
-
-            actual.Should().Be(TaskProgress.CannotStart);
-        }
-
-        [Theory]
-        [MockAutoData]
-        public static void Get_NoContractInfoEntered_ReturnsNotStarted(
-            Order order,
-            AssociatedServiceRequirementsStatusProvider service)
-        {
-            var state = new OrderProgress
-            {
-                AssociatedServiceBilling = TaskProgress.Completed,
-            };
-
-            order.OrderType = OrderTypeEnum.AssociatedServiceOther;
-            order.Contract = new Contract { ContractBilling = new ContractBilling { HasConfirmedRequirements = false }, };
-
-            var actual = service.Get(new OrderWrapper(order), state);
-
-            actual.Should().Be(TaskProgress.NotStarted);
-        }
-
-        [Theory]
-        [MockAutoData]
-        public static void Get_RequirementsCompleted_ReturnsInCompleted(
-            Order order,
-            AssociatedServiceRequirementsStatusProvider service)
-        {
-            var state = new OrderProgress
-            {
-                AssociatedServiceBilling = TaskProgress.Completed,
-            };
-
-            order.OrderType = OrderTypeEnum.AssociatedServiceOther;
-            order.Contract = new Contract() { ContractBilling = new ContractBilling() { HasConfirmedRequirements = true, }, };
-
-            var actual = service.Get(new OrderWrapper(order), state);
-
-            actual.Should().Be(TaskProgress.Completed);
-        }
+        actual.Should().Be(TaskProgress.Completed);
+    }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/CommencementDateStatusProviderTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/CommencementDateStatusProviderTests.cs
@@ -49,14 +49,14 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         [MockInlineAutoData(TaskProgress.NotApplicable)]
         [MockInlineAutoData(TaskProgress.NotStarted)]
         [MockInlineAutoData(TaskProgress.Optional)]
-        public static void Get_SupplierStatusNotComplete_ReturnsCannotStart(
-            TaskProgress supplierStatus,
+        public static void Get_DescriptionStatusNotComplete_ReturnsCannotStart(
+            TaskProgress descriptionStatus,
             Order order,
             CommencementDateStatusProvider service)
         {
             var state = new OrderProgress
             {
-                SupplierStatus = supplierStatus,
+                DescriptionStatus = descriptionStatus,
             };
 
             var actual = service.Get(new OrderWrapper(order), state);
@@ -68,13 +68,13 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         [MockInlineAutoData(TaskProgress.Completed)]
         [MockInlineAutoData(TaskProgress.Amended)]
         public static void Get_TimescalesNotStarted_ReturnsNotStarted(
-            TaskProgress supplierStatus,
+            TaskProgress descriptionStatus,
             Order order,
             CommencementDateStatusProvider service)
         {
             var state = new OrderProgress
             {
-                SupplierStatus = supplierStatus,
+                DescriptionStatus = descriptionStatus,
             };
 
             order.CommencementDate = null;
@@ -90,13 +90,13 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         [MockInlineAutoData(TaskProgress.Completed)]
         [MockInlineAutoData(TaskProgress.Amended)]
         public static void Get_OnlyCommencementDateSpecified_ReturnsInProgress(
-            TaskProgress supplierStatus,
+            TaskProgress descriptionStatus,
             Order order,
             CommencementDateStatusProvider service)
         {
             var state = new OrderProgress
             {
-                SupplierStatus = supplierStatus,
+                DescriptionStatus = descriptionStatus,
             };
 
             order.CommencementDate = DateTime.UtcNow;
@@ -114,7 +114,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         [MockInlineAutoData(TaskProgress.Completed, null, 6)]
         [MockInlineAutoData(TaskProgress.Amended, null, 6)]
         public static void Get_MaximumTermAndInitialPeriod_ReturnsInProgress(
-            TaskProgress supplierStatus,
+            TaskProgress descriptionStatus,
             int? maximumTerm,
             int? initialPeriod,
             Order order,
@@ -122,7 +122,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         {
             var state = new OrderProgress
             {
-                SupplierStatus = supplierStatus,
+                DescriptionStatus = descriptionStatus,
             };
 
             order.CommencementDate = null;
@@ -138,13 +138,13 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         [MockInlineAutoData(TaskProgress.Completed)]
         [MockInlineAutoData(TaskProgress.Amended)]
         public static void Get_ReturnsCompleted(
-            TaskProgress supplierStatus,
+            TaskProgress descriptionStatus,
             Order order,
             CommencementDateStatusProvider service)
         {
             var state = new OrderProgress
             {
-                SupplierStatus = supplierStatus,
+                DescriptionStatus = descriptionStatus,
             };
 
             order.CommencementDate = DateTime.UtcNow;

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/DataProcessingStatusProviderTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/DataProcessingStatusProviderTests.cs
@@ -17,7 +17,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             DataProcessingStatusProvider service)
         {
             var actual = service.Get(null, new OrderProgress());
-
             actual.Should().Be(TaskProgress.CannotStart);
         }
 
@@ -27,7 +26,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             DataProcessingStatusProvider service)
         {
             var actual = service.Get(new OrderWrapper(), new OrderProgress());
-
             actual.Should().Be(TaskProgress.CannotStart);
         }
 
@@ -38,113 +36,256 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             DataProcessingStatusProvider service)
         {
             var actual = service.Get(new OrderWrapper(order), null);
-
             actual.Should().Be(TaskProgress.CannotStart);
         }
 
         [Theory]
         [MockAutoData]
-        public static void Get_FundingSourceAndAssociatedServiceBillingIncomplete_ReturnsCannotStart(
+        public static void Get_AllDependentTaskCannotStart_ReturnsCannotStart(
             Order order,
             DataProcessingStatusProvider service)
         {
-            var state = new OrderProgress
-            {
-                FundingSource = TaskProgress.InProgress,
-                AssociatedServiceBilling = TaskProgress.InProgress,
-            };
-
+            var state = new OrderProgress();
             order.ContractFlags = null;
-
             var actual = service.Get(new OrderWrapper(order), state);
-
             actual.Should().Be(TaskProgress.CannotStart);
         }
 
         [Theory]
-        [MockInlineAutoData(TaskProgress.CannotStart)]
-        [MockInlineAutoData(TaskProgress.InProgress)]
+        [MockInlineAutoData(OrderTaskListStatus.Description, TaskProgress.CannotStart)]
+        [MockInlineAutoData(OrderTaskListStatus.Description, TaskProgress.InProgress)]
+        [MockInlineAutoData(OrderTaskListStatus.Description, TaskProgress.NotStarted)]
+        [MockInlineAutoData(OrderTaskListStatus.Description, TaskProgress.Optional)]
+        [MockInlineAutoData(OrderTaskListStatus.OrderingParty, TaskProgress.CannotStart)]
+        [MockInlineAutoData(OrderTaskListStatus.OrderingParty, TaskProgress.InProgress)]
+        [MockInlineAutoData(OrderTaskListStatus.OrderingParty, TaskProgress.NotStarted)]
+        [MockInlineAutoData(OrderTaskListStatus.OrderingParty, TaskProgress.Optional)]
+        [MockInlineAutoData(OrderTaskListStatus.Supplier, TaskProgress.CannotStart)]
+        [MockInlineAutoData(OrderTaskListStatus.Supplier, TaskProgress.InProgress)]
+        [MockInlineAutoData(OrderTaskListStatus.Supplier, TaskProgress.NotStarted)]
+        [MockInlineAutoData(OrderTaskListStatus.Supplier, TaskProgress.Optional)]
+        [MockInlineAutoData(OrderTaskListStatus.CommencementDate, TaskProgress.CannotStart)]
+        [MockInlineAutoData(OrderTaskListStatus.CommencementDate, TaskProgress.InProgress)]
+        [MockInlineAutoData(OrderTaskListStatus.CommencementDate, TaskProgress.NotStarted)]
+        [MockInlineAutoData(OrderTaskListStatus.CommencementDate, TaskProgress.Optional)]
+        [MockInlineAutoData(OrderTaskListStatus.ServiceRecipients, TaskProgress.CannotStart)]
+        [MockInlineAutoData(OrderTaskListStatus.ServiceRecipients, TaskProgress.InProgress)]
+        [MockInlineAutoData(OrderTaskListStatus.ServiceRecipients, TaskProgress.NotStarted)]
+        [MockInlineAutoData(OrderTaskListStatus.ServiceRecipients, TaskProgress.Optional)]
+        [MockInlineAutoData(OrderTaskListStatus.SolutionsOrServices, TaskProgress.CannotStart)]
+        [MockInlineAutoData(OrderTaskListStatus.SolutionsOrServices, TaskProgress.InProgress)]
+        [MockInlineAutoData(OrderTaskListStatus.SolutionsOrServices, TaskProgress.NotStarted)]
+        [MockInlineAutoData(OrderTaskListStatus.SolutionsOrServices, TaskProgress.Optional)]
+        [MockInlineAutoData(OrderTaskListStatus.DeliveryDates, TaskProgress.CannotStart)]
+        [MockInlineAutoData(OrderTaskListStatus.DeliveryDates, TaskProgress.InProgress)]
+        [MockInlineAutoData(OrderTaskListStatus.DeliveryDates, TaskProgress.NotStarted)]
+        [MockInlineAutoData(OrderTaskListStatus.DeliveryDates, TaskProgress.Optional)]
+        [MockInlineAutoData(OrderTaskListStatus.FundingSources, TaskProgress.CannotStart)]
+        [MockInlineAutoData(OrderTaskListStatus.FundingSources, TaskProgress.InProgress)]
+        [MockInlineAutoData(OrderTaskListStatus.FundingSources, TaskProgress.NotStarted)]
+        [MockInlineAutoData(OrderTaskListStatus.FundingSources, TaskProgress.Optional)]
+        [MockInlineAutoData(OrderTaskListStatus.ImplementationPlan, TaskProgress.CannotStart)]
+        [MockInlineAutoData(OrderTaskListStatus.ImplementationPlan, TaskProgress.InProgress)]
+        [MockInlineAutoData(OrderTaskListStatus.ImplementationPlan, TaskProgress.NotStarted)]
+        [MockInlineAutoData(OrderTaskListStatus.ImplementationPlan, TaskProgress.Optional)]
+        public static void Get_DependentTaskNotComplete_HasService_ReturnsICannotStart(
+            OrderTaskListStatus task,
+            TaskProgress status,
+            Order order,
+            DataProcessingStatusProvider service)
+        {
+            var state = GetDependentTaskOrderProgress(task, status, true);
+            var actual = service.Get(new OrderWrapper(order), state);
+            actual.Should().Be(TaskProgress.CannotStart);
+        }
+
+        [Theory]
+        [MockInlineAutoData(OrderTaskListStatus.Description, TaskProgress.CannotStart)]
+        [MockInlineAutoData(OrderTaskListStatus.Description, TaskProgress.InProgress)]
+        [MockInlineAutoData(OrderTaskListStatus.Description, TaskProgress.NotStarted)]
+        [MockInlineAutoData(OrderTaskListStatus.Description, TaskProgress.Optional)]
+        [MockInlineAutoData(OrderTaskListStatus.OrderingParty, TaskProgress.CannotStart)]
+        [MockInlineAutoData(OrderTaskListStatus.OrderingParty, TaskProgress.InProgress)]
+        [MockInlineAutoData(OrderTaskListStatus.OrderingParty, TaskProgress.NotStarted)]
+        [MockInlineAutoData(OrderTaskListStatus.OrderingParty, TaskProgress.Optional)]
+        [MockInlineAutoData(OrderTaskListStatus.Supplier, TaskProgress.CannotStart)]
+        [MockInlineAutoData(OrderTaskListStatus.Supplier, TaskProgress.InProgress)]
+        [MockInlineAutoData(OrderTaskListStatus.Supplier, TaskProgress.NotStarted)]
+        [MockInlineAutoData(OrderTaskListStatus.Supplier, TaskProgress.Optional)]
+        [MockInlineAutoData(OrderTaskListStatus.CommencementDate, TaskProgress.CannotStart)]
+        [MockInlineAutoData(OrderTaskListStatus.CommencementDate, TaskProgress.InProgress)]
+        [MockInlineAutoData(OrderTaskListStatus.CommencementDate, TaskProgress.NotStarted)]
+        [MockInlineAutoData(OrderTaskListStatus.CommencementDate, TaskProgress.Optional)]
+        [MockInlineAutoData(OrderTaskListStatus.ServiceRecipients, TaskProgress.CannotStart)]
+        [MockInlineAutoData(OrderTaskListStatus.ServiceRecipients, TaskProgress.InProgress)]
+        [MockInlineAutoData(OrderTaskListStatus.ServiceRecipients, TaskProgress.NotStarted)]
+        [MockInlineAutoData(OrderTaskListStatus.ServiceRecipients, TaskProgress.Optional)]
+        [MockInlineAutoData(OrderTaskListStatus.SolutionsOrServices, TaskProgress.CannotStart)]
+        [MockInlineAutoData(OrderTaskListStatus.SolutionsOrServices, TaskProgress.InProgress)]
+        [MockInlineAutoData(OrderTaskListStatus.SolutionsOrServices, TaskProgress.NotStarted)]
+        [MockInlineAutoData(OrderTaskListStatus.SolutionsOrServices, TaskProgress.Optional)]
+        [MockInlineAutoData(OrderTaskListStatus.DeliveryDates, TaskProgress.CannotStart)]
+        [MockInlineAutoData(OrderTaskListStatus.DeliveryDates, TaskProgress.InProgress)]
+        [MockInlineAutoData(OrderTaskListStatus.DeliveryDates, TaskProgress.NotStarted)]
+        [MockInlineAutoData(OrderTaskListStatus.DeliveryDates, TaskProgress.Optional)]
+        [MockInlineAutoData(OrderTaskListStatus.FundingSources, TaskProgress.CannotStart)]
+        [MockInlineAutoData(OrderTaskListStatus.FundingSources, TaskProgress.InProgress)]
+        [MockInlineAutoData(OrderTaskListStatus.FundingSources, TaskProgress.NotStarted)]
+        [MockInlineAutoData(OrderTaskListStatus.FundingSources, TaskProgress.Optional)]
+        [MockInlineAutoData(OrderTaskListStatus.ImplementationPlan, TaskProgress.CannotStart)]
+        [MockInlineAutoData(OrderTaskListStatus.ImplementationPlan, TaskProgress.InProgress)]
+        [MockInlineAutoData(OrderTaskListStatus.ImplementationPlan, TaskProgress.NotStarted)]
+        [MockInlineAutoData(OrderTaskListStatus.ImplementationPlan, TaskProgress.Optional)]
+        public static void Get_DependentTaskNotComplete_NoService_ReturnsICannotStart(
+            OrderTaskListStatus task,
+            TaskProgress status,
+            Order order,
+            DataProcessingStatusProvider service)
+        {
+            var state = GetDependentTaskOrderProgress(task, status, false);
+            var actual = service.Get(new OrderWrapper(order), state);
+            actual.Should().Be(TaskProgress.CannotStart);
+        }
+
+        [Theory]
+        [MockInlineAutoData(OrderTaskListStatus.AssociatedServicesBilling, TaskProgress.CannotStart)]
+        [MockInlineAutoData(OrderTaskListStatus.AssociatedServicesBilling, TaskProgress.NotStarted)]
+        [MockInlineAutoData(OrderTaskListStatus.AssociatedServicesRequirements, TaskProgress.CannotStart)]
+        [MockInlineAutoData(OrderTaskListStatus.AssociatedServicesRequirements, TaskProgress.NotStarted)]
+        public static void Get_AssociatedServiceTaskNotComplete_HasService_ReturnsCannotStart(
+            OrderTaskListStatus task,
+            TaskProgress status,
+            Order order,
+            DataProcessingStatusProvider service)
+        {
+            var state = GetDependentTaskOrderProgress(task, status, true);
+            var actual = service.Get(new OrderWrapper(order), state);
+            actual.Should().Be(TaskProgress.CannotStart);
+        }
+
+        [Theory]
+        [MockInlineAutoData(TaskProgress.Completed)]
         [MockInlineAutoData(TaskProgress.NotApplicable)]
-        [MockInlineAutoData(TaskProgress.NotStarted)]
-        [MockInlineAutoData(TaskProgress.Optional)]
-        public static void Get_FundingSourceIncomplete_ContractInfoEntered_ReturnsInProgress(
-            TaskProgress status,
-            Order order,
-            DataProcessingStatusProvider service)
-        {
-            var state = new OrderProgress
-            {
-                FundingSource = status,
-            };
-
-            order.ContractFlags.UseDefaultDataProcessing = true;
-
-            var actual = service.Get(new OrderWrapper(order), state);
-
-            actual.Should().Be(TaskProgress.InProgress);
-        }
-
-        [Theory]
-        [MockInlineAutoData(TaskProgress.CannotStart)]
-        [MockInlineAutoData(TaskProgress.InProgress)]
-        [MockInlineAutoData(TaskProgress.NotStarted)]
-        [MockInlineAutoData(TaskProgress.Optional)]
-        public static void Get_AssociatedServiceBillingIncomplete_ContractInfoEntered_ReturnsInProgress(
-            TaskProgress status,
-            Order order,
-            DataProcessingStatusProvider service)
-        {
-            var state = new OrderProgress
-            {
-                FundingSource = TaskProgress.Completed,
-                AssociatedServiceBilling = status,
-            };
-
-            order.ContractFlags.UseDefaultDataProcessing = true;
-
-            var actual = service.Get(new OrderWrapper(order), state);
-
-            actual.Should().Be(TaskProgress.InProgress);
-        }
-
-        [Theory]
-        [MockAutoData]
         public static void Get_ContractInfoNotEntered_ReturnsNotStarted(
+            TaskProgress status,
             Order order,
             DataProcessingStatusProvider service)
         {
             var state = new OrderProgress
             {
+                DescriptionStatus = TaskProgress.Completed,
+                OrderingPartyStatus = TaskProgress.Completed,
+                SupplierStatus = TaskProgress.Completed,
+                CommencementDateStatus = TaskProgress.Completed,
+                ServiceRecipients = TaskProgress.Completed,
+                SolutionOrService = TaskProgress.Completed,
+                DeliveryDates = TaskProgress.Completed,
                 FundingSource = TaskProgress.Completed,
-                AssociatedServiceRequirements = TaskProgress.Completed,
+                ImplementationPlan = TaskProgress.Completed,
+                AssociatedServiceBilling = status,
+                AssociatedServiceRequirements = status,
             };
 
             order.ContractFlags = null;
 
             var actual = service.Get(new OrderWrapper(order), state);
-
             actual.Should().Be(TaskProgress.NotStarted);
         }
 
         [Theory]
-        [MockInlineAutoData(true)]
+        [MockInlineAutoData(TaskProgress.Completed)]
+        [MockInlineAutoData(TaskProgress.NotApplicable)]
         public static void Get_ContractInfoEntered_ReturnsCompleted(
+            TaskProgress status,
             bool useDefaultDataProcessing,
             Order order,
             DataProcessingStatusProvider service)
         {
             var state = new OrderProgress
             {
+                DescriptionStatus = TaskProgress.Completed,
+                OrderingPartyStatus = TaskProgress.Completed,
+                SupplierStatus = TaskProgress.Completed,
+                CommencementDateStatus = TaskProgress.Completed,
+                ServiceRecipients = TaskProgress.Completed,
+                SolutionOrService = TaskProgress.Completed,
+                DeliveryDates = TaskProgress.Completed,
                 FundingSource = TaskProgress.Completed,
                 ImplementationPlan = TaskProgress.Completed,
-                AssociatedServiceRequirements = TaskProgress.NotApplicable,
+                AssociatedServiceBilling = status,
+                AssociatedServiceRequirements = status,
             };
 
             order.ContractFlags.UseDefaultDataProcessing = useDefaultDataProcessing;
 
             var actual = service.Get(new OrderWrapper(order), state);
-
             actual.Should().Be(TaskProgress.Completed);
+        }
+
+        private static OrderProgress GetDependentTaskOrderProgress(
+            OrderTaskListStatus task,
+            TaskProgress status,
+            bool hasService)
+        {
+            var state = new OrderProgress
+            {
+                DescriptionStatus = TaskProgress.Completed,
+                OrderingPartyStatus = TaskProgress.Completed,
+                SupplierStatus = TaskProgress.Completed,
+                CommencementDateStatus = TaskProgress.Completed,
+                ServiceRecipients = TaskProgress.Completed,
+                SolutionOrService = TaskProgress.Completed,
+                DeliveryDates = TaskProgress.Completed,
+                FundingSource = TaskProgress.Completed,
+                ImplementationPlan = TaskProgress.Completed,
+                AssociatedServiceBilling = TaskProgress.Completed,
+                AssociatedServiceRequirements = TaskProgress.Completed,
+            };
+
+            if (!hasService)
+            {
+                state.AssociatedServiceBilling = TaskProgress.NotApplicable;
+                state.AssociatedServiceRequirements = TaskProgress.NotApplicable;
+            }
+
+            switch (task)
+            {
+                case OrderTaskListStatus.Description:
+                    state.DescriptionStatus = status;
+                    break;
+                case OrderTaskListStatus.OrderingParty:
+                    state.OrderingPartyStatus = status;
+                    break;
+                case OrderTaskListStatus.Supplier:
+                    state.SupplierStatus = status;
+                    break;
+                case OrderTaskListStatus.CommencementDate:
+                    state.CommencementDateStatus = status;
+                    break;
+                case OrderTaskListStatus.ServiceRecipients:
+                    state.ServiceRecipients = status;
+                    break;
+                case OrderTaskListStatus.SolutionsOrServices:
+                    state.SolutionOrService = status;
+                    break;
+                case OrderTaskListStatus.DeliveryDates:
+                    state.DeliveryDates = status;
+                    break;
+                case OrderTaskListStatus.FundingSources:
+                    state.FundingSource = status;
+                    break;
+                case OrderTaskListStatus.ImplementationPlan:
+                    state.ImplementationPlan = status;
+                    break;
+                case OrderTaskListStatus.AssociatedServicesBilling:
+                    state.AssociatedServiceBilling = status;
+                    break;
+                case OrderTaskListStatus.AssociatedServicesRequirements:
+                    state.AssociatedServiceRequirements = status;
+                    break;
+            }
+
+            return state;
         }
     }
 }

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/FundingSourceStatusProviderTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/FundingSourceStatusProviderTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using FluentAssertions;
 using MoreLinq;
 using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
@@ -14,6 +13,11 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
 {
     public static class FundingSourceStatusProviderTests
     {
+        private static readonly OrderProgress ValidOrderState = new()
+        {
+            SolutionOrService = TaskProgress.Completed,
+        };
+
         [Theory]
         [MockAutoData]
         public static void Get_OrderWrapperIsNull_ReturnsCannotStart(
@@ -51,14 +55,14 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         [MockInlineAutoData(TaskProgress.NotApplicable)]
         [MockInlineAutoData(TaskProgress.NotStarted)]
         [MockInlineAutoData(TaskProgress.Optional)]
-        public static void Get_DeliveryDatesNotComplete_ReturnsCannotStart(
+        public static void Get_SolutionOrServiceNotComplete_ReturnsCannotStart(
             TaskProgress status,
             Order order,
             FundingSourceStatusProvider service)
         {
             var state = new OrderProgress
             {
-                DeliveryDates = status,
+                SolutionOrService = status,
             };
 
             order.OrderItems.ForEach(x => x.OrderItemFunding = null);
@@ -74,14 +78,9 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             Order order,
             FundingSourceStatusProvider service)
         {
-            var state = new OrderProgress
-            {
-                DeliveryDates = TaskProgress.Completed,
-            };
-
             order.OrderItems.ForEach(x => x.OrderItemFunding = null);
 
-            var actual = service.Get(new OrderWrapper(order), state);
+            var actual = service.Get(new OrderWrapper(order), ValidOrderState);
 
             actual.Should().Be(TaskProgress.NotStarted);
         }
@@ -93,12 +92,10 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             Order order,
             FundingSourceStatusProvider service)
         {
-            var state = new OrderProgress { DeliveryDates = TaskProgress.Completed };
-
             order.OrderItems.ForEach(x => x.OrderItemFunding = null);
             order.OrderItems.First().OrderItemFunding = funding;
 
-            var actual = service.Get(new OrderWrapper(order), state);
+            var actual = service.Get(new OrderWrapper(order), ValidOrderState);
 
             actual.Should().Be(TaskProgress.InProgress);
         }
@@ -111,12 +108,10 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             Order order,
             FundingSourceStatusProvider service)
         {
-            var state = new OrderProgress { DeliveryDates = TaskProgress.Completed };
-
             order.Revision = revision;
             var wrapper = new OrderWrapper(order);
 
-            var actual = service.Get(wrapper, state);
+            var actual = service.Get(wrapper, ValidOrderState);
 
             actual.Should().Be(expectedTaskProgress);
         }
@@ -129,13 +124,12 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             Order order,
             FundingSourceStatusProvider service)
         {
-            var state = new OrderProgress { DeliveryDates = TaskProgress.Completed };
             var previous = new Order { Revision = 1 };
 
             order.Revision = revision;
             var wrapper = new OrderWrapper(order, [previous]);
 
-            var actual = service.Get(wrapper, state);
+            var actual = service.Get(wrapper, ValidOrderState);
 
             actual.Should().Be(expectedTaskProgress);
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/ImplementationPlanStatusProviderTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/ImplementationPlanStatusProviderTests.cs
@@ -50,7 +50,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         {
             var state = new OrderProgress
             {
-                FundingSource = TaskProgress.Completed,
+                DescriptionStatus = TaskProgress.Completed,
             };
 
             order.OrderType = OrderTypeEnum.AssociatedServiceOther;
@@ -66,14 +66,14 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         [MockInlineAutoData(TaskProgress.NotApplicable)]
         [MockInlineAutoData(TaskProgress.NotStarted)]
         [MockInlineAutoData(TaskProgress.Optional)]
-        public static void Get_FundingSourceNotComplete_NullContract_ReturnsCannotStart(
+        public static void Get_DescriptionStatusNotComplete_ReturnsCannotStart(
             TaskProgress status,
             Order order,
             ImplementationPlanStatusProvider service)
         {
             var state = new OrderProgress
             {
-                FundingSource = status,
+                DescriptionStatus = status,
             };
 
             order.Contract = null;
@@ -89,14 +89,14 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         [MockInlineAutoData(TaskProgress.NotApplicable)]
         [MockInlineAutoData(TaskProgress.NotStarted)]
         [MockInlineAutoData(TaskProgress.Optional)]
-        public static void Get_FundingSourceNotComplete_NullImplementationPlan_ReturnsCannotStart(
+        public static void Get_DescriptionNotComplete_NullImplementationPlan_ReturnsCannotStart(
             TaskProgress status,
             Order order,
             ImplementationPlanStatusProvider service)
         {
             var state = new OrderProgress
             {
-                FundingSource = status,
+                DescriptionStatus = status,
             };
 
             order.Contract = new Contract() { ImplementationPlan = null };
@@ -107,39 +107,16 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         }
 
         [Theory]
-        [MockInlineAutoData(TaskProgress.CannotStart)]
-        [MockInlineAutoData(TaskProgress.InProgress)]
-        [MockInlineAutoData(TaskProgress.NotApplicable)]
-        [MockInlineAutoData(TaskProgress.NotStarted)]
-        [MockInlineAutoData(TaskProgress.Optional)]
-        public static void Get_FundingSourceNotComplete_ContractInfoAlreadyEntered_ReturnsInProgress(
+        [MockInlineAutoData(TaskProgress.Completed)]
+        [MockInlineAutoData(TaskProgress.Amended)]
+        public static void Get_ContractNull_ReturnsNotStarted(
             TaskProgress status,
             Order order,
             ImplementationPlanStatusProvider service)
         {
             var state = new OrderProgress
             {
-                FundingSource = status,
-            };
-
-            order.Contract = new Contract() { ImplementationPlan = new ImplementationPlan() };
-
-            var actual = service.Get(new OrderWrapper(order), state);
-
-            actual.Should().Be(TaskProgress.InProgress);
-        }
-
-        [Theory]
-        [MockInlineAutoData(TaskProgress.Completed)]
-        [MockInlineAutoData(TaskProgress.Amended)]
-        public static void Get_ContractNull_ReturnsNotStarted(
-            TaskProgress fundingTaskProgress,
-            Order order,
-            ImplementationPlanStatusProvider service)
-        {
-            var state = new OrderProgress
-            {
-                FundingSource = fundingTaskProgress,
+                DescriptionStatus = status,
             };
 
             order.Contract = null;
@@ -153,13 +130,13 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         [MockInlineAutoData(TaskProgress.Completed)]
         [MockInlineAutoData(TaskProgress.Amended)]
         public static void Get_ImplementationPlanNull_ReturnsNotStarted(
-            TaskProgress fundingTaskProgress,
+            TaskProgress status,
             Order order,
             ImplementationPlanStatusProvider service)
         {
             var state = new OrderProgress
             {
-                FundingSource = fundingTaskProgress,
+                DescriptionStatus = status,
             };
 
             order.Contract = new Contract() { ImplementationPlan = null };
@@ -173,13 +150,13 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         [MockInlineAutoData(TaskProgress.Completed)]
         [MockInlineAutoData(TaskProgress.Amended)]
         public static void Get_ContractInfoEntered_ReturnsCompleted(
-            TaskProgress fundingTaskProgress,
+            TaskProgress status,
             Order order,
             ImplementationPlanStatusProvider service)
         {
             var state = new OrderProgress
             {
-                FundingSource = fundingTaskProgress,
+                DescriptionStatus = status,
             };
 
             order.Contract = new Contract() { ImplementationPlan = new ImplementationPlan() };

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/ServiceRecipientsStatusProviderTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/ServiceRecipientsStatusProviderTests.cs
@@ -16,7 +16,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
     {
         private static readonly OrderProgress ValidOrderState = new()
         {
-            CommencementDateStatus = TaskProgress.Completed,
+            DescriptionStatus = TaskProgress.Completed,
         };
 
         [Theory]
@@ -51,14 +51,19 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         }
 
         [Theory]
-        [MockAutoData]
-        public static void Get_CommencementDateStatus_NotCompleted_Returns_CannotStart(
+        [MockInlineAutoData(TaskProgress.CannotStart)]
+        [MockInlineAutoData(TaskProgress.InProgress)]
+        [MockInlineAutoData(TaskProgress.NotApplicable)]
+        [MockInlineAutoData(TaskProgress.NotStarted)]
+        [MockInlineAutoData(TaskProgress.Optional)]
+        public static void Get_DescriptionStatus_NotCompleted_Returns_CannotStart(
+            TaskProgress descriptionStatus,
             Order order,
             ServiceRecipientsStatusProvider service)
         {
             var state = new OrderProgress()
             {
-                CommencementDateStatus = TaskProgress.InProgress,
+                DescriptionStatus = descriptionStatus,
             };
 
             var actual = service.Get(new OrderWrapper(order), state);

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/SolutionOrServiceStatusProviderTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/SolutionOrServiceStatusProviderTests.cs
@@ -14,6 +14,12 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
 {
     public static class SolutionOrServiceStatusProviderTests
     {
+        private static readonly OrderProgress ValidOrderState = new()
+        {
+            SupplierStatus = TaskProgress.Completed,
+            ServiceRecipients = TaskProgress.Completed,
+        };
+
         [Theory]
         [MockAutoData]
         public static void Get_OrderWrapperIsNull_ReturnsCannotStart(
@@ -51,6 +57,27 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         [MockInlineAutoData(TaskProgress.NotApplicable)]
         [MockInlineAutoData(TaskProgress.NotStarted)]
         [MockInlineAutoData(TaskProgress.Optional)]
+        public static void Get_ServiceRecipientsNotComplete_ReturnsCannotStart(
+            TaskProgress status,
+            Order order,
+            SolutionOrServiceStatusProvider service)
+        {
+            var state = new OrderProgress
+            {
+                ServiceRecipients = status,
+            };
+
+            var actual = service.Get(new OrderWrapper(order), state);
+
+            actual.Should().Be(TaskProgress.CannotStart);
+        }
+
+        [Theory]
+        [MockInlineAutoData(TaskProgress.CannotStart)]
+        [MockInlineAutoData(TaskProgress.InProgress)]
+        [MockInlineAutoData(TaskProgress.NotApplicable)]
+        [MockInlineAutoData(TaskProgress.NotStarted)]
+        [MockInlineAutoData(TaskProgress.Optional)]
         public static void Get_SupplierStatusNotComplete_ReturnsCannotStart(
             TaskProgress status,
             Order order,
@@ -58,7 +85,29 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         {
             var state = new OrderProgress
             {
-                CommencementDateStatus = status,
+                SupplierStatus = status,
+            };
+
+            var actual = service.Get(new OrderWrapper(order), state);
+
+            actual.Should().Be(TaskProgress.CannotStart);
+        }
+
+        [Theory]
+        [MockInlineAutoData(TaskProgress.CannotStart)]
+        [MockInlineAutoData(TaskProgress.InProgress)]
+        [MockInlineAutoData(TaskProgress.NotApplicable)]
+        [MockInlineAutoData(TaskProgress.NotStarted)]
+        [MockInlineAutoData(TaskProgress.Optional)]
+        public static void Get_ServiceRecipientsNotComplete_SupplierStatusNotComplete_ReturnsCannotStart(
+            TaskProgress status,
+            Order order,
+            SolutionOrServiceStatusProvider service)
+        {
+            var state = new OrderProgress
+            {
+                ServiceRecipients = status,
+                SupplierStatus = status,
             };
 
             var actual = service.Get(new OrderWrapper(order), state);
@@ -74,15 +123,10 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             Order order,
             SolutionOrServiceStatusProvider service)
         {
-            var state = new OrderProgress
-            {
-                ServiceRecipients = TaskProgress.Completed,
-            };
-
             order.OrderType = OrderTypeEnum.Solution;
             order.OrderItems.ForEach(x => x.CatalogueItem.CatalogueItemType = itemType);
 
-            var actual = service.Get(new OrderWrapper(order), state);
+            var actual = service.Get(new OrderWrapper(order), ValidOrderState);
 
             actual.Should().Be(TaskProgress.NotStarted);
         }
@@ -93,17 +137,12 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             Order order,
             SolutionOrServiceStatusProvider service)
         {
-            var state = new OrderProgress
-            {
-                ServiceRecipients = TaskProgress.Completed,
-            };
-
             order.Revision = 1;
             order.OrderType = OrderTypeEnum.Solution;
             order.OrderItems.ForEach(x => x.CatalogueItem.CatalogueItemType = CatalogueItemType.AdditionalService);
             var amendedOrder = order.BuildAmendment(2);
 
-            var actual = service.Get(new OrderWrapper(amendedOrder, [order]), state);
+            var actual = service.Get(new OrderWrapper(amendedOrder, [order]), ValidOrderState);
 
             actual.Should().Be(TaskProgress.NotStarted);
         }
@@ -115,11 +154,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             OrderSublocation newOrderSublocation,
             SolutionOrServiceStatusProvider service)
         {
-            var state = new OrderProgress
-            {
-                ServiceRecipients = TaskProgress.Completed,
-            };
-
             order.Revision = 1;
             order.OrderType = OrderTypeEnum.Solution;
             order.OrderItems.ForEach(x => x.CatalogueItem.CatalogueItemType = CatalogueItemType.Solution);
@@ -131,7 +165,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             });
             amendedOrder.OrderSublocations.Add(newOrderSublocation);
 
-            var actual = service.Get(new OrderWrapper(amendedOrder, [order]), state);
+            var actual = service.Get(new OrderWrapper(amendedOrder, [order]), ValidOrderState);
 
             actual.Should().Be(TaskProgress.InProgress);
         }
@@ -144,11 +178,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             OrderSublocation sublocation,
             SolutionOrServiceStatusProvider service)
         {
-            var state = new OrderProgress
-            {
-                ServiceRecipients = TaskProgress.Completed,
-            };
-
             order.Revision = 1;
             order.OrderType = OrderTypeEnum.Solution;
             order.OrderItems.ForEach(x => x.CatalogueItem.CatalogueItemType = CatalogueItemType.Solution);
@@ -161,7 +190,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             amendedOrder.OrderItems.Add(orderItemToAdd);
             amendedOrder.OrderSublocations.Add(sublocation);
 
-            var actual = service.Get(new OrderWrapper(amendedOrder, [order]), state);
+            var actual = service.Get(new OrderWrapper(amendedOrder, [order]), ValidOrderState);
 
             actual.Should().Be(TaskProgress.InProgress);
         }
@@ -172,15 +201,10 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             Order order,
             SolutionOrServiceStatusProvider service)
         {
-            var state = new OrderProgress
-            {
-                ServiceRecipients = TaskProgress.Completed,
-            };
-
             order.OrderType = OrderTypeEnum.AssociatedServiceOther;
             order.AssociatedServicesOnlyDetails.SolutionId = null;
 
-            var actual = service.Get(new OrderWrapper(order), state);
+            var actual = service.Get(new OrderWrapper(order), ValidOrderState);
 
             actual.Should().Be(TaskProgress.NotStarted);
         }
@@ -192,16 +216,11 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             Order order,
             SolutionOrServiceStatusProvider service)
         {
-            var state = new OrderProgress
-            {
-                ServiceRecipients = TaskProgress.Completed,
-            };
-
             order.OrderType = OrderTypeEnum.AssociatedServiceOther;
             order.AssociatedServicesOnlyDetails.SolutionId = solutionId;
             order.OrderItems.Clear();
 
-            var actual = service.Get(new OrderWrapper(order), state);
+            var actual = service.Get(new OrderWrapper(order), ValidOrderState);
 
             actual.Should().Be(TaskProgress.InProgress);
         }
@@ -212,11 +231,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             Order order,
             SolutionOrServiceStatusProvider service)
         {
-            var state = new OrderProgress
-            {
-                ServiceRecipients = TaskProgress.Completed,
-            };
-
             order.Revision = 1;
             order.OrderType = OrderTypeEnum.Solution;
             order.OrderItems.ForEach(x =>
@@ -227,7 +241,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
 
             order.FlattenedRecipients.ForEach(x => x.OrderItemSublocationRecipients.ForEach(y => y.Quantity = null));
 
-            var actual = service.Get(new OrderWrapper(order), state);
+            var actual = service.Get(new OrderWrapper(order), ValidOrderState);
 
             actual.Should().Be(TaskProgress.InProgress);
         }
@@ -238,8 +252,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             Order order,
             SolutionOrServiceStatusProvider service)
         {
-            var state = new OrderProgress { ServiceRecipients = TaskProgress.Completed };
-
             order.Revision = 1;
             order.OrderType = OrderTypeEnum.Solution;
             order.OrderItems.ForEach(x =>
@@ -248,7 +260,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             });
             order.OrderItems.First().CatalogueItem.CatalogueItemType = CatalogueItemType.Solution;
 
-            TaskProgress actual = service.Get(new OrderWrapper(order), state);
+            TaskProgress actual = service.Get(new OrderWrapper(order), ValidOrderState);
 
             actual.Should().Be(TaskProgress.Completed);
         }
@@ -262,8 +274,6 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             Order order,
             SolutionOrServiceStatusProvider service)
         {
-            var state = new OrderProgress { ServiceRecipients = TaskProgress.Completed };
-
             order.Revision = 2;
             order.OrderType = OrderTypeEnum.Solution;
             order.OrderItems.ForEach(x =>
@@ -272,7 +282,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
             });
             order.OrderItems.First().CatalogueItem.CatalogueItemType = CatalogueItemType.Solution;
 
-            TaskProgress actual = service.Get(new OrderWrapper(order, [previousOrder]), state);
+            TaskProgress actual = service.Get(new OrderWrapper(order, [previousOrder]), ValidOrderState);
 
             actual.Should().Be(TaskProgress.Amended);
         }

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/SupplierStatusProviderTests.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/SupplierStatusProviderTests.cs
@@ -51,14 +51,14 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         [MockInlineAutoData(TaskProgress.NotApplicable)]
         [MockInlineAutoData(TaskProgress.NotStarted)]
         [MockInlineAutoData(TaskProgress.Optional)]
-        public static void Get_OrderingPartyStatusNotComplete_ReturnsCannotStart(
-            TaskProgress orderingPartyStatus,
+        public static void Get_DescriptionStatusNotComplete_ReturnsCannotStart(
+            TaskProgress descriptionStatus,
             Order order,
             SupplierStatusProvider service)
         {
             var state = new OrderProgress
             {
-                OrderingPartyStatus = orderingPartyStatus,
+                DescriptionStatus = descriptionStatus,
             };
 
             var actual = service.Get(new OrderWrapper(order), state);
@@ -74,7 +74,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         {
             var state = new OrderProgress
             {
-                OrderingPartyStatus = TaskProgress.Completed,
+                DescriptionStatus = TaskProgress.Completed,
             };
 
             order.Supplier = null;
@@ -88,14 +88,14 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         [MockInlineAutoData(TaskProgress.Completed)]
         [MockInlineAutoData(TaskProgress.Amended)]
         public static void Get_OrderHasNoSupplierContact_ReturnsInProgress(
-            TaskProgress orderingPartyStatus,
+            TaskProgress descriptionStatus,
             Supplier supplier,
             Order order,
             SupplierStatusProvider service)
         {
             var state = new OrderProgress
             {
-                OrderingPartyStatus = orderingPartyStatus,
+                DescriptionStatus = descriptionStatus,
             };
 
             order.Supplier = supplier;
@@ -110,7 +110,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         [MockInlineAutoData(TaskProgress.Completed)]
         [MockInlineAutoData(TaskProgress.Amended)]
         public static void Get_OrderHasSupplierAndSupplierContact_ReturnsCompleted(
-            TaskProgress orderingPartyStatus,
+            TaskProgress descriptionStatus,
             Supplier supplier,
             Contact contact,
             Order order,
@@ -118,7 +118,7 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         {
             var state = new OrderProgress
             {
-                OrderingPartyStatus = orderingPartyStatus,
+                DescriptionStatus = descriptionStatus,
             };
 
             order.Supplier = supplier;
@@ -133,13 +133,13 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         [MockInlineAutoData(TaskProgress.Completed)]
         [MockInlineAutoData(TaskProgress.Amended)]
         public static void Get_OrderIsAnAmendment_SupplierContactTheSame_ReturnsCompleted(
-            TaskProgress orderingPartyStatus,
+            TaskProgress descriptionStatus,
             List<Order> orders,
             SupplierStatusProvider service)
         {
             var state = new OrderProgress
             {
-                OrderingPartyStatus = orderingPartyStatus,
+                DescriptionStatus = descriptionStatus,
             };
 
             orders[0].Revision = 1;
@@ -157,13 +157,13 @@ namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
         [MockInlineAutoData(TaskProgress.Completed)]
         [MockInlineAutoData(TaskProgress.Amended)]
         public static void Get_OrderIsAnAmendment_SupplierContactDifferent_ReturnsAmended(
-            TaskProgress orderingPartyStatus,
+            TaskProgress descriptionStatus,
             List<Order> orders,
             SupplierStatusProvider service)
         {
             var state = new OrderProgress
             {
-                OrderingPartyStatus = orderingPartyStatus,
+                DescriptionStatus = descriptionStatus,
             };
 
             orders[0].Revision = 1;

--- a/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/TaskListStatusServiceTest.cs
+++ b/tests/NHSD.GPIT.BuyingCatalogue.Services.UnitTests/TaskList/Providers/TaskListStatusServiceTest.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using FluentAssertions;
+using NHSD.GPIT.BuyingCatalogue.EntityFramework.Ordering.Models;
+using NHSD.GPIT.BuyingCatalogue.ServiceContracts.Enums;
+using NHSD.GPIT.BuyingCatalogue.Services.TaskList.Providers;
+using NHSD.GPIT.BuyingCatalogue.UnitTest.Framework.Attributes;
+using Xunit;
+
+namespace NHSD.GPIT.BuyingCatalogue.Services.UnitTests.TaskList.Providers
+{
+    public class TaskListStatusServiceTest
+    {
+        [Fact]
+        public static void CompletedOrAmended_IsAmendend_ReturnsAmended()
+        {
+            var actual = TaskListStatusService.CompletedOrAmended(true);
+            actual.Should().Be(TaskProgress.Amended);
+        }
+
+        [Fact]
+        public static void CompletedOrAmended_NotAmendend_ReturnsCompleted()
+        {
+            var actual = TaskListStatusService.CompletedOrAmended(false);
+            actual.Should().Be(TaskProgress.Completed);
+        }
+
+        [Theory]
+        [MockInlineAutoData(TaskProgress.Completed)]
+        [MockInlineAutoData(TaskProgress.Amended)]
+        public static void IsTaskCompleted_ReturnsTrue(TaskProgress status)
+        {
+            var actual = TaskListStatusService.IsTaskCompleted(status);
+            actual.Should().Be(true);
+        }
+
+        [Theory]
+        [MockInlineAutoData(TaskProgress.Optional)]
+        [MockInlineAutoData(TaskProgress.NotApplicable)]
+        [MockInlineAutoData(TaskProgress.CannotStart)]
+        [MockInlineAutoData(TaskProgress.NotStarted)]
+        [MockInlineAutoData(TaskProgress.InProgress)]
+        public static void IsTaskCompleted_ReturnsFalse(TaskProgress status)
+        {
+            var actual = TaskListStatusService.IsTaskCompleted(status);
+            actual.Should().Be(false);
+        }
+
+        [Fact]
+        public static void HasAssociatedServices_NullOrder_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(() => TaskListStatusService.HasAssociatedServices(null));
+        }
+
+        [Theory]
+        [MockAutoData]
+        public static void HasAssociatedServices_NoService_ReturnsFalse(Order order)
+        {
+            var actual = TaskListStatusService.HasAssociatedServices(order);
+            actual.Should().Be(false);
+        }
+
+        [Theory]
+        [MockAutoData]
+        public static void HasAssociatedServices_HasService_ReturnsTrue(Order order)
+        {
+            order.OrderType = OrderTypeEnum.AssociatedServiceOther;
+            order.Contract = null;
+            var actual = TaskListStatusService.HasAssociatedServices(order);
+            actual.Should().Be(true);
+        }
+    }
+}


### PR DESCRIPTION
Modify the order flow to allow buyers to complete tasks in the order journey as soon as it is possible to do so in line with dependencies on other tasks.